### PR TITLE
fix(global-hooks): block bash -c wrapper to avoid prompts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/tool-selection-guard.py
+++ b/global-hooks/hooks/tool-selection-guard.py
@@ -374,8 +374,17 @@ def main():
         # Unwrap bash -c '...' / sh -c '...' and check the inner command
         inner_cmd = extract_bash_c(subcmd)
         if inner_cmd:
+            # First check if inner command breaks any rules (e.g. bash -c 'cat file')
             for inner_sub in split_commands(inner_cmd):
                 check_rules(inner_sub)
+            # If inner command is safe, STILL block — the bash -c wrapper itself
+            # causes a permission prompt. Run the inner command directly instead.
+            print(
+                f"Run the command directly without the `bash -c` wrapper — "
+                f"it causes a permission prompt. Just use: `{inner_cmd}`",
+                file=sys.stderr,
+            )
+            sys.exit(2)
         else:
             check_rules(subcmd)
         # Also check inside $() and `` substitutions

--- a/global-hooks/tests/test_tool_selection_guard.py
+++ b/global-hooks/tests/test_tool_selection_guard.py
@@ -144,7 +144,7 @@ for args in [
     ("bash -c cat -> blocked",        "bash -c 'cat file.py'",          2, "Read tool"),
     ("bash -c grep -> blocked",       "bash -c 'grep -rn pat src/'",   2, "Grep tool"),
     ("bash -c python -> blocked",     "bash -c 'python script.py'",    2, "uv run"),
-    ("bash -c safe -> allow",         "bash -c 'git status'",          0),
+    ("bash -c safe -> still blocked", "bash -c 'git status'",          2, "directly"),
     ("bash -e flag -> allow",         "bash -e script.sh",             0),
     ("./script.sh -> make",           "./scripts/build.sh",             2, "make"),
     ("scripts/foo.sh -> make",        "scripts/deploy.sh prod",         2, "make"),


### PR DESCRIPTION
bash -c wraps cause permission prompts even when the inner command is safe. Now all bash -c usage is blocked with guidance to run the inner command directly. v1.7.1.