### PR TITLE
fix(global-hooks): removes PostToolUse hook blocking all bash commands

### DIFF
--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, and pre-push review",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/hooks.json
+++ b/global-hooks/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Global hooks for git safety checks, commit validation, and pre-push review",
+  "description": "Global hooks for git safety checks and pre-push review",
   "hooks": {
     "PreToolUse": [
       {
@@ -8,17 +8,6 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/git-safety-check.sh"
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-commit-message.sh"
           }
         ]
       }

--- a/global-hooks/hooks/validate-commit-message.sh
+++ b/global-hooks/hooks/validate-commit-message.sh
@@ -11,15 +11,22 @@
 #   2 = Error (blocks the commit)
 #
 
-set -euo pipefail
+# Early exit if not in a git repository
+if ! git rev-parse --git-dir &>/dev/null; then
+    exit 0
+fi
 
 # Get commit message (optional SHA argument, defaults to HEAD)
 SHA="${1:-HEAD}"
-COMMIT_MSG=$(git log -1 --pretty=%B "$SHA" 2>/dev/null)
+COMMIT_MSG=$(git log -1 --pretty=%B "$SHA" 2>/dev/null || echo "")
+
+# If we can't get a commit message, this isn't a git commit operation
 if [[ -z "$COMMIT_MSG" ]]; then
-    echo "ERROR: Could not retrieve last commit message"
-    exit 2
+    exit 0
 fi
+
+# Now enable strict error handling for the actual validation
+set -euo pipefail
 
 # Extract subject line (first line)
 SUBJECT=$(echo "$COMMIT_MSG" | head -1)


### PR DESCRIPTION
## Summary
Removes PostToolUse hook that was blocking every bash command with validation errors.

## Problem
The `validate-commit-message.sh` PostToolUse hook was:
- Running after EVERY bash command (not just git commits)
- Unable to reliably determine if a git commit occurred
- Blocking all bash commands with "No stderr output" errors

## Solution
- Removed PostToolUse hook from hooks.json entirely
- Commit message validation already happens at git hook level (prepare-commit-msg.sh)
- The Claude Code PostToolUse hook was redundant and problematic

## Changes
- Removes PostToolUse section from hooks.json
- Updates validate-commit-message.sh for graceful degradation (though it won't be called)
- Bumps version to 1.1.1