### PR TITLE
feat(global-hooks): allows safe chained git commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "private-claude-marketplace",
   "metadata": {
     "description": "Private Claude Code plugins: LSP servers (uvx/npx) and custom agents",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "owner": {
     "name": "wgordon"
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "source": "./global-hooks",
       "description": "Global hooks: git safety checks, commit validation, pre-push review",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, and pre-push review",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/git-safety-check.sh
+++ b/global-hooks/hooks/git-safety-check.sh
@@ -39,18 +39,10 @@ else
 fi
 
 # EARLY EXIT: If not a git command, allow immediately (no logging, no delay)
-# This is necessary because we use Bash matcher to catch chained commands
 # Match: "git " at start OR after space/operators (prevent false positives like "digital", ".gitignore")
 # Pattern matches: "git ", " git ", "&&git ", "||git ", ";git "
 if [[ ! "$FULL_COMMAND" =~ (^|[[:space:]]|&&|\|\||;)git[[:space:]] ]]; then
     exit 0
-fi
-
-# CRITICAL SAFEGUARD: Block chained commands with git (known Claude Code hook bypass - Issue #13340)
-# We use Bash matcher because Bash(git*) patterns don't work reliably
-# Chained git commands can bypass safety checks, so we block them entirely
-if [[ "$FULL_COMMAND" =~ (&&|\|\||;) ]]; then
-    log_block "Chained git commands (using &&, ||, or ;) are FORBIDDEN - they bypass safety checks. Run commands separately."
 fi
 
 # Helper: Check if command contains --force (not --force-with-lease)


### PR DESCRIPTION
## Summary
Removes blanket blocking of chained git commands while maintaining all safety checks.

## Problem
Previously ALL chained git commands were blocked, including safe ones:
- git status && git log (blocked unnecessarily)
- git fetch && git pull (blocked unnecessarily)
- git add . && git commit -m "msg" (blocked unnecessarily)

## Solution
Remove the blanket chain blocking since all dangerous flags are detected even in chained commands.

## Testing

Safe chains now work:
- git status && git log (allowed)
- git add file && git commit -m "msg" (allowed)

Dangerous flags still blocked in chains:
- git add . && git commit --no-verify -m "test" (blocked by flag check)
- echo test && git push --force origin (blocked by flag check)
- git fetch && git reset --hard (blocked by operation check)

## Changes
- Removes chained command blocking logic from git-safety-check.sh
- All specific safety checks still apply (force, no-verify, reset hard, etc.)
- Version bump: global-hooks 1.2.0 to 1.2.1, marketplace 1.2.0 to 1.2.1
