### PR TITLE
fix(global-hooks): fix broken hook matchers and add command filtering

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,7 +78,7 @@
     },
     {
       "name": "global-skills",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "source": "./global-skills",
       "description": "Global skills: file-audit, git-history, lsp-navigation, test-runner, uv-python, incremental-planning",
       "category": "productivity",
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/hooks.json
+++ b/global-hooks/hooks/hooks.json
@@ -66,7 +66,7 @@
         ]
       },
       {
-        "matcher": "Bash(git push origin*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
@@ -77,7 +77,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash(git commit:*)",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",

--- a/global-hooks/hooks/pre-push-review.sh
+++ b/global-hooks/hooks/pre-push-review.sh
@@ -9,6 +9,17 @@
 
 set -uo pipefail
 
+# --- Hook Input Filtering ---
+# When called as a PreToolUse hook, stdin contains JSON with tool_input.
+# Only proceed for git push commands; exit 0 for everything else.
+if ! [ -t 0 ]; then
+    INPUT=$(cat)
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+    if [[ ! "$COMMAND" =~ ^git[[:space:]]+push[[:space:]] ]]; then
+        exit 0
+    fi
+fi
+
 # Get the current branch
 CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 if [[ -z "$CURRENT_BRANCH" ]]; then

--- a/global-hooks/hooks/validate-commit-message.sh
+++ b/global-hooks/hooks/validate-commit-message.sh
@@ -11,6 +11,17 @@
 #   2 = Error (blocks the commit)
 #
 
+# --- Hook Input Filtering ---
+# When called as a PostToolUse hook, stdin contains JSON with tool_input.
+# Only proceed for git commit commands; exit 0 for everything else.
+if ! [ -t 0 ]; then
+    INPUT=$(cat)
+    COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+    if [[ ! "$COMMAND" =~ ^git[[:space:]]+commit ]]; then
+        exit 0
+    fi
+fi
+
 # Early exit if not in a git repository
 if ! git rev-parse --git-dir &>/dev/null; then
     exit 0

--- a/global-skills/.claude-plugin/plugin.json
+++ b/global-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-skills",
   "description": "Global skills for file auditing, git operations, LSP navigation, test execution, Python tooling, bug investigation, and incremental planning",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-skills/skills/test-runner/SKILL.md
+++ b/global-skills/skills/test-runner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: test-runner
 description: Efficient test execution patterns for pytest and pre-commit - sequential execution, targeted re-runs, and smart failure handling
+allowed-tools: [Bash, Read, Grep, Glob]
 ---
 
 # Test Execution Best Practices


### PR DESCRIPTION
## Summary
- Fixes `Bash(git commit:*)` and `Bash(git push origin*)` matchers in hooks.json — these used invalid parenthesized syntax that never matched (matchers are regex on tool names only)
- Adds stdin JSON parsing to validate-commit-message.sh and pre-push-review.sh to filter for relevant git commands
- Adds TestHooksJsonConfiguration test class validating matchers have no parentheses, are valid regex, and reference existing scripts
- Adds missing `allowed-tools` to test-runner skill
- Bumps global-hooks 1.11.0 -> 1.12.0, global-skills 1.4.0 -> 1.5.0

## Test plan
- [x] `make all` passes (298 tests, all green)
- [ ] Verify commit validation fires after git commit (PostToolUse)
- [ ] Verify pre-push review fires before git push (PreToolUse)