### PR TITLE
fix(global-hooks): register EnterPlanMode matcher in hooks.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,17 +19,21 @@ Python 3.10+. Ruff line-length 100, select `E,W,F,I,UP,B,SIM`. Tests only exist 
 
 ## Change Workflow
 
+**CLAUDE.md-only changes** do not need a PR. Edit in place and leave uncommitted.
+
+**All other changes** follow this workflow:
+
 1. **Develop and test locally** — Run `make all` before committing.
-2. **Branch, commit, push, PR** — Branch from `origin/main`. Conventional commits.
-3. **Wait for CI** — `gh pr checks <number> --watch`. Do not merge on red.
+2. **Branch, commit, push, PR** — Branch from `origin/main`. Conventional commits. Show the PR link to the user.
+3. **Wait for CI** — `gh pr checks <number> --watch`. Do not merge on red. CI only triggers on `*.py`, `pyproject.toml`, `Makefile`, `.pre-commit-config.yaml`, and `.github/workflows/ci.yml` changes. If no checks appear (JSON-only, markdown-only, or skill-only PRs), merge after local `make all` passes.
 4. **Merge** — `gh pr merge <number> --merge`.
-5. **Update local plugin** — After merge:
+5. **Update local plugin** — After merge, run these commands (do not hand them to the user):
    ```bash
    git switch main && git pull origin main
    claude plugin marketplace update private-claude-marketplace
    claude plugin update <plugin-name>@private-claude-marketplace
    ```
-6. **Restart and E2E verify** — User restarts their session. Run real commands (both blocked and allowed) to confirm behavior. Do not rely solely on unit tests.
+6. **Restart and E2E verify** — Tell user to restart their session. E2E verification happens in the new session.
 
 ## Repository Structure
 

--- a/global-hooks/hooks/hooks.json
+++ b/global-hooks/hooks/hooks.json
@@ -57,6 +57,15 @@
         ]
       },
       {
+        "matcher": "EnterPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py"
+          }
+        ]
+      },
+      {
         "matcher": "Bash(git push origin*)",
         "hooks": [
           {


### PR DESCRIPTION
The tool-selection-guard.py had the EnterPlanMode deny logic (from PR #24) but hooks.json only registered matchers for Bash, Read, Write, Edit, Grep, and Glob. The hook never fired for EnterPlanMode because there was no matcher entry.