### PR TITLE
fix(git-hooks)!: fixes --no-verify bypass and rebase blocking issues

### DIFF
--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, and pre-push review",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/hooks.json
+++ b/global-hooks/hooks/hooks.json
@@ -1,26 +1,26 @@
 {
-  "description": "Global hooks for git safety, commit validation, and pre-push review",
+  "description": "Global hooks for git safety checks, commit validation, and pre-push review",
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-push-review.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/git-safety-check.sh"
           }
-        ],
-        "matcher": "Bash(git push origin*)"
+        ]
       }
     ],
     "PostToolUse": [
       {
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-commit-message.sh"
           }
-        ],
-        "matcher": "Bash(git commit:*)"
+        ]
       }
     ]
   }

--- a/global-hooks/hooks/validate-installation.sh
+++ b/global-hooks/hooks/validate-installation.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Validate that hooks are correctly installed and active
+
+set -euo pipefail
+
+HOOKS_FILE="${CLAUDE_PLUGIN_ROOT}/hooks/hooks.json"
+
+echo "=== Hook Installation Validation ==="
+
+# Check hooks.json exists and is valid JSON
+if ! jq empty "$HOOKS_FILE" 2>/dev/null; then
+    echo "❌ FAIL: Invalid JSON in hooks.json"
+    exit 1
+fi
+echo "✓ hooks.json is valid JSON"
+
+# Check required structure
+if ! jq -e '.hooks.PreToolUse' "$HOOKS_FILE" >/dev/null 2>&1; then
+    echo "❌ FAIL: Missing PreToolUse in hooks.json"
+    exit 1
+fi
+echo "✓ PreToolUse hooks defined"
+
+# Check matcher syntax (no parentheses allowed)
+if jq -r '.. | .matcher? // empty' "$HOOKS_FILE" | grep -q '('; then
+    echo "❌ FAIL: Invalid matcher syntax (found parentheses)"
+    exit 1
+fi
+echo "✓ Matcher syntax is correct"
+
+# Check script references exist
+jq -r '.. | .command? // empty' "$HOOKS_FILE" | while read -r cmd; do
+    # Expand CLAUDE_PLUGIN_ROOT
+    expanded="${cmd//\$\{CLAUDE_PLUGIN_ROOT\}/${CLAUDE_PLUGIN_ROOT}}"
+    if [[ "$expanded" == *".sh"* ]] && [[ ! -x "$expanded" ]]; then
+        echo "⚠ WARNING: Script not executable: $expanded"
+    fi
+done
+
+echo "=== Validation Complete ==="

--- a/global-skills/.claude-plugin/plugin.json
+++ b/global-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-skills",
   "description": "Global skills for file auditing, git operations, LSP navigation, test execution, and Python tooling",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-skills/git-hooks/post-commit.sh
+++ b/global-skills/git-hooks/post-commit.sh
@@ -4,6 +4,14 @@
 
 set -euo pipefail
 
+# Skip if running via pre-commit run (not during actual git commit)
+# During a real commit, GIT_INDEX_FILE will be set to a temp file like .git/index.lock
+# During pre-commit run, it will be unset or point to .git/index
+if [[ -z "${GIT_INDEX_FILE:-}" ]] || [[ "${GIT_INDEX_FILE:-}" == ".git/index" ]] || [[ "${GIT_INDEX_FILE:-}" == *"/.git/index" ]]; then
+    # Not running as part of a commit - don't set marker
+    exit 0
+fi
+
 # Get unique repository identifier (hash of absolute path)
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || exit 0)
 
@@ -25,6 +33,11 @@ if [[ -n "${GIT_REFLOG_ACTION:-}" ]]; then
     exit 0
 fi
 
+# Skip if git-branchless is managing the commit
+if [[ -n "${GIT_BRANCHLESS_OPERATION:-}" ]]; then
+    exit 0
+fi
+
 # Create marker directory and file
 MARKER_DIR="$HOME/.cache/hook-checks"
 mkdir -p "$MARKER_DIR"
@@ -33,9 +46,11 @@ MARKER_FILE="$MARKER_DIR/${REPO_HASH}.mark"
 # Get the SHA of the commit that just succeeded
 COMMIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown")
 
-# Write marker with timestamp and commit SHA
+# Atomic write to prevent race conditions
 # Format: timestamp|commit-sha
 # This marker indicates: "Pre-commit hooks ran successfully for THIS specific commit"
-echo "$(date +%s)|${COMMIT_SHA}" > "$MARKER_FILE"
+MARKER_TMP="${MARKER_FILE}.$$"
+echo "$(date +%s)|${COMMIT_SHA}" > "$MARKER_TMP"
+mv "$MARKER_TMP" "$MARKER_FILE"
 
 exit 0


### PR DESCRIPTION
## Summary
- Fixes Claude Code PreToolUse hook not being wired (invalid matcher syntax)
- Fixes marker system bypass via `pre-commit run` + `--no-verify` 
- Fixes rebase/cherry-pick operations being blocked by stale markers

## Changes
- **Corrects hooks.json matchers**: Changed from `Bash(pattern)` to `Bash` (proper syntax)
- **Prevents marker bypass**: Adds GIT_INDEX_FILE check to skip marker creation during `pre-commit run`
- **Improves rebase support**: Increases marker timeout to 120s (configurable via `GIT_HOOK_MARKER_TIMEOUT`)
- **Enhanced batch detection**: Better detection of rebase/merge/cherry-pick operations
- **Adds cleanup helper**: `GIT_HOOK_CLEAN_MARKERS=1` to clear stale markers
- **Validation script**: New hook installation validation script
- **Version bumps**: global-hooks and global-skills to 1.1.0

## Breaking Changes
Hook matcher syntax changed - requires Claude Code session restart after update.

## Testing
See plan verification tests in commit message.