### PR TITLE
feat(global-hooks): tool guard v1.5.0 — chain splitting, convention rules, andon cord

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "wgordon"
   }


### PR DESCRIPTION
## Summary

Expands `tool-selection-guard.py` from 28 to 33 rules (v1.5.0):

- **Chain splitting**: `split_commands()` splits `&&`/`||`/`;`/newlines (respects quotes and `\` continuation)
- **Category C conventions**: bash-script, direct-script → encourage make targets; tmp-path → encourage `hack/tmp/`
- **pre-commit → prek**: catches all forms (`pre-commit`, `uvx pre-commit`, `uv run pre-commit`) → guides to `uvx prek run --all-files` or make target
- **Andon cord**: `GUARD_BYPASS=1` prefix skips guard (requires user approval via settings.json `ask` list)
- **Edge fix**: cat-heredoc now allows piped usage (`cat <<EOF | grep`)

## Test plan
- [x] 110/110 tests pass (chain splitting, newline splitting, andon cord, conventions, pre-commit→prek)