### PR TITLE
feat: add incremental-planning skill and EnterPlanMode hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,9 +78,9 @@
     },
     {
       "name": "global-skills",
-      "version": "1.2.3",
+      "version": "1.4.0",
       "source": "./global-skills",
-      "description": "Global skills: file-audit, git-history, lsp-navigation, test-runner, uv-python",
+      "description": "Global skills: file-audit, git-history, lsp-navigation, test-runner, uv-python, incremental-planning",
       "category": "productivity",
       "tags": ["skills", "git", "lsp", "python", "testing"]
     },
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,83 +1,46 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Development Commands
 
 ```bash
 make all          # Lint + test (CI runs this)
-make lint         # uv run ruff check . && uv run ruff format --check .
 make format       # Auto-fix: uv run ruff format . && uv run ruff check --fix .
 make test         # uv run pytest (runs global-hooks/tests/)
-make prek         # uvx prek run --all-files
-
-# Single test file or test
-uv run pytest global-hooks/tests/test_tool_selection_guard.py -v
-uv run pytest global-hooks/tests/test_tool_selection_guard.py::TestGitBranchEnforcement::test_branch_enforcement -k "deny-switch-c-no-start"
 ```
 
 Python 3.10+. Ruff line-length 100, select `E,W,F,I,UP,B,SIM`. Tests only exist in `global-hooks/tests/`.
 
-## Critical Rule
+## Critical Rules
 
-**Never edit `~/.claude/plugins/`** — always edit this source repository. After changes:
-1. Commit and push
-2. `claude plugin marketplace update private-claude-marketplace`
-3. `claude plugin update <plugin-name>@private-claude-marketplace`
+- **Never edit `~/.claude/plugins/`** — always edit this source repository.
+- **Always bump versions in both files** when modifying a plugin:
+  - `<plugin>/.claude-plugin/plugin.json`
+  - `.claude-plugin/marketplace.json`
 
-## Repository Architecture
+## Change Workflow
 
-This is a **private Claude Code plugin marketplace** containing 11 plugins. The master registry is `.claude-plugin/marketplace.json` — it lists all plugins with their versions and source paths. Each plugin has its own `.claude-plugin/plugin.json` with independent versioning.
+1. **Develop and test locally** — Run `make all` before committing.
+2. **Branch, commit, push, PR** — Branch from `origin/main`. Conventional commits.
+3. **Wait for CI** — `gh pr checks <number> --watch`. Do not merge on red.
+4. **Merge** — `gh pr merge <number> --merge`.
+5. **Update local plugin** — After merge:
+   ```bash
+   git switch main && git pull origin main
+   claude plugin marketplace update private-claude-marketplace
+   claude plugin update <plugin-name>@private-claude-marketplace
+   ```
+6. **Restart and E2E verify** — User restarts their session. Run real commands (both blocked and allowed) to confirm behavior. Do not rely solely on unit tests.
 
-### Plugin Categories
+## Repository Structure
 
-**LSP Plugins (5)** — Language servers via `.lsp.json`:
-`pyright-uvx`, `vtsls-npx`, `gopls-go`, `vscode-html-css-npx`, `rust-analyzer-rustup`
-Minimal structure: `.claude-plugin/plugin.json` + `.lsp.json`. No code to maintain.
+Private Claude Code plugin marketplace with 11 plugins. Master registry: `.claude-plugin/marketplace.json`.
 
-**Agent Plugins (3)** — `.md` files with YAML frontmatter (name, tools, model, color):
-- `project-dev/` — 10 agents (orchestrator, feature-writer, bug-fixer, etc.) + 6 skills
-- `test-execution/` — 1 agent (test-runner)
-- `superclaude/` — 4 agents (architect, security, qa, performance) + 2 skills
+- **LSP plugins (5):** `pyright-uvx`, `vtsls-npx`, `gopls-go`, `vscode-html-css-npx`, `rust-analyzer-rustup`
+- **Agent plugins (3):** `project-dev/`, `test-execution/`, `superclaude/`
+- **Productivity plugins (3):** `global-hooks/` (only plugin with tests), `global-skills/`, `global-commands/`
 
