### PR TITLE
fix(global-hooks): allow hack/tmp/ in tmp-path guard rule

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/tool-selection-guard.py
+++ b/global-hooks/hooks/tool-selection-guard.py
@@ -185,7 +185,7 @@ RULES = [
     (
         "tmp-path",
         re.compile(r"/tmp/"),
-        re.compile(r"\brm\b"),
+        re.compile(r"\brm\b|hack/tmp"),
         "Use `hack/tmp/` (gitignored) instead of `/tmp/` for temporary files. "
         "Native tools (Read/Write/Edit) work without Bash permissions on local files. "
         "Clean up when done.",


### PR DESCRIPTION
## Summary
- The `/tmp/` regex was matching `hack/tmp/` as a false positive
- Adds `hack/tmp` to the exception pattern so the recommended alternative is not blocked
- Bumps to v1.5.1

## Test plan
- [x] 112/112 tests pass (including 2 new hack/tmp tests)
- [x] Live hook verified: `hack/tmp/` commands now allowed