### PR TITLE
feat(global-hooks): branch creation enforcement with fetch tracking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "author": {
     "name": "wgordon"
   }


### PR DESCRIPTION
## Summary
- Add `branch-no-base` DENY rule: blocks `git switch -c`/`git checkout -b`/`git worktree add -b` without a start-point
- Add `branch-needs-fetch` ASK rule: prompts when branching from `upstream/main` without `git fetch` earlier in the same `&&` chain
- Add `branch-from-local-main` ASK rule: warns that local `main`/`master` may be stale
- Add `branch-from-non-upstream` ASK rule: catches feature branch stacking
- Add `_parse_branch_creation` parser and `_is_safe_start_point` classifier
- Bump global-hooks to v1.9.0

## Test plan
- [x] 263 tests pass (79 new: 35 integration + 22 parser unit + 22 classifier unit)
- [x] Ruff lint and format clean
- [ ] Verify CI passes
- [ ] Update local plugin after merge