### PR TITLE
fix(global-hooks): block heredoc pipes, register guard for all tools

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/hooks.json
+++ b/global-hooks/hooks/hooks.json
@@ -16,6 +16,15 @@
         ]
       },
       {
+        "matcher": "Read|Write|Edit|Grep|Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py"
+          }
+        ]
+      },
+      {
         "matcher": "Bash(git push origin*)",
         "hooks": [
           {

--- a/global-hooks/hooks/tool-selection-guard.py
+++ b/global-hooks/hooks/tool-selection-guard.py
@@ -74,8 +74,8 @@ RULES = [
     (
         "cat-heredoc",
         re.compile(r"^\s*cat\s*<<"),
-        re.compile(r"\|"),
-        "Use the Write tool instead of cat heredoc.",
+        None,
+        "Use the Write tool for file content, or native tools (Grep/Read) for the downstream operation.",
     ),
     (
         "pager",

--- a/global-hooks/tests/test_tool_selection_guard.py
+++ b/global-hooks/tests/test_tool_selection_guard.py
@@ -86,7 +86,7 @@ for args in [
     ("echo > file -> Write",          "echo hello > output.txt",    2, "Write tool"),
     ("echo > /dev/null -> allow",     "echo test > /dev/null",      0),
     ("cat heredoc -> Write",          "cat <<EOF > file.py",        2, "Write tool"),
-    ("cat heredoc pipe -> allow",     "cat <<EOF | grep pattern",   0),
+    ("cat heredoc pipe -> blocked",   "cat <<EOF | grep pattern",   2, "Write tool"),
     ("printf > file -> Write",        "printf '%s' x > out.txt",    2, "Write tool"),
     ("less -> Read",                  "less file.py",               2, "Pagers"),
     ("more -> Read",                  "more file.py",               2, "Pagers"),


### PR DESCRIPTION
## Summary
- Removes pipe exception from cat-heredoc: `cat <<EOF | cmd` now blocked (was causing prompts)
- Registers guard for Read|Write|Edit|Grep|Glob in hooks.json so /tmp/ blocking works for all tools
- v1.6.1

## Test plan
- [x] 142/142 tests pass
- [x] Live: `cat <<EOF | grep` now blocked