### PR TITLE
feat(global-hooks): guard pipe segments and add python-json jq rule

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "author": {
     "name": "wgordon"
   }


### PR DESCRIPTION
## Summary
- Splits commands on `|` (and `|&`) to check each pipe segment against guard rules, catching guarded commands mid-pipeline (e.g., `oc get ... | python3 -c "import json; ..."`)
- Adds `python-json` rule that suggests `jq` when python is used with `-c` and `json` for JSON processing
- Skips native-tool rules (cat→Read, grep→Grep, head→Read, etc.) for pipe segments since those tools can't process piped command output
- Applies pipe splitting to subshell content too (`$(cmd | python3 ...)`)

## Test plan
- [x] 354 tests pass (`make all` — lint + test)
- [x] 23 new pipe segment integration tests (python-json, plain python, multi-pipe, pager/editor, pipe-exception preservation, chain+pipe, env prefix, subshell, `|&`, for-loop)
- [x] 10 new `split_pipes` unit tests (simple, multi, quoted, `|&`, empty, whitespace, real-world)
- [x] 3 new `python-json` rule tests (standalone, sys import, uv run exception)
- [x] Zero regressions on 318 existing tests