### PR TITLE
feat(global-hooks): adds cargo guard rules

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules/
 .ruff_cache/
 .pytest_cache/
 hack/
+.serena

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/tool-selection-guard.py
+++ b/global-hooks/hooks/tool-selection-guard.py
@@ -183,6 +183,28 @@ RULES = [
         None,
         "Linting should be performed with ruff.",
     ),
+    # ── Rust tooling ──
+    (
+        "cargo-lint",
+        re.compile(r"^\s*cargo\s+(check|clippy|fmt)\b"),
+        None,
+        "Check for a `make` target (e.g. `make rust-lint`, `make lint`) instead of "
+        "running cargo directly. Makefile targets handle working directory and standard flags.",
+    ),
+    (
+        "cargo-test",
+        re.compile(r"^\s*cargo\s+(test|nextest)\b"),
+        None,
+        "Check for a `make` target (e.g. `make rust-test`, `make test`) instead of "
+        "running cargo test directly.",
+    ),
+    (
+        "cargo-build",
+        re.compile(r"^\s*cargo\s+build\b"),
+        None,
+        "Check for a `make` target (e.g. `make rust-build`, `make build`) instead of "
+        "running cargo build directly.",
+    ),
     # ── Category C: Encourage project conventions ──
     (
         "bash-script",

--- a/global-hooks/tests/test_tool_selection_guard.py
+++ b/global-hooks/tests/test_tool_selection_guard.py
@@ -193,6 +193,64 @@ class TestPythonTooling:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Category B2: Rust tooling (3 rules)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestRustTooling:
+    @pytest.mark.parametrize(
+        "command, expected_exit, expected_msg",
+        [
+            # cargo-lint: check, clippy, fmt
+            ("cargo check", 2, "make"),
+            ("cargo clippy --all-targets", 2, "make"),
+            ("cargo fmt --all --check", 2, "make"),
+            ("cargo check 2>&1", 2, "make"),
+            # cargo-test: test, nextest
+            ("cargo test --all-features", 2, "make"),
+            ("cargo nextest run --all-features", 2, "make"),
+            # cargo-build
+            ("cargo build --release", 2, "make"),
+            # chained with cd (real-world pattern)
+            ("cd lib/rust && cargo check 2>&1", 2, "make"),
+            ("cd lib/rust && cargo clippy -- -D warnings", 2, "make"),
+            # env prefix
+            ("RUSTFLAGS=-Dwarnings cargo check", 2, "make"),
+            # passthrough: non-build cargo subcommands
+            ("cargo add serde", 0, None),
+            ("cargo install cargo-nextest", 0, None),
+            ("cargo update", 0, None),
+            ("cargo doc --open", 0, None),
+            ("cargo run --release", 0, None),
+            ("cargo new my-project", 0, None),
+            ("cargo init", 0, None),
+        ],
+        ids=[
+            "cargo-check",
+            "cargo-clippy",
+            "cargo-fmt",
+            "cargo-check-stderr",
+            "cargo-test",
+            "cargo-nextest",
+            "cargo-build",
+            "cd-cargo-check",
+            "cd-cargo-clippy",
+            "env-cargo-check",
+            "cargo-add-allow",
+            "cargo-install-allow",
+            "cargo-update-allow",
+            "cargo-doc-allow",
+            "cargo-run-allow",
+            "cargo-new-allow",
+            "cargo-init-allow",
+        ],
+    )
+    def test_rust_tooling(self, command, expected_exit, expected_msg):
+        result = run_bash(command)
+        assert_guard(result, expected_exit, expected_msg)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Category C: Project conventions (5 rules)
 # ═══════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
- Adds 3 cargo rules to tool-selection-guard redirecting build-cycle commands (check, clippy, fmt, test, nextest, build) to Makefile targets
- Non-build cargo subcommands (add, install, update, doc, run, new, init) pass through
- 17 new test cases covering blocks, cd-chained patterns, env prefix, and passthroughs
- Gitignores .serena directory

## Test plan
- [x] `make all` passes (315 tests, lint clean)