### PR TITLE
feat(global-hooks): block /tmp/ paths across all tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/tool-selection-guard.py
+++ b/global-hooks/hooks/tool-selection-guard.py
@@ -272,10 +272,22 @@ def main():
         sys.exit(0)
 
     tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+
+    # ── /tmp/ guard for ALL tools (Read, Write, Edit, Grep, Glob, Bash) ──
+    # Fires before the permission layer so the agent gets guidance, not a prompt.
+    file_path = tool_input.get("file_path", "") or tool_input.get("path", "")
+    if file_path and "/tmp/" in file_path and "hack/tmp" not in file_path:
+        print(
+            "Use `hack/tmp/` (gitignored) instead of `/tmp/` for temporary files. "
+            "Native tools (Read/Write/Edit) work on local files without extra permissions.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     if tool_name != "Bash":
         sys.exit(0)
 
-    tool_input = data.get("tool_input", {})
     command = tool_input.get("command", "").strip()
     if not command:
         sys.exit(0)


### PR DESCRIPTION
## Summary
- Guard now checks Read, Write, Edit, Grep, Glob for /tmp/ paths — not just Bash
- Blocks before the permission layer, so agents get redirect guidance instead of a user prompt
- hack/tmp/ paths are excepted (the recommended alternative)
- Bumps to v1.5.2

## Test plan
- [x] 120/120 tests pass (8 new non-Bash /tmp/ tests)
- [x] Live hook verified for Bash /tmp/ blocking