### PR TITLE
chore: bumps plugin versions for recent changes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "private-claude-marketplace",
   "metadata": {
     "description": "Private Claude Code plugins: LSP servers (uvx/npx) and custom agents",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "owner": {
     "name": "wgordon"
@@ -78,7 +78,7 @@
     },
     {
       "name": "global-skills",
-      "version": "1.0.5",
+      "version": "1.0.9",
       "source": "./global-skills",
       "description": "Global skills: file-audit, git-history, lsp-navigation, test-runner, uv-python",
       "category": "productivity",
@@ -86,7 +86,7 @@
     },
     {
       "name": "global-commands",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "source": "./global-commands",
       "description": "Global commands: session management, project review, commit validation, LSP status",
       "category": "productivity",

--- a/global-commands/.claude-plugin/plugin.json
+++ b/global-commands/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-commands",
   "description": "Global commands for session management, project review, commit validation, and LSP status",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": {
     "name": "wgordon"
   }

--- a/global-skills/.claude-plugin/plugin.json
+++ b/global-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-skills",
   "description": "Global skills for file auditing, git operations, LSP navigation, test execution, and Python tooling",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": {
     "name": "wgordon"
   }


### PR DESCRIPTION
## Summary
Bumps plugin versions to reflect recent changes in PR #2.

## Version Changes
- **Marketplace**: 1.0.1 → 1.0.2
- **global-commands**: 1.0.1 → 1.0.2 (lsp-status rust support)
- **global-skills**: 1.0.8 → 1.0.9 (git-hooks-install path fix)

## Dependencies
Requires PR #2 to be merged first.