-**Productivity Plugins (3)**:
-- `global-hooks/` — Hook scripts + `hooks/hooks.json` registration. **Only plugin with tests.**
-- `global-skills/` — 8 skills in `skills/*/SKILL.md`
-- `global-commands/` — 6 commands in `commands/*.md`
-
-### Plugin Anatomy
-
-```
-plugin-name/
-  .claude-plugin/plugin.json    # Always present: name, version, description
-  .lsp.json                     # LSP only: server command, extensions, settings
-  agents/*.md                   # Agent definitions (YAML frontmatter + system prompt)
-  skills/*/SKILL.md             # Skill definitions (YAML frontmatter + instructions)
-  commands/*.md                 # Slash command definitions
-  hooks/hooks.json              # Hook registration (PreToolUse/PostToolUse matchers)
-  hooks/*.py, hooks/*.sh        # Hook implementations
-```
-
-### global-hooks: tool-selection-guard.py
-
-The most complex component. A PreToolUse hook (~860 lines) that runs on every Bash/Read/Write/Edit/Grep/Glob invocation. Three rule systems:
-
-1. **RULES** — Tool selection (28 regex rules). 4-tuple: `(name, pattern, exception, message)`. Blocks suboptimal patterns like `cat file` (use Read), `grep` (use Grep), `ls` (use Glob), `python` (use `uv run`).
-
-2. **GIT_DENY_RULES** — Hard blocks (exit 2). 3-tuple: `(name, check_fn, message)`. Prevents force push, push to upstream, reset --hard, branch -D, branch creation without start-point, etc.
-
-3. **GIT_ASK_RULES** — User prompts (exit 1). Same 3-tuple format. Warns about stash drop, local main staleness, non-upstream branching, etc.
-
-Additional special cases in `check_git_safety()`: commit-to-main detection (subprocess), branch-needs-fetch (chain-aware fetch tracking via `fetch_seen` parameter from `main()`).
-
-Key helpers: `_parse_branch_creation(cmd)`, `_is_safe_start_point(ref)`, `_get_push_target(cmd)`, `_has_force_flag(cmd)`. Command parsing: `split_commands()` (&&/||/;), `extract_bash_c()`, `extract_subshells()`. Preprocessing: `strip_env_prefix()` (KEY=val), `strip_shell_keyword()` (do/then/else from for/if/while splits).
-
-### Version Bumping
-
-When modifying a plugin, bump its version in **both** files:
-- `<plugin>/.claude-plugin/plugin.json` (the plugin's own version)
-- `.claude-plugin/marketplace.json` (the marketplace entry's version)
+Each plugin has `.claude-plugin/plugin.json`. Hooks register in `hooks/hooks.json`. Skills live in `skills/*/SKILL.md`.
 
 ## CI
 
-GitHub Actions on PRs to main (Python/config file changes only). Runs `make all`. Uses `uv sync --group dev` for dependencies.
+GitHub Actions on PRs to main. Runs `make all`. Uses `uv sync --group dev`.

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/tool-selection-guard.py
+++ b/global-hooks/hooks/tool-selection-guard.py
@@ -784,6 +784,19 @@ def main():
         )
         sys.exit(2)
 
+    # ── EnterPlanMode redirect: use incremental-planning skill instead ──
+    if tool_name == "EnterPlanMode":
+        print(
+            "Native plan mode writes and displays the full plan at once.\n"
+            "Use the incremental-planning skill instead:\n"
+            "  Invoke Skill tool with 'global-skills:incremental-planning'\n\n"
+            "This skill asks clarifying questions first, writes the plan\n"
+            "incrementally to a file, and provides research context in chat\n"
+            "for informed feedback.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     if tool_name != "Bash":
         sys.exit(0)
 

--- a/global-hooks/tests/test_tool_selection_guard.py
+++ b/global-hooks/tests/test_tool_selection_guard.py
@@ -521,6 +521,27 @@ class TestNonBashPassthrough:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# EnterPlanMode redirect (exit 2)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestEnterPlanModeRedirect:
+    def test_enter_plan_mode_denied(self):
+        result = run_guard("EnterPlanMode", {})
+        assert_guard(result, 2, "incremental-planning")
+
+    def test_enter_plan_mode_message_content(self):
+        result = run_guard("EnterPlanMode", {})
+        assert "Native plan mode" in result.stderr
+        assert "Skill tool" in result.stderr
+
+    def test_exit_plan_mode_passthrough(self):
+        """ExitPlanMode is not intercepted — only EnterPlanMode is."""
+        result = run_guard("ExitPlanMode", {})
+        assert result.returncode == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Non-Bash /tmp/ blocking (all tools)
 # ═══════════════════════════════════════════════════════════════════════════════
 

--- a/global-skills/.claude-plugin/plugin.json
+++ b/global-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-skills",
-  "description": "Global skills for file auditing, git operations, LSP navigation, test execution, Python tooling, and bug investigation",
-  "version": "1.3.0",
+  "description": "Global skills for file auditing, git operations, LSP navigation, test execution, Python tooling, bug investigation, and incremental planning",
+  "version": "1.4.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-skills/skills/incremental-planning/SKILL.md
+++ b/global-skills/skills/incremental-planning/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: incremental-planning
+description: >-
+  Incremental planning workflow that replaces native plan mode. Use when Claude tries to enter
+  plan mode (EnterPlanMode is denied by hook), when asked to "plan", "design an approach",
+  "how should we implement", or before any multi-file implementation task. Asks clarifying
+  questions first, writes plan to file incrementally, provides research context and summaries
+  in chat for feedback. Never displays full plan content in chat.
+allowed-tools: [Read, Write, Edit, Glob, Grep, Task, Bash, AskUserQuestion, LSP, Skill, ToolSearch]
+---
+
+# Incremental Planning
+
+Replaces native plan mode with a question-first, file-based, incremental workflow.
+The plan lives in a file. Chat contains research, questions, and summaries — never full plan content.
+
+## Activation
+
+This skill activates when:
+- `EnterPlanMode` is denied by the tool-selection-guard hook (message includes "incremental-planning")
+- User asks to "plan", "design", "how should we build", "let's think about how to implement"
+- You're about to start a multi-file implementation task
+
+**Announce at start:** "Using incremental-planning to design the approach."
+
+## Core Rules
+
+1. **Research and context go in chat.** Share what you find, your reasoning, and your questions
+   directly in conversational output. The user needs this context to give informed answers.
+2. **Plan content goes to file.** Write plan sections to the plan file using Write/Edit tools.
+   Provide 1-2 sentence summaries in chat after each section.
+3. **Never dump plan content into chat.** If the user wants to read the plan, tell them
+   the file path. Only paste specific sections if the user explicitly asks to see them.
+4. **Questions before writing.** Do not write ANY plan content until Phase 2 is complete.
+5. **Incremental writing.** Write one section/task at a time, never the whole plan at once.
+
+## Phase 0: Assess
+
+Before starting the full workflow, assess whether planning is needed and at what depth.
+
+**Decision matrix:**
+
+| Signal | Action |
+|--------|--------|
+| Single file, clear requirement | Skip planning. Just do the work. |
+| Multi-file, clear requirements | Light planning: 1-2 questions in Phase 2, skip Phase 3 |
+| Multi-file, unclear requirements | Full planning: all phases |
+| Architecture or design change | Full planning + Phase 3 expert consultation |
+
+**Chat output:**
+> "This touches [areas] and involves [scope]. I'll do [full/light] planning."
+
+The user can override your assessment.
+
+## Phase 1: Explore
+
+Gather context before asking questions. You need to understand the landscape to ask informed,
+specific questions — not generic ones.
+
+### Actions
+
+- Launch an **Explore agent** (`Task` with `subagent_type: "Explore"`) for relevant codebase areas
+- Read `hack/PROJECT.md` (or equivalent memory file) for past architectural decisions
+- Search **claude-mem** MCP for relevant past work, decisions, and learnings
+- Use **Serena** MCP `get_symbols_overview` for component-level understanding (if applicable)
+- Use **sequential-thinking** MCP to reason about scope boundaries
+
+### Chat Output
+
+Share your findings in full. The user needs this context to answer Phase 2 questions accurately.
+This is NOT a summary — include specific files, patterns, past decisions, and anything relevant.
+
+Example:
+> "I explored the codebase. Here's what's relevant:
+>
+> - The auth system uses middleware in `src/middleware/auth.ts` with JWT strategy only
+> - `src/stores/redis.ts` has a connection pool, currently used for caching
+> - Tests in `tests/middleware/` cover JWT validation but no session tests exist
+> - PROJECT.md notes a Jan 15 decision to keep auth stateless — this would reverse that
+> - Your last session refactored the Redis connection pool, which is relevant here
+>
+> This shapes my questions."
+
+## Phase 2: Clarify
+
+Ask targeted questions using the `AskUserQuestion` tool. Questions must be informed by
+Phase 1 findings — reference specific code, files, and past decisions.
+
+### Hard Gate
+
+**You MUST ask at least 3 rounds of `AskUserQuestion` and receive answers before writing
+ANY plan content to a file. No exceptions.**
+
+"Simple" tasks are where unexamined assumptions cause the most wasted work. If the task is
+truly simple, the questions will be quick to answer.
+
+### Exit Condition
+
+You can proceed to Phase 4 (or Phase 3 for complex tasks) when you can articulate ALL of:
+
+1. **Scope** — what the user wants built
+2. **Behavior** — how it should work
+3. **Constraints** — technical, security, compatibility requirements
+4. **Non-scope** — what's explicitly out of scope
+
+If you can't articulate all four, ask another question.
+
+### Question Design
+
+- Use `AskUserQuestion` with structured options when possible (easier to answer)
+- Include research context WITH each question — don't make the user remember Phase 1 findings
+- One primary question per `AskUserQuestion` call
+- Question categories: **Scope** (multi-select), **Approach** (single-select),
+  **Constraints** (open-ended ok), **Priority** (single-select)
+
+### Anti-Pattern: Proposing Approaches Too Early
+
+Do NOT propose "2-3 approaches" during clarification. That's the brainstorming skill's pattern.
+Here, the approach **emerges from answers**. Ask about requirements, not solutions.
+
+Bad: "I see two approaches: A or B. Which do you prefer?"
+Good: "Should sessions replace JWT for web clients, or coexist alongside JWT?"
+
+The difference: the first imposes Claude's framing. The second discovers the user's intent.
+
+## Phase 3: Consult (Conditional)
+
+**Only for complex tasks** (architecture changes, security-sensitive work, major features).
+Skip this phase for light planning.
+
+### Actions
+
+Launch specialized agents in parallel using the `Task` tool:
+
+- **`superclaude:architect`** — "Given [Phase 1 context] and [Phase 2 requirements],
+  what are the key architectural considerations?"
+- **`superclaude:security`** — "Review these requirements for security implications"
+  (only if auth, data, or API work)
+- **`superclaude:qa`** — "What testing approach covers these requirements?"
+  (only if test strategy is non-obvious)
+
+### Chat Output
+
+Present findings and decision points directly in chat. Use `AskUserQuestion` for
+decisions that came out of expert review.
+
+Example:
+> "Expert agents flagged two things:
+>
+> **Architecture:** Recommends separating session middleware from JWT middleware.
+> The existing chain pattern in `src/middleware/index.ts` supports this.
+>
+> **Security:** Flags that Redis sessions need session fixation protection and
+> key expiry. Current Redis config doesn't set expiry."
+
+Then:
+```
+AskUserQuestion: "Should we address session fixation in this work or note it as follow-up?"
+```
+
+## Phase 4: Write Incrementally
+
+Now write the plan. One section at a time.
+
+### Determine Plan File Location
+
+Before creating the plan file, check where it belongs:
+
+1. Check if the project uses a local memory directory — look for `hack/`, `.local/`,
+   `scratch/`, or `.dev/` in the project root (check in this order)
+2. **If found:** Create plans in `{memory-dir}/plans/YYYY-MM-DD-<feature>.md`
+   (create the `plans/` subdirectory if it doesn't exist)
+3. **If none found:** Fall back to `~/.claude/plans/YYYY-MM-DD-<feature>.md`
+   (create `~/.claude/plans/` if it doesn't exist)
+
+**Do NOT create a `hack/` directory if one doesn't exist.** That's a project-level decision.
+
+Announce the location: "Plan file: `hack/plans/2026-02-15-session-auth.md`"
+
+### Writing Sequence
+
+#### 1. Write the Header
+
+Write the plan file with a header containing: goal (1 sentence), architecture summary
+(2-3 sentences), tech stack, and key decisions from Phase 2.
+
+**Chat output:** "Wrote plan header. Goal: [1 sentence]. Architecture: [1 sentence]."
+
+#### 2. Write Each Task
+
+Append one task at a time using the Edit tool. Each task should follow bite-sized structure:
+- Files to create/modify (exact paths)
+- Steps (each step is one action: write test, run test, implement, verify, commit)
+- Test commands with expected output
+- Commit message
+
+**Chat output per task:** "Task N written: [1 sentence description]. N steps."
+
+#### 3. Checkpoint Every 2-3 Tasks
+
+After every 2-3 tasks:
+
+```
+AskUserQuestion: "I've written tasks N-M covering [summary].
+Tasks so far: 1) X, 2) Y, 3) Z.
+Any adjustments before I continue?"
+
+Options:
+- "Looks good, continue"
+- "Let me review the plan file"
+- "Adjust something"
+```
+
+If "Let me review" → wait for the user to read the file and come back.
+If "Adjust something" → discuss, rewrite just that task, continue.
+
+#### 4. Incorporate Feedback Immediately
+
+When the user gives feedback on a specific task, rewrite ONLY that task. Don't regenerate
+the entire plan.
+
+## Phase 5: Validate
+
+After all tasks are written:
+
+1. Re-read the complete plan file
+2. Use **sequential-thinking** MCP to check for gaps: missing error handling, untested paths,
+   dependency ordering issues
+3. Cross-reference against Phase 2 requirements: does the plan cover everything?
+
+**Chat output:**
+> "Plan complete. N tasks, M steps total. Covers: [list of areas].
+>
+> One gap I noticed: [description]. Should I add a task for that?"
+
+## Phase 6: Handoff
+
+Offer execution options:
+
+```
+AskUserQuestion: "How do you want to execute this plan?"
+
+Options:
+- "Subagent-driven (this session)" → invoke superpowers:subagent-driven-development
+- "Executing-plans (new session)" → guide to superpowers:executing-plans
+- "I'll handle it manually"
+- "Let me review the full plan first"
+```
+
+## Quick Reference
+
+### Flow
+```
+Phase 0: Assess depth → Phase 1: Explore (findings in chat) →
+Phase 2: Clarify (min 3 questions) → Phase 3: Consult (complex only) →
+Phase 4: Write incrementally (summaries in chat, content to file) →
+Phase 5: Validate → Phase 6: Handoff
+```
+
+### What Goes Where
+```
+CHAT: Research findings, reasoning, questions, 1-sentence task summaries, checkpoints
+FILE: Plan header, task definitions, code snippets, test commands, commit messages
+NEVER IN CHAT: Full plan content, task details, code blocks from the plan
+```
+
+### Plan File Location
+```
+1. hack/plans/ (or .local/plans/, scratch/plans/, .dev/plans/) → if memory dir exists
+2. ~/.claude/plans/ → fallback for all other cases
+```


### PR DESCRIPTION
## Summary
- New `incremental-planning` skill in global-skills that replaces native plan mode with a question-first, incremental workflow
- PreToolUse hook denies `EnterPlanMode` tool call, redirecting Claude to invoke the skill instead
- Plan files go to `hack/plans/` (if project uses memory dir) or `~/.claude/plans/` (fallback)
- 3 new tests for the hook rule
- Version bumps: global-skills 1.4.0, global-hooks 1.11.0

## What this changes
Native plan mode writes and displays the full plan at once, leading to reject-rewrite cycles. The incremental-planning skill:
1. Explores the codebase first (findings shared in chat)
2. Asks clarifying questions via AskUserQuestion (hard gate: min 3 rounds before any plan writing)
3. Writes plan content to a file incrementally (1 task at a time, summaries in chat)
4. Checkpoints every 2-3 tasks for user feedback
5. Never dumps plan content into chat

User-initiated `/plan` mode is unaffected (CLI command, not a tool call).

## Test plan
- [x] `make all` passes (294 tests, lint clean)
- [ ] E2E: Start session, trigger plan mode, verify hook fires and skill is invoked
- [ ] E2E: Verify `/plan` CLI command still works (not intercepted)