### PR TITLE
fix(global-hooks): relaxes temp path guard for reads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/tool-selection-guard.py
+++ b/global-hooks/hooks/tool-selection-guard.py
@@ -863,10 +863,15 @@ def main():
     tool_name = data.get("tool_name", "")
     tool_input = data.get("tool_input", {})
 
-    # ── /tmp/ guard for ALL tools (Read, Write, Edit, Grep, Glob, Bash) ──
-    # Fires before the permission layer so the agent gets guidance, not a prompt.
+    # ── /tmp/ guard for write-oriented tools (Write, Edit, NotebookEdit) ──
+    # Read/Grep/Glob are allowed — Claude Code stores task output files in /tmp/.
     file_path = tool_input.get("file_path", "") or tool_input.get("path", "")
-    if file_path and "/tmp/" in file_path and "hack/tmp" not in file_path:
+    if (
+        file_path
+        and "/tmp/" in file_path
+        and "hack/tmp" not in file_path
+        and tool_name in ("Write", "Edit", "NotebookEdit")
+    ):
         print(
             "Use `hack/tmp/` (gitignored) instead of `/tmp/` for temporary files. "
             "Native tools (Read/Write/Edit) work on local files without extra permissions.",


### PR DESCRIPTION
## Summary
- The /tmp/ guard was blocking Read/Grep/Glob on Claude Code's internal task output files (/private/tmp/claude-*/...tasks/*.output)
- Restricts the guard to write-oriented tools only (Write, Edit, NotebookEdit) since the purpose is preventing scratch file creation, not blocking reads
- Adds test coverage for NotebookEdit blocking and Read/Grep/Glob/task-output allowance

## Test plan
- [x] All 356 tests pass locally
- [x] Verified Read/Grep/Glob on /tmp/ paths now allowed
- [x] Verified Write/Edit/NotebookEdit on /tmp/ paths still blocked
- [x] Verified hack/tmp/ paths still allowed for all tools