### PR TITLE
fix(global-hooks): fix commit hook stderr output and chained command detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/pre-push-review.sh
+++ b/global-hooks/hooks/pre-push-review.sh
@@ -15,7 +15,7 @@ set -uo pipefail
 if ! [ -t 0 ]; then
     INPUT=$(cat)
     COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
-    if [[ ! "$COMMAND" =~ ^git[[:space:]]+push[[:space:]] ]]; then
+    if [[ ! "$COMMAND" =~ git[[:space:]]+push[[:space:]] ]]; then
         exit 0
     fi
 fi

--- a/global-hooks/hooks/validate-commit-message.sh
+++ b/global-hooks/hooks/validate-commit-message.sh
@@ -17,7 +17,7 @@
 if ! [ -t 0 ]; then
     INPUT=$(cat)
     COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
-    if [[ ! "$COMMAND" =~ ^git[[:space:]]+commit ]]; then
+    if [[ ! "$COMMAND" =~ git[[:space:]]+commit ]]; then
         exit 0
     fi
 fi
@@ -38,6 +38,9 @@ fi
 
 # Now enable strict error handling for the actual validation
 set -euo pipefail
+
+# Redirect all output to stderr — PostToolUse exit 2 only shows stderr to Claude
+exec 1>&2
 
 # Extract subject line (first line)
 SUBJECT=$(echo "$COMMIT_MSG" | head -1)


### PR DESCRIPTION
## Summary
- Adds `exec 1>&2` to validate-commit-message.sh — PostToolUse exit 2 only shows stderr to Claude, but all error messages were going to stdout and being silently discarded
- Removes `^` anchor from command regex in both shell scripts — chained commands like `git add && git commit` were not detected because the command string starts with `git add`, not `git commit`
- Bumps global-hooks 1.12.0 -> 1.13.0

## Test plan
- [x] `make all` passes (297 passed, 1 skipped)
- [ ] E2E: standalone `git commit` with invalid message triggers validation feedback
- [ ] E2E: chained `git add && git commit` with invalid message triggers validation feedback