### PR TITLE
feat(global-skills): adds unfuck comprehensive cleanup skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -78,9 +78,9 @@
     },
     {
       "name": "global-skills",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "source": "./global-skills",
-      "description": "Global skills: file-audit, git-history, lsp-navigation, test-runner, uv-python, incremental-planning",
+      "description": "Global skills: file-audit, git-history, lsp-navigation, test-runner, uv-python, incremental-planning, unfuck (comprehensive repo cleanup)",
       "category": "productivity",
       "tags": ["skills", "git", "lsp", "python", "testing"]
     },

--- a/global-skills/.claude-plugin/plugin.json
+++ b/global-skills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-skills",
-  "description": "Global skills for file auditing, git operations, LSP navigation, test execution, Python tooling, bug investigation, and incremental planning",
-  "version": "1.5.0",
+  "description": "Global skills for file auditing, git operations, LSP navigation, test execution, Python tooling, bug investigation, incremental planning, and comprehensive repo cleanup",
+  "version": "1.6.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-skills/skills/unfuck/SKILL.md
+++ b/global-skills/skills/unfuck/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: unfuck
+description: >-
+  Comprehensive one-shot repo cleanup skill. This skill should be used when the user asks to
+  "clean up the repo", "remove dead code", "de-AI-slop", "unfuck this codebase",
+  "comprehensive cleanup", "remove unused code", "simplify the codebase", "fix code quality",
+  "clean everything up", "audit the codebase", "fix tech debt", "remove duplicates",
+  "unify the architecture", "security review and fix", or wants a thorough, automated cleanup
+  of their entire repository. Launches a full agent swarm to discover issues, plan fixes, and
+  implement changes autonomously. Combines detailed custom analysis with existing skills
+  (file-audit, security-review, sc:cleanup, sc:improve, docs-sync, sc:index-repo,
+  superclaude:architect, superclaude:security, superclaude:qa, code-simplifier,
+  project-dev:refactor, test-execution:test-runner) into a unified cleanup workflow.
+allowed-tools: [Read, Write, Edit, Glob, Grep, Task, Bash, AskUserQuestion, TeamCreate, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, LSP, Skill]
+---
+
+# /unfuck — Comprehensive Repo Cleanup
+
+One-shot command that launches a full agent swarm to discover, plan, and fix everything wrong
+with a codebase: dead code, duplicates, security issues, AI slop, architectural drift,
+complexity, and documentation rot.
+
+## Quick Start
+
+```
+/unfuck                     # Full cleanup of entire repo
+/unfuck src/                # Scope to a directory
+/unfuck --dry-run           # Discovery + plan only, no implementation
+```
+
+## What It Does
+
+Runs a 5-phase workflow combining 12+ existing skills/agents with detailed custom analysis
+logic and optional external CLI tools. Phase 0 indexes the repo. Phase 1 spawns 7 parallel
+discovery agents that scan every file. Phase 2 synthesizes findings into a prioritized cleanup
+plan. Phase 3 spawns sequential implementation agents that fix each category and commit.
+Phase 4 verifies everything passes and generates a report.
+
+## Workflow Phases
+
+### Phase 0: Index & Setup
+1. Run `sc:index-repo` to create PROJECT_INDEX.md (~3K token project reference)
+2. Detect project languages from config files (package.json, pyproject.toml, go.mod, etc.)
+3. Detect available external tools (Knip, Semgrep, radon, gitleaks, etc.) — see `references/external-tools.md`
+4. Create feature branch: `cleanup/unfuck-YYYY-MM-DD`
+5. Create `hack/unfuck/YYYY-MM-DD/discovery/` directory for agent output (date-scoped per run)
+6. Create TeamCreate swarm: `unfuck-cleanup`
+
+### Phase 1: Discovery (7 parallel agents)
+
+All agents run simultaneously in background. Each writes structured JSON findings to
+`hack/unfuck/YYYY-MM-DD/discovery/`. Full prompts in `references/discovery-agents.md`.
+
+| Agent | Role | Paired Skills | External Tools | Output |
+|-------|------|---------------|----------------|--------|
+| dead-code-hunter | Unused code, exports, imports, files, deps | `file-audit` | Knip, Vulture, deadcode | `dead-code.json` |
+| duplicate-detector | Copy-paste code, near-duplicates, redundant wrappers | `file-audit` | jscpd | `duplicates.json` |
+| security-auditor | OWASP Top 10, secrets, CVEs, auth gaps | `security-review`, `superclaude:security` | Semgrep, gitleaks, Bandit | `security.json` |
+| architecture-reviewer | Circular deps, divergent patterns, god objects | `superclaude:architect`, `sc:analyze` | dependency-cruiser, Madge | `architecture.json` |
+| ai-slop-detector | Over-abstraction, unnecessary wrappers, catch-rethrow, comment noise | (novel — see `references/ai-slop-checklist.md`) | — | `ai-slop.json` |
+| complexity-auditor | Long functions, deep nesting, magic values, parameter bloat | `superclaude:qa` | radon | `complexity.json` |
+| documentation-auditor | README drift, broken links, stale TODOs, missing docs | `docs-sync`, `file-audit` | — | `documentation.json` |
+
+**Model note:** ai-slop-detector uses `opus` (detecting AI patterns requires stronger judgment).
+All others use `sonnet`.
+
+**Tool fallback:** When external tools are unavailable, agents perform equivalent analysis
+manually using LSP, Grep, and file reading. See `references/external-tools.md` fallback table.
+
+### Phase 2: Synthesis & Planning
+
+The orchestrator (not a subagent) directly:
+1. Reads all 7 discovery JSON files
+2. Deduplicates overlapping findings across agents
+3. Cross-references compound patterns (dead + divergent = safe to remove)
+4. Prioritizes: security → dead code → duplicates → AI slop → complexity → architecture → docs
+5. Writes `hack/unfuck/YYYY-MM-DD/cleanup-plan.md` with per-finding detail
+6. Creates TaskList with one task per category
+7. **AskUserQuestion** if: public API deletions, 5+ file architectural changes, ambiguous findings,
+   security policy decisions, or >100 total findings
+
+### Phase 3: Implementation (sequential per category)
+
+For each category in priority order, spawn an implementation agent with its full prompt from
+`references/implementation-agents.md`. Each agent:
+- Receives filtered findings for its category
+- Uses paired existing skills for execution (sc:cleanup, project-dev:refactor, code-simplifier, etc.)
+- Applies custom fix strategies from its prompt
+- After EACH category: run tests → run formatter → commit or rollback (git stash on failure)
+
+| Agent | Category | Paired Skills | Model | Commit Format |
+|-------|----------|---------------|-------|---------------|
+| fix-security | Security fixes | `security-review` | sonnet | `fix(security): <vuln>` |
+| fix-dead-code | Dead code removal | `sc:cleanup --aggressive` | sonnet | `refactor: removes dead code` |
+| fix-duplicates | Duplicate consolidation | `project-dev:refactor` | sonnet | `refactor: consolidates duplicates` |
+| fix-ai-slop | AI slop simplification | `code-simplifier`, `sc:improve` | opus | `refactor: simplifies over-engineered code` |
+| fix-complexity | Complexity reduction | `sc:improve --type maintainability` | sonnet | `refactor: reduces complexity` |
+| fix-architecture | Architecture unification | `project-dev:refactor`, `superclaude:architect` | sonnet | `refactor: unifies <pattern>` |
+| fix-documentation | Documentation sync | `docs-sync` | sonnet | `docs: syncs documentation` |
+
+### Phase 4: Verification & Report
+
+1. Run full test suite via `test-execution:test-runner`
+2. Run `project-dev:code-quality` on all modified files
+3. Apply `superpowers:verification-before-completion` patterns
+4. Generate `hack/unfuck/YYYY-MM-DD/cleanup-report.md` with:
+   - Summary stats (files modified, lines added/removed, net delta, issues fixed by category)
+   - Per-category breakdown with specific changes and commit SHAs
+   - Blocked items (test failures, needs-review) with stash names and manual fix guidance
+   - External tools used vs agent-only analysis
+   - Remaining tech debt intentionally deferred
+5. Clean up intermediate discovery files
+6. Report completion to user with summary and report location
+
+## Git Workflow
+
+- Creates feature branch: `cleanup/unfuck-YYYY-MM-DD`
+- One commit per cleanup category (security, dead-code, duplicates, ai-slop, complexity, architecture, docs)
+- Conventional commit messages
+- Blocked categories are stashed with descriptive names for manual recovery
+
+## Safety
+
+- Tests verified after every implementation category — rollback on failure
+- LSP `findReferences` before every deletion, move, or rename
+- Security fixes NEVER auto-applied if they could change business logic
+- AskUserQuestion for all ambiguous or high-risk decisions
+- `--dry-run` flag for discovery + planning without implementation
+- Agents use `needs-review` escape hatch for uncertain changes
+
+## Output Files
+
+| File | Purpose | Persistent |
+|------|---------|------------|
+| `hack/unfuck/YYYY-MM-DD/cleanup-plan.md` | Prioritized findings with fix strategies | Yes |
+| `hack/unfuck/YYYY-MM-DD/cleanup-report.md` | Final report with stats and blocked items | Yes |
+| `hack/unfuck/YYYY-MM-DD/discovery/*.json` | Raw agent findings (7 files) | Cleaned up |
+| `hack/unfuck/YYYY-MM-DD/available-tools.json` | Detected external tools | Cleaned up |
+
+## References
+
+| File | Content |
+|------|---------|
+| `references/orchestration-playbook.md` | Complete phase-by-phase coordination guide with JSON schemas, dedup algorithm, rollback procedures, TeamCreate config, and error handling |
+| `references/discovery-agents.md` | Full prompts for all 7 discovery agents — role, methodology, external tool commands, LSP patterns, severity/risk guides, output format |
+| `references/implementation-agents.md` | Full prompts for all 7 implementation agents — fix strategies, paired skills, safety rules, test cadence, commit formats |
+| `references/ai-slop-checklist.md` | 32 anti-patterns across 7 categories (structural, error handling, naming, comments, testing, imports, types) with before/after examples and false-positive guidance |
+| `references/external-tools.md` | Tool matrix by language, detection commands, JSON output schemas, parsing instructions, Phase 0 detection script, fallback strategies |

--- a/global-skills/skills/unfuck/references/ai-slop-checklist.md
+++ b/global-skills/skills/unfuck/references/ai-slop-checklist.md
@@ -1,0 +1,1902 @@
+# AI Slop Detection Checklist
+
+Reference for identifying AI-generated code anti-patterns. Used by the AI Slop Detector agent
+during `/unfuck` Phase 1 discovery.
+
+## How to Use This Checklist
+
+1. Read source files in batches of 10-20 files
+2. For each file, scan against ALL categories below
+3. For each match, record: file, line range, pattern ID, severity, suggested fix
+4. Generate before/after code for the top 20 worst findings
+5. Rate each finding against the false-positive guidance before including it
+
+## Severity Ratings
+
+- **critical**: Pattern that actively harms readability AND maintainability (e.g., abstraction layer that makes debugging impossible)
+- **high**: Pattern that significantly increases code complexity without benefit
+- **medium**: Pattern that adds unnecessary code but doesn't actively harm
+- **low**: Style preference that experienced developers would typically simplify
+
+---
+
+## Category 1: Structural Slop (default severity: high)
+
+### SS-01: Unnecessary Wrapper Function
+
+**Detection:** A function whose body is a single call to another function with the same (or subset of) arguments, adding no logic, transformation, or error handling.
+
+**Before (slop):**
+```python
+def get_user_data(user_id):
+    return fetch_user_from_database(user_id)
+```
+
+**After (clean):**
+```python
+# Just use fetch_user_from_database directly at call sites
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+function handleSubmit(data: FormData) {
+  return submitForm(data);
+}
+
+// Clean: call submitForm directly
+```
+
+**False positive:** Wrapper is legitimate if it adds logging, caching, error transformation, retry logic, adapts the interface (different parameter names/order for consumers), or provides a stable public API over an unstable internal one.
+
+---
+
+### SS-02: Over-Abstraction (Interface with Single Implementation)
+
+**Detection:** An interface, abstract class, or protocol with exactly one implementing class, where the interface is not used for test mocking or dependency injection.
+
+**Before (slop):**
+```python
+class UserRepositoryInterface(ABC):
+    @abstractmethod
+    def get_user(self, user_id: int) -> User: ...
+    @abstractmethod
+    def save_user(self, user: User) -> None: ...
+
+class UserRepository(UserRepositoryInterface):
+    def get_user(self, user_id: int) -> User:
+        return self.db.query(User).get(user_id)
+    def save_user(self, user: User) -> None:
+        self.db.add(user)
+        self.db.commit()
+```
+
+**After (clean):**
+```python
+class UserRepository:
+    def get_user(self, user_id: int) -> User:
+        return self.db.query(User).get(user_id)
+    def save_user(self, user: User) -> None:
+        self.db.add(user)
+        self.db.commit()
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+interface ILogger {
+  log(message: string): void;
+  error(message: string): void;
+}
+
+class ConsoleLogger implements ILogger {
+  log(message: string): void { console.log(message); }
+  error(message: string): void { console.error(message); }
+}
+
+// Clean — no second implementation exists or is tested against
+class Logger {
+  log(message: string): void { console.log(message); }
+  error(message: string): void { console.error(message); }
+}
+```
+
+**False positive:** Interface is legitimate if: (a) it is used as a mock/stub type in tests, (b) the codebase follows a DI framework that requires interfaces, or (c) a second implementation is tracked in an active issue/ticket. Search for test files that reference the interface before flagging.
+
+---
+
+### SS-03: Premature Generalization (Design Pattern with Single Variant)
+
+**Detection:** Strategy, Factory, Builder, Observer, or Command pattern where only one concrete variant exists. Look for class hierarchies where the abstract parent has exactly one child.
+
+**Before (slop):**
+```typescript
+interface NotificationStrategy {
+  send(message: string): void;
+}
+
+class EmailNotificationStrategy implements NotificationStrategy {
+  send(message: string): void {
+    sendEmail(message);
+  }
+}
+
+class NotificationService {
+  constructor(private strategy: NotificationStrategy) {}
+  notify(message: string) {
+    this.strategy.send(message);
+  }
+}
+
+// Usage: new NotificationService(new EmailNotificationStrategy())
+```
+
+**After (clean):**
+```typescript
+function notify(message: string): void {
+  sendEmail(message);
+}
+```
+
+**Python example:**
+```python
+# Slop — factory with one product
+class ParserFactory:
+    @staticmethod
+    def create(format_type: str) -> Parser:
+        if format_type == "json":
+            return JSONParser()
+        raise ValueError(f"Unknown format: {format_type}")
+
+# Clean — just use JSONParser directly
+parser = JSONParser()
+```
+
+**False positive:** Pattern is legitimate if multiple variants exist in the codebase, or if the pattern is part of a plugin/extension system that external code extends.
+
+---
+
+### SS-04: Single-Use Helper Function
+
+**Detection:** A function called from exactly one location, where inlining it would be equally readable or more readable. Use grep/search to verify there is only one call site.
+
+**Before (slop):**
+```python
+def validate_email_format(email):
+    return re.match(r'^[\w\.-]+@[\w\.-]+\.\w+$', email) is not None
+
+def register_user(email, password):
+    if not validate_email_format(email):  # only call site
+        raise ValueError("Invalid email")
+    # ... rest of registration
+```
+
+**After (clean):**
+```python
+def register_user(email, password):
+    if not re.match(r'^[\w\.-]+@[\w\.-]+\.\w+$', email):
+        raise ValueError("Invalid email")
+    # ... rest of registration
+```
+
+**JS/TS example:**
+```typescript
+// Slop — called once, trivial logic
+function formatPrice(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+
+function renderProduct(product: Product) {
+  return `${product.name}: ${formatPrice(product.price)}`; // only call site
+}
+
+// Clean
+function renderProduct(product: Product) {
+  return `${product.name}: $${product.price.toFixed(2)}`;
+}
+```
+
+**False positive:** Helper is legitimate if: (a) the logic is complex (>5 lines), (b) it is separately unit-tested, (c) the function name provides significant documentation value for a non-obvious operation, or (d) it is likely to gain additional call sites soon.
+
+---
+
+### SS-05: Configuration-Driven Behavior Where Hardcoding is Clearer
+
+**Detection:** Constants, config objects, or environment variables for values that never change across environments and have exactly one valid value. Look for config files where every value is the same in dev, staging, and production.
+
+**Before (slop):**
+```typescript
+const CONFIG = {
+  MAX_RETRIES: 3,
+  RETRY_DELAY_MS: 1000,
+  ENABLE_LOGGING: true,
+  LOG_LEVEL: 'info',
+};
+
+function fetchWithRetry(url: string) {
+  for (let i = 0; i < CONFIG.MAX_RETRIES; i++) {
+    // ...
+    await sleep(CONFIG.RETRY_DELAY_MS);
+  }
+}
+```
+
+**After (clean, if these never change):**
+```typescript
+function fetchWithRetry(url: string) {
+  for (let i = 0; i < 3; i++) {
+    // ...
+    await sleep(1000);
+  }
+}
+```
+
+**Python example:**
+```python
+# Slop — config for a constant
+SETTINGS = {
+    "HASH_ALGORITHM": "sha256",
+    "ENCODING": "utf-8",
+}
+
+def hash_data(data: str) -> str:
+    return hashlib.new(SETTINGS["HASH_ALGORITHM"], data.encode(SETTINGS["ENCODING"])).hexdigest()
+
+# Clean
+def hash_data(data: str) -> str:
+    return hashlib.sha256(data.encode()).hexdigest()
+```
+
+**False positive:** Config is legitimate if values are environment-specific, user-configurable, or changed during testing. Magic numbers ARE bad if the meaning is not obvious -- use named constants (`MAX_RETRIES = 3`), not config objects.
+
+---
+
+### SS-06: Unnecessary Indirection Layer
+
+**Detection:** A module or class that exists only to forward calls to another module/class without adding any logic, validation, transformation, or error handling. Every method is a one-liner delegating to the same dependency.
+
+**Before (slop):**
+```python
+# services/user_service.py
+class UserService:
+    def __init__(self, repo: UserRepository):
+        self.repo = repo
+
+    def get_user(self, user_id):
+        return self.repo.get_user(user_id)
+
+    def create_user(self, data):
+        return self.repo.create_user(data)
+
+    def delete_user(self, user_id):
+        return self.repo.delete_user(user_id)
+```
+
+**After (clean):**
+```python
+# Use UserRepository directly — the service layer adds nothing
+```
+
+**JS/TS example:**
+```typescript
+// Slop — controller that just forwards to service
+class UserController {
+  constructor(private service: UserService) {}
+  getUser(id: string) { return this.service.getUser(id); }
+  createUser(data: UserDTO) { return this.service.createUser(data); }
+  deleteUser(id: string) { return this.service.deleteUser(id); }
+}
+
+// Clean: wire routes directly to UserService methods
+```
+
+**False positive:** Service/controller layer is legitimate if it contains business logic (validation, authorization, event emission, transaction management, response formatting) beyond forwarding. Check that at least one method adds meaningful logic before flagging.
+
+---
+
+### SS-07: God Object Created by "Organizing" Code
+
+**Severity: critical**
+
+**Detection:** A class or module that accumulates unrelated methods because AI tried to "organize" functions into a class. Look for classes with >10 public methods that touch different domains, or a `utils` class with methods spanning formatting, validation, networking, and file I/O.
+
+**Before (slop):**
+```python
+class AppHelpers:
+    @staticmethod
+    def format_date(dt): ...
+    @staticmethod
+    def validate_email(email): ...
+    @staticmethod
+    def send_http_request(url, data): ...
+    @staticmethod
+    def read_config_file(path): ...
+    @staticmethod
+    def hash_password(password): ...
+    @staticmethod
+    def parse_csv(content): ...
+```
+
+**After (clean):**
+```python
+# date_utils.py
+def format_date(dt): ...
+
+# validation.py
+def validate_email(email): ...
+
+# http.py
+def send_request(url, data): ...
+
+# Or better: just inline these where they're used if they're trivial
+```
+
+**False positive:** Utility classes are legitimate in some frameworks (e.g., Django's `utils` module with a clear theme). Flag only when the methods have no cohesion.
+
+---
+
+### SS-08: Premature Class Where a Function Suffices
+
+**Detection:** A class that is instantiated, has one public method called, and is then discarded. No state is carried between method calls. This is a function disguised as a class.
+
+**Before (slop):**
+```python
+class ReportGenerator:
+    def __init__(self, data: list[dict]):
+        self.data = data
+
+    def generate(self) -> str:
+        lines = [f"{row['name']}: {row['value']}" for row in self.data]
+        return "\n".join(lines)
+
+# Usage
+report = ReportGenerator(data).generate()
+```
+
+**After (clean):**
+```python
+def generate_report(data: list[dict]) -> str:
+    lines = [f"{row['name']}: {row['value']}" for row in data]
+    return "\n".join(lines)
+
+# Usage
+report = generate_report(data)
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+class Validator {
+  constructor(private rules: Rule[]) {}
+  validate(input: string): boolean {
+    return this.rules.every(rule => rule.test(input));
+  }
+}
+// Usage: new Validator(rules).validate(input)
+
+// Clean
+function validate(input: string, rules: Rule[]): boolean {
+  return rules.every(rule => rule.test(input));
+}
+```
+
+**False positive:** Class is legitimate if it carries meaningful state across multiple method calls, if it implements an interface required by a framework, or if it manages resources (connections, file handles) via context manager/disposable patterns.
+
+---
+
+## Category 2: Error Handling Slop (default severity: high)
+
+### EH-01: Catch and Rethrow Without Modification
+
+**Detection:** A try/catch block that catches an exception and immediately re-raises it without adding context, wrapping it in a different type, or performing cleanup.
+
+**Before (slop):**
+```python
+def get_user(user_id):
+    try:
+        return db.query(User).get(user_id)
+    except DatabaseError as e:
+        raise e
+```
+
+**After (clean):**
+```python
+def get_user(user_id):
+    return db.query(User).get(user_id)
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+async function fetchData(url: string) {
+  try {
+    const response = await fetch(url);
+    return await response.json();
+  } catch (error) {
+    throw error;
+  }
+}
+
+// Clean
+async function fetchData(url: string) {
+  const response = await fetch(url);
+  return await response.json();
+}
+```
+
+**False positive:** Catch-and-rethrow is legitimate if: (a) the catch block adds context to the error message (`raise DatabaseError(f"Failed to get user {user_id}") from e`), (b) it wraps the error in a domain-specific type, (c) it performs cleanup before re-raising, or (d) it catches a broad type and re-raises only specific subtypes.
+
+---
+
+### EH-02: Logging at Every Level
+
+**Detection:** The same error is logged at multiple layers as it propagates up the call stack. Look for a pattern where a function logs an error, wraps it, throws it, and the caller also logs it.
+
+**Before (slop):**
+```python
+def fetch_user(user_id):
+    try:
+        return api.get(f"/users/{user_id}")
+    except APIError as e:
+        logger.error(f"API error fetching user: {e}")  # log #1
+        raise
+
+def get_user_profile(user_id):
+    try:
+        user = fetch_user(user_id)
+        return build_profile(user)
+    except APIError as e:
+        logger.error(f"Failed to get user profile: {e}")  # log #2 (same error)
+        raise
+
+def handle_request(request):
+    try:
+        return get_user_profile(request.user_id)
+    except APIError as e:
+        logger.error(f"Request failed: {e}")  # log #3 (same error again)
+        return error_response(500)
+```
+
+**After (clean):**
+```python
+def fetch_user(user_id):
+    return api.get(f"/users/{user_id}")
+
+def get_user_profile(user_id):
+    user = fetch_user(user_id)
+    return build_profile(user)
+
+def handle_request(request):
+    try:
+        return get_user_profile(request.user_id)
+    except APIError as e:
+        logger.error(f"Request failed for user {request.user_id}: {e}")
+        return error_response(500)
+```
+
+**JS/TS example:**
+```typescript
+// Slop — same error logged 3 times
+async function getUser(id: string) {
+  try { return await db.findUser(id); }
+  catch (e) { console.error("DB error:", e); throw e; }  // log 1
+}
+
+async function loadProfile(id: string) {
+  try { return await getUser(id); }
+  catch (e) { console.error("Profile error:", e); throw e; }  // log 2
+}
+
+// Clean — log once at the boundary
+async function getUser(id: string) {
+  return await db.findUser(id);
+}
+
+async function loadProfile(id: string) {
+  return await getUser(id);  // let errors propagate
+}
+```
+
+**False positive:** Multiple log statements are legitimate if each level adds genuinely different context (e.g., one logs the raw DB error, the handler logs the request ID and user context). Check whether the log messages contain different information.
+
+---
+
+### EH-03: Defensive Coding Against Impossible States
+
+**Detection:** Null checks, type checks, or bounds checks that guard against states the type system or control flow already prevents. In TypeScript, look for `if (x !== null)` when `x` is typed as non-nullable. In Python, look for `isinstance` checks on values just returned from a typed function.
+
+**Before (slop):**
+```typescript
+function processUser(user: User): string {
+  if (user === null || user === undefined) {
+    throw new Error("User cannot be null");  // TS already prevents this
+  }
+  if (typeof user.name !== "string") {
+    throw new Error("Name must be a string");  // TS already guarantees this
+  }
+  return user.name.toUpperCase();
+}
+```
+
+**After (clean):**
+```typescript
+function processUser(user: User): string {
+  return user.name.toUpperCase();
+}
+```
+
+**Python example:**
+```python
+# Slop — checking types the function signature guarantees
+def calculate_total(prices: list[float]) -> float:
+    if not isinstance(prices, list):
+        raise TypeError("prices must be a list")
+    if not all(isinstance(p, (int, float)) for p in prices):
+        raise TypeError("all prices must be numbers")
+    return sum(prices)
+
+# Clean
+def calculate_total(prices: list[float]) -> float:
+    return sum(prices)
+```
+
+**False positive:** Defensive checks are legitimate at system boundaries (API endpoints, deserialized data, user input, data from external services) where the type system cannot guarantee the shape. Also legitimate in dynamically-typed Python when the function is part of a public API.
+
+---
+
+### EH-04: Fallback Values Masking Bugs
+
+**Detection:** Default values that silently hide errors instead of surfacing them. Look for `|| defaultValue`, `?? defaultValue`, `.get(key, default)`, or bare `except: pass` where a failure should be visible.
+
+**Before (slop):**
+```typescript
+function getUserAge(user: User): number {
+  return user.profile?.age || 0;  // age 0 is valid, and missing profile is a bug
+}
+
+function loadConfig(path: string): Config {
+  try {
+    return JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch {
+    return {};  // silently returns empty config on parse error, file-not-found, etc.
+  }
+}
+```
+
+**After (clean):**
+```typescript
+function getUserAge(user: User): number {
+  return user.profile.age;  // let it fail visibly if profile is missing
+}
+
+function loadConfig(path: string): Config {
+  return JSON.parse(fs.readFileSync(path, "utf8"));  // caller handles errors
+}
+```
+
+**Python example:**
+```python
+# Slop — empty except swallows everything
+def get_setting(key):
+    try:
+        return settings[key]
+    except Exception:
+        return None  # KeyError, TypeError, and genuine bugs all become None
+
+# Clean
+def get_setting(key):
+    return settings[key]  # KeyError is informative
+```
+
+**False positive:** Fallback values are legitimate for optional features (e.g., `user.nickname or user.name`), graceful degradation in non-critical paths, or when the default is explicitly part of the business logic.
+
+---
+
+### EH-05: Error Handling Deeper Than System Boundaries
+
+**Detection:** try/catch blocks wrapping internal pure business logic that should simply let errors propagate to the nearest system boundary (HTTP handler, CLI entrypoint, queue consumer). Look for try/catch in functions 3+ levels deep in the call stack.
+
+**Before (slop):**
+```python
+def calculate_discount(price, discount_pct):
+    try:
+        return price * (1 - discount_pct / 100)
+    except Exception as e:
+        logger.error(f"Error calculating discount: {e}")
+        raise DiscountCalculationError(f"Failed to calculate discount: {e}") from e
+
+def apply_discount(order):
+    try:
+        order.total = calculate_discount(order.subtotal, order.discount)
+    except DiscountCalculationError as e:
+        logger.error(f"Error applying discount to order {order.id}: {e}")
+        raise OrderProcessingError(f"Discount failed: {e}") from e
+```
+
+**After (clean):**
+```python
+def calculate_discount(price, discount_pct):
+    return price * (1 - discount_pct / 100)
+
+def apply_discount(order):
+    order.total = calculate_discount(order.subtotal, order.discount)
+
+# Error handling happens at the boundary (e.g., HTTP handler)
+```
+
+**JS/TS example:**
+```typescript
+// Slop — try/catch in internal helper
+function parseAmount(raw: string): number {
+  try {
+    const amount = parseFloat(raw);
+    if (isNaN(amount)) throw new Error("Not a number");
+    return amount;
+  } catch (e) {
+    throw new ParseError(`Failed to parse amount: ${e}`);
+  }
+}
+
+// Clean
+function parseAmount(raw: string): number {
+  const amount = parseFloat(raw);
+  if (isNaN(amount)) throw new Error(`Invalid amount: "${raw}"`);
+  return amount;
+}
+```
+
+**False positive:** Deep error handling is legitimate when: (a) recovering from the error is possible at that level (retry, fallback to cache), (b) the function crosses a system boundary (DB call, HTTP call, file I/O), or (c) the error needs domain-specific wrapping to be meaningful to the caller.
+
+---
+
+### EH-06: Excessive Validation of Trusted Internal Data
+
+**Detection:** Re-validating data that was already validated at the API/system boundary. Look for the same validation checks (email format, string length, required fields) appearing in both the controller/handler AND the service/domain layer.
+
+**Before (slop):**
+```python
+# controller.py
+def create_user_endpoint(request):
+    email = request.json["email"]
+    if not email or "@" not in email:
+        return error_response("Invalid email")
+    return UserService().create_user(email)
+
+# service.py
+class UserService:
+    def create_user(self, email: str):
+        if not email or "@" not in email:  # same validation again
+            raise ValueError("Invalid email")
+        return self.repo.save(User(email=email))
+```
+
+**After (clean):**
+```python
+# controller.py — validates at the boundary
+def create_user_endpoint(request):
+    email = request.json.get("email", "")
+    if not email or "@" not in email:
+        return error_response("Invalid email")
+    return UserService().create_user(email)
+
+# service.py — trusts that boundary validation happened
+class UserService:
+    def create_user(self, email: str):
+        return self.repo.save(User(email=email))
+```
+
+**JS/TS example:**
+```typescript
+// Slop — schema validation at handler AND service AND repository
+// Handler: zod.parse(input)
+// Service: if (!input.email) throw ...
+// Repository: if (!data.email) throw ...
+
+// Clean — validate once at the handler with zod, trust downstream
+```
+
+**False positive:** Re-validation is legitimate at domain boundaries in a modular monolith (where the service may be called by other services, not just the HTTP handler), in library code consumed by external callers, or for security-critical checks (authorization) that must not be bypassed.
+
+---
+
+## Category 3: Naming Slop (default severity: medium)
+
+### NS-01: Overly Verbose Names
+
+**Detection:** Identifiers that include words conveying no additional meaning beyond what the type signature or context already provides. Look for names with 4+ words that could be shortened without losing clarity.
+
+**Before (slop):**
+```python
+current_user_authentication_token = get_auth_token(user)
+all_available_product_categories = db.query(Category).all()
+is_user_currently_logged_in = session.get("user_id") is not None
+```
+
+**After (clean):**
+```python
+auth_token = get_auth_token(user)
+categories = db.query(Category).all()
+is_logged_in = session.get("user_id") is not None
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+const retrievedUserDataFromDatabase = await getUserById(id);
+const formattedDateTimeString = date.toISOString();
+const isFormSubmissionCurrentlyInProgress = loading;
+
+// Clean
+const user = await getUserById(id);
+const timestamp = date.toISOString();
+const isSubmitting = loading;
+```
+
+**False positive:** Longer names are legitimate when disambiguation is needed (e.g., `sourceAccountId` vs `targetAccountId` in a transfer function) or in domain-specific code where precision matters.
+
+---
+
+### NS-02: Redundant Type-in-Name
+
+**Detection:** Variable names that encode the type when the type is already evident from the declaration, the collection semantics, or the context. Look for suffixes like `List`, `Array`, `Map`, `Dict`, `String`, `Object`, `Boolean`, `Number`.
+
+**Before (slop):**
+```python
+user_list = get_users()
+name_string = user.name
+config_dict = load_config()
+is_active_boolean = user.active
+error_object = ValueError("bad input")
+```
+
+**After (clean):**
+```python
+users = get_users()
+name = user.name
+config = load_config()
+is_active = user.active
+error = ValueError("bad input")
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+const userArray: User[] = [];
+const nameString: string = getName();
+const settingsMap = new Map<string, Setting>();
+const countNumber = items.length;
+
+// Clean
+const users: User[] = [];
+const name = getName();
+const settings = new Map<string, Setting>();
+const count = items.length;
+```
+
+**False positive:** Type-in-name is legitimate when the same conceptual value exists in multiple representations (e.g., `userIds: number[]` and `userIdSet: Set<number>` in the same scope, or `dateStr` vs `dateObj`).
+
+---
+
+### NS-03: Generic Meaningless Names
+
+**Detection:** Function, file, or module names that use generic verbs (`handle`, `process`, `manage`, `do`, `perform`, `execute`) or nouns (`data`, `info`, `stuff`, `item`, `thing`, `utils`, `helpers`, `misc`) without qualifying what they handle/process/contain.
+
+**Before (slop):**
+```python
+# utils.py — contains date formatting, string parsing, and HTTP helpers
+def process_data(data):
+    # 200 lines of CSV parsing
+    ...
+
+def handle_result(result):
+    # formats result as JSON
+    ...
+
+def do_operation(items):
+    # filters and sorts items
+    ...
+```
+
+**After (clean):**
+```python
+# csv_parser.py
+def parse_csv(raw_content: str) -> list[dict]:
+    ...
+
+# formatting.py
+def to_json_response(result: QueryResult) -> dict:
+    ...
+
+# filtering.py
+def filter_and_sort(items: list[Item], criteria: FilterCriteria) -> list[Item]:
+    ...
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+// helpers.ts — 500 lines of unrelated functions
+export function processData(data: any) { ... }
+export function handleEvent(event: any) { ... }
+export function manageState(state: any) { ... }
+
+// Clean
+// csv-parser.ts
+export function parseCSV(content: string): Row[] { ... }
+// event-bus.ts
+export function emitUserCreated(user: User): void { ... }
+```
+
+**False positive:** Generic names are acceptable for genuinely generic utilities (e.g., `retry(fn)`, `debounce(fn)`, `cache(fn)`) where the function operates on arbitrary inputs by design.
+
+---
+
+### NS-04: Redundant Namespace in Name
+
+**Detection:** Method or property names that repeat the class/module name. Since the class already provides context, the method name should not restate it.
+
+**Before (slop):**
+```python
+class UserService:
+    def get_user_by_id(self, user_id): ...
+    def create_user(self, data): ...
+    def delete_user(self, user_id): ...
+    def update_user_email(self, user_id, email): ...
+
+class EmailValidator:
+    def validate_email(self, email): ...
+    def validate_email_format(self, email): ...
+```
+
+**After (clean):**
+```python
+class UserService:
+    def get_by_id(self, user_id): ...
+    def create(self, data): ...
+    def delete(self, user_id): ...
+    def update_email(self, user_id, email): ...
+
+class EmailValidator:
+    def validate(self, email): ...
+    def check_format(self, email): ...
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+class FileManager {
+  readFile(path: string) { ... }
+  writeFile(path: string, content: string) { ... }
+  deleteFile(path: string) { ... }
+}
+
+// Clean
+class FileManager {
+  read(path: string) { ... }
+  write(path: string, content: string) { ... }
+  delete(path: string) { ... }
+}
+```
+
+**False positive:** Including the noun is legitimate if the class handles multiple entity types (e.g., `OrderService.getUser()` vs `OrderService.getOrder()`), or if the method is commonly called on its own (destructured, passed as callback) where the class context is not visible.
+
+---
+
+## Category 4: Comment Slop (default severity: medium)
+
+### CS-01: Comments Restating the Code
+
+**Detection:** A comment that says the same thing as the code on the next line, using nearly identical words. The comment adds zero information that the code does not already convey.
+
+**Before (slop):**
+```python
+# Increment the counter
+counter += 1
+
+# Return the user
+return user
+
+# Check if the list is empty
+if len(items) == 0:
+    return []
+
+# Set the name to the provided value
+self.name = name
+```
+
+**After (clean):**
+```python
+counter += 1
+return user
+if not items:
+    return []
+self.name = name
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+// Create a new array
+const results: string[] = [];
+
+// Loop through each item
+for (const item of items) {
+  // Push the item to the results
+  results.push(item.name);
+}
+
+// Clean — the code is self-documenting
+const results = items.map(item => item.name);
+```
+
+**False positive:** Comments are legitimate when they explain *why* something is done a particular way (business reason, performance reason, workaround), not *what* is being done. A comment like `# Use >= not > because end date is inclusive` is valuable.
+
+---
+
+### CS-02: Excessive JSDoc/Docstrings on Internal Functions
+
+**Detection:** Full formal documentation (JSDoc `@param`/`@returns`, Python docstrings with `:param:` blocks) on private/internal helper functions with obvious signatures, where the function name and type annotations already communicate everything.
+
+**Before (slop):**
+```python
+def _add_numbers(a: float, b: float) -> float:
+    """Add two numbers together.
+
+    Args:
+        a: The first number to add.
+        b: The second number to add.
+
+    Returns:
+        The sum of a and b.
+    """
+    return a + b
+```
+
+**After (clean):**
+```python
+def _add_numbers(a: float, b: float) -> float:
+    return a + b
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+/**
+ * Checks if a user is an admin.
+ * @param user - The user to check
+ * @returns True if the user is an admin, false otherwise
+ */
+private isAdmin(user: User): boolean {
+  return user.role === "admin";
+}
+
+// Clean
+private isAdmin(user: User): boolean {
+  return user.role === "admin";
+}
+```
+
+**False positive:** Full documentation is legitimate on public API surfaces, library exports, or functions with non-obvious behavior (e.g., side effects, specific error conditions, performance characteristics). Also legitimate if the project has a policy requiring docstrings on all public methods.
+
+---
+
+### CS-03: AI-Generated TODO Comments
+
+**Detection:** Generic TODO comments that lack context, owner, or ticket reference. They typically use vague language like "add error handling", "implement caching", "add tests", "improve performance" without specifying what, where, or why.
+
+**Before (slop):**
+```python
+# TODO: add error handling
+# TODO: implement caching
+# TODO: add tests
+# TODO: improve performance
+# TODO: refactor this
+# TODO: handle edge cases
+```
+
+**After (clean):**
+```python
+# Either remove the TODO (it will never be done) or make it actionable:
+# TODO(PROJ-1234): cache user lookups — profile page loads 3s without cache
+# Or better: create an actual issue/ticket and remove the comment
+```
+
+**JS/TS example:**
+```typescript
+// Slop — generic, will never be addressed
+// TODO: add validation
+// TODO: handle errors
+// TODO: optimize this
+
+// Clean — actionable with context
+// TODO(#142): validate against schema v2 — currently accepts deprecated fields
+```
+
+**False positive:** TODOs are legitimate if they reference a specific ticket/issue, describe a concrete scenario, or are part of an active work-in-progress (recently added, not stale).
+
+---
+
+### CS-04: Section Divider Comments
+
+**Detection:** Comments whose sole purpose is to visually divide code into sections using lines of `=`, `-`, `*`, `#`, or similar characters. These add visual noise and are a sign the file should be split into separate modules.
+
+**Before (slop):**
+```python
+# ============================================
+# USER MANAGEMENT
+# ============================================
+
+def get_user(): ...
+def create_user(): ...
+
+# ============================================
+# ORDER PROCESSING
+# ============================================
+
+def get_order(): ...
+def process_order(): ...
+
+# ============================================
+# UTILITIES
+# ============================================
+
+def format_date(): ...
+```
+
+**After (clean):**
+```python
+# user_management.py
+def get_user(): ...
+def create_user(): ...
+
+# order_processing.py
+def get_order(): ...
+def process_order(): ...
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+// ---------- Constants ----------
+const MAX_ITEMS = 100;
+
+// ---------- Types ----------
+interface Item { ... }
+
+// ---------- Helpers ----------
+function formatItem(item: Item) { ... }
+
+// Clean: if the file needs sections, it should be multiple files
+```
+
+**False positive:** Section comments are acceptable in very long configuration files, test files with logical groupings (describe blocks serve this purpose in JS), or files that genuinely cannot be split (e.g., a single React component with hooks, handlers, and render logic).
+
+---
+
+### CS-05: Commented-Out Code
+
+**Detection:** Blocks of code that have been commented out rather than deleted. Look for multiple consecutive commented lines that contain valid syntax (function calls, variable assignments, control flow).
+
+**Before (slop):**
+```python
+def process_order(order):
+    # old_total = calculate_legacy_total(order)
+    # if old_total != order.total:
+    #     logger.warning(f"Total mismatch: {old_total} vs {order.total}")
+    #     order.total = old_total
+    new_total = calculate_total(order)
+    order.total = new_total
+```
+
+**After (clean):**
+```python
+def process_order(order):
+    order.total = calculate_total(order)
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+function handleLogin(credentials: Credentials) {
+  // const token = await legacyAuth(credentials);
+  // if (!token) {
+  //   return redirect('/legacy-login');
+  // }
+  return newAuth(credentials);
+}
+
+// Clean — version control has the history
+function handleLogin(credentials: Credentials) {
+  return newAuth(credentials);
+}
+```
+
+**False positive:** Commented code is (reluctantly) acceptable if it includes a comment explaining *why* it is kept (e.g., `# Disabled until upstream fixes bug #XYZ — re-enable after v2.3 release`). Even then, prefer a feature flag or a link to the issue.
+
+---
+
+## Category 5: Testing Slop (default severity: medium)
+
+### TS-01: Tests That Test the Mock
+
+**Detection:** A test that sets up a mock to return a specific value, calls the function under test, and then asserts the result equals the mocked value. The test verifies the mock framework works, not the code.
+
+**Before (slop):**
+```python
+def test_get_user():
+    mock_repo = Mock()
+    mock_repo.get_user.return_value = User(id=1, name="Alice")
+    service = UserService(mock_repo)
+
+    result = service.get_user(1)
+
+    assert result.name == "Alice"  # you're testing that Mock returns what you told it to
+```
+
+**After (clean):**
+```python
+def test_get_user_calls_repo_with_correct_id():
+    mock_repo = Mock()
+    mock_repo.get_user.return_value = User(id=1, name="Alice")
+    service = UserService(mock_repo)
+
+    service.get_user(1)
+
+    mock_repo.get_user.assert_called_once_with(1)  # tests actual behavior
+
+# Or better: integration test with real DB
+def test_get_user_returns_saved_user(db_session):
+    user = User(name="Alice")
+    db_session.add(user)
+    db_session.commit()
+
+    result = UserService(UserRepository(db_session)).get_user(user.id)
+    assert result.name == "Alice"
+```
+
+**JS/TS example:**
+```typescript
+// Slop — testing the mock
+test("getUser returns user", async () => {
+  jest.spyOn(db, "findUser").mockResolvedValue({ id: 1, name: "Alice" });
+  const user = await getUser(1);
+  expect(user.name).toBe("Alice"); // just tests jest.spyOn works
+});
+
+// Clean — test the behavior
+test("getUser queries by ID", async () => {
+  const spy = jest.spyOn(db, "findUser").mockResolvedValue({ id: 1, name: "Alice" });
+  await getUser(1);
+  expect(spy).toHaveBeenCalledWith(1);
+});
+```
+
+**False positive:** Asserting the mock's return value is legitimate if the function under test *transforms* the data (e.g., `service.get_user(1)` maps a DB row to a domain object, and you're testing the mapping logic).
+
+---
+
+### TS-02: Excessive Mocking of Internal Modules
+
+**Detection:** A test that mocks every dependency of the function under test, leaving nothing real to test. If you mock the database, the HTTP client, the logger, and the cache, the only thing left is glue code -- and glue code does not need unit tests.
+
+**Before (slop):**
+```python
+def test_process_order():
+    mock_db = Mock()
+    mock_cache = Mock()
+    mock_logger = Mock()
+    mock_email = Mock()
+    mock_metrics = Mock()
+
+    service = OrderService(mock_db, mock_cache, mock_logger, mock_email, mock_metrics)
+    service.process_order(order_data)
+
+    mock_db.save.assert_called_once()
+    mock_email.send.assert_called_once()
+    mock_metrics.increment.assert_called_once()
+```
+
+**After (clean):**
+```python
+# Integration test with real dependencies (except external services)
+def test_process_order(db_session, email_stub):
+    service = OrderService(db_session, email_stub)
+    service.process_order(order_data)
+
+    assert db_session.query(Order).count() == 1
+    assert email_stub.sent[-1].to == order_data["email"]
+```
+
+**JS/TS example:**
+```typescript
+// Slop — everything is mocked, nothing is tested
+test("createUser", () => {
+  const mockDb = { save: jest.fn() };
+  const mockValidator = { validate: jest.fn().mockReturnValue(true) };
+  const mockHasher = { hash: jest.fn().mockReturnValue("hashed") };
+  const mockLogger = { info: jest.fn() };
+
+  createUser({ db: mockDb, validator: mockValidator, hasher: mockHasher, logger: mockLogger }, userData);
+
+  expect(mockDb.save).toHaveBeenCalled();
+});
+
+// Clean — test with real implementations, mock only external I/O
+```
+
+**False positive:** Mocking is legitimate for: (a) external HTTP APIs, (b) services with side effects you cannot undo (sending emails, charging credit cards), (c) slow dependencies in a fast unit test suite. The key question: does the test verify meaningful behavior, or just call ordering?
+
+---
+
+### TS-03: Tests Mirroring Implementation
+
+**Detection:** Test code that mirrors the implementation structure 1:1 -- each implementation step has a corresponding assertion, and changing the implementation (without changing behavior) breaks the test. Look for tests that assert on call order, intermediate variables, or internal method calls.
+
+**Before (slop):**
+```python
+def test_calculate_total():
+    order = Order(items=[Item(price=10), Item(price=20)])
+
+    # Mirrors implementation step by step
+    subtotal = sum(item.price for item in order.items)
+    assert subtotal == 30
+    tax = subtotal * 0.1
+    assert tax == 3.0
+    total = subtotal + tax
+    assert total == 33.0
+
+    assert order.calculate_total() == 33.0
+```
+
+**After (clean):**
+```python
+def test_calculate_total():
+    order = Order(items=[Item(price=10), Item(price=20)])
+    assert order.calculate_total() == 33.0  # test behavior, not implementation
+
+def test_calculate_total_with_no_items():
+    order = Order(items=[])
+    assert order.calculate_total() == 0.0
+```
+
+**JS/TS example:**
+```typescript
+// Slop — tests implementation details
+test("processPayment", () => {
+  const spy = jest.spyOn(service, "validateCard");
+  const chargeSpy = jest.spyOn(service, "chargeCard");
+  const receiptSpy = jest.spyOn(service, "generateReceipt");
+
+  service.processPayment(payment);
+
+  expect(spy).toHaveBeenCalledBefore(chargeSpy);
+  expect(chargeSpy).toHaveBeenCalledBefore(receiptSpy);
+});
+
+// Clean — test the outcome
+test("processPayment returns receipt for valid card", () => {
+  const receipt = service.processPayment(validPayment);
+  expect(receipt.amount).toBe(validPayment.amount);
+  expect(receipt.status).toBe("completed");
+});
+```
+
+**False positive:** Testing call order is legitimate when order matters for correctness (e.g., "must validate before charging", "must acquire lock before writing"). The test should explain *why* the order matters.
+
+---
+
+### TS-04: Snapshot Tests for Everything
+
+**Detection:** Snapshot tests used for data structures, API responses, computed values, or configuration objects instead of being limited to UI rendering output. Snapshot tests are hard to review, easy to update blindly, and provide weak guarantees.
+
+**Before (slop):**
+```typescript
+test("getUser returns correct data", () => {
+  const user = getUser(1);
+  expect(user).toMatchSnapshot(); // what does the snapshot contain? who knows
+});
+
+test("calculateTotals", () => {
+  const result = calculateTotals(orders);
+  expect(result).toMatchSnapshot();
+});
+
+test("API response format", () => {
+  const response = buildResponse(data);
+  expect(response).toMatchSnapshot();
+});
+```
+
+**After (clean):**
+```typescript
+test("getUser returns user with email", () => {
+  const user = getUser(1);
+  expect(user.email).toBe("alice@example.com");
+  expect(user.role).toBe("admin");
+});
+
+test("calculateTotals sums all order amounts", () => {
+  const result = calculateTotals([
+    { amount: 10 }, { amount: 20 },
+  ]);
+  expect(result.total).toBe(30);
+  expect(result.count).toBe(2);
+});
+```
+
+**Python equivalent (slop):**
+```python
+# Using pytest-snapshot or similar
+def test_api_response(snapshot):
+    response = build_response(data)
+    assert response == snapshot  # opaque, hard to review
+
+# Clean — explicit assertions
+def test_api_response():
+    response = build_response(data)
+    assert response["status"] == 200
+    assert "users" in response["data"]
+```
+
+**False positive:** Snapshot tests are legitimate for: (a) UI component rendering (React components, HTML templates), (b) large generated outputs where manual assertion is impractical (compiler output, code generation), or (c) regression guards during refactoring when you explicitly plan to review and remove them.
+
+---
+
+### TS-05: Tests Without Meaningful Assertions
+
+**Detection:** Tests that call a function and only assert that it did not throw an exception, returned a truthy value, or was called -- without checking the actual result or side effects.
+
+**Before (slop):**
+```python
+def test_process_order():
+    result = process_order(sample_order)
+    assert result is not None  # what IS the result? is it correct?
+
+def test_send_email():
+    # no assertion at all — just "it didn't crash"
+    send_email("user@example.com", "Hello")
+
+def test_validate():
+    result = validate(data)
+    assert result  # True? A string? An object? Who knows
+```
+
+**After (clean):**
+```python
+def test_process_order_creates_invoice():
+    result = process_order(sample_order)
+    assert result.invoice_id is not None
+    assert result.total == expected_total
+    assert result.status == "confirmed"
+
+def test_send_email_delivers_to_recipient(email_stub):
+    send_email("user@example.com", "Hello")
+    assert len(email_stub.sent) == 1
+    assert email_stub.sent[0].to == "user@example.com"
+    assert email_stub.sent[0].subject == "Hello"
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+test("createUser works", async () => {
+  const result = await createUser(userData);
+  expect(result).toBeTruthy(); // what does "truthy" mean here?
+});
+
+test("deleteUser", async () => {
+  await expect(deleteUser(1)).resolves.not.toThrow(); // only tests no crash
+});
+
+// Clean
+test("createUser returns user with generated ID", async () => {
+  const user = await createUser({ name: "Alice", email: "a@b.com" });
+  expect(user.id).toBeDefined();
+  expect(user.name).toBe("Alice");
+  expect(user.email).toBe("a@b.com");
+});
+```
+
+**False positive:** "Does not throw" is a legitimate assertion for: (a) smoke tests that verify a system starts up, (b) tests verifying that a specific previously-crashing input no longer crashes, (c) property-based tests where the assertion is "holds for all inputs."
+
+---
+
+## Category 6: Import/Dependency Slop (default severity: low)
+
+### ID-01: Unused Imports
+
+**Detection:** Import statements for modules, classes, or functions that are never referenced in the file. Linters catch most of these, but AI-generated code frequently adds imports "just in case."
+
+**Before (slop):**
+```python
+import os
+import sys
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Optional, List, Dict, Any, Union, Tuple
+
+def greet(name: str) -> str:
+    return f"Hello, {name}"  # uses none of the imports
+```
+
+**After (clean):**
+```python
+def greet(name: str) -> str:
+    return f"Hello, {name}"
+```
+
+**JS/TS example:**
+```typescript
+// Slop
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useRouter } from 'next/router';
+import axios from 'axios';
+
+export function Greeting({ name }: { name: string }) {
+  return <h1>Hello, {name}</h1>;  // only uses React
+}
+
+// Clean
+import React from 'react';
+
+export function Greeting({ name }: { name: string }) {
+  return <h1>Hello, {name}</h1>;
+}
+```
+
+**False positive:** Imports may appear unused but are needed for: (a) type-only imports in TypeScript (`import type`), (b) side effects (`import './polyfill'`), (c) re-exports, or (d) runtime reflection / dependency injection frameworks. Check before removing.
+
+---
+
+### ID-02: Whole-Library Imports for One Function
+
+**Detection:** Importing an entire library or a large module when only one function or class is used. This increases bundle size (JS) or startup time and obscures actual dependencies.
+
+**Before (slop):**
+```python
+import pandas as pd
+
+def get_average(numbers: list[float]) -> float:
+    return pd.Series(numbers).mean()  # pandas for a mean?
+```
+
+**After (clean):**
+```python
+def get_average(numbers: list[float]) -> float:
+    return sum(numbers) / len(numbers)
+```
+
+**JS/TS example:**
+```typescript
+// Slop — lodash for one function
+import _ from 'lodash';
+
+const unique = _.uniq(items);
+
+// Clean — use native or import just the function
+const unique = [...new Set(items)];
+// or
+import uniq from 'lodash/uniq';
+```
+
+**False positive:** Whole-library imports are acceptable when: (a) tree-shaking handles it (modern JS bundlers), (b) you use many functions from the library throughout the file, or (c) the library is designed for namespace imports (e.g., `import numpy as np` is idiomatic Python).
+
+---
+
+### ID-03: Circular Import Workarounds
+
+**Detection:** Imports placed inside function bodies, `TYPE_CHECKING` guards used extensively, or delayed imports specifically to avoid circular dependencies. These indicate an architectural problem that should be solved by restructuring modules.
+
+**Before (slop):**
+```python
+# models/user.py
+class User:
+    def get_orders(self):
+        from models.order import Order  # circular import workaround
+        return Order.query.filter_by(user_id=self.id).all()
+
+# models/order.py
+class Order:
+    def get_user(self):
+        from models.user import User  # circular import workaround
+        return User.query.get(self.user_id)
+```
+
+**After (clean):**
+```python
+# models/user.py
+class User:
+    pass  # no cross-model methods
+
+# models/order.py
+class Order:
+    pass
+
+# services/queries.py — breaks the cycle
+from models.user import User
+from models.order import Order
+
+def get_user_orders(user: User) -> list[Order]:
+    return Order.query.filter_by(user_id=user.id).all()
+
+def get_order_user(order: Order) -> User:
+    return User.query.get(order.user_id)
+```
+
+**JS/TS example:**
+```typescript
+// Slop — lazy require to avoid circular dependency
+// user.ts
+export class User {
+  getOrders() {
+    const { Order } = require('./order'); // circular workaround
+    return Order.find({ userId: this.id });
+  }
+}
+
+// Clean — restructure so the dependency flows one direction
+```
+
+**False positive:** `TYPE_CHECKING` guards are legitimate and idiomatic in Python for type annotations that would cause circular imports at runtime. Lazy imports are also acceptable for optional heavy dependencies (`try: import pandas except ImportError`).
+
+---
+
+### ID-04: Re-Export-Everything Index Files
+
+**Detection:** An `index.ts`, `__init__.py`, or barrel file that re-exports every symbol from every submodule, creating a "mega-module" that defeats code splitting and makes dependency tracking impossible.
+
+**Before (slop):**
+```typescript
+// utils/index.ts
+export * from './string-utils';
+export * from './date-utils';
+export * from './http-utils';
+export * from './validation-utils';
+export * from './formatting-utils';
+export * from './crypto-utils';
+export * from './file-utils';
+```
+
+**After (clean):**
+```typescript
+// Import directly from the specific module
+import { formatDate } from './utils/date-utils';
+import { validateEmail } from './utils/validation-utils';
+
+// If an index file is needed, export only the public API
+// utils/index.ts
+export { formatDate, parseDate } from './date-utils';
+export { validateEmail } from './validation-utils';
+```
+
+**Python example:**
+```python
+# Slop — __init__.py that imports everything
+# utils/__init__.py
+from .strings import *
+from .dates import *
+from .http import *
+from .validation import *
+
+# Clean — import from specific modules
+from utils.dates import format_date
+from utils.validation import validate_email
+```
+
+**False positive:** Barrel files are legitimate for: (a) library public APIs where consumers expect a single import path, (b) small, cohesive modules (3-4 submodules with related functionality), or (c) when the project's build system handles tree-shaking effectively.
+
+---
+
+## Category 7: Type/Annotation Slop (default severity: low)
+
+### TA-01: `any` Type Everywhere
+
+**Detection:** Excessive use of `any` (TypeScript), `Any` (Python typing), or `object` as a catch-all type that defeats the purpose of static typing. Look for functions where inputs and outputs are all `any`.
+
+**Before (slop):**
+```typescript
+function processData(data: any): any {
+  const result: any = {};
+  for (const key of Object.keys(data)) {
+    result[key] = transform(data[key] as any);
+  }
+  return result;
+}
+
+function handleResponse(response: any): any {
+  return response.data;
+}
+```
+
+**After (clean):**
+```typescript
+interface UserData {
+  name: string;
+  email: string;
+  age: number;
+}
+
+interface TransformedData {
+  name: string;
+  email: string;
+  age: string;  // transformed to string
+}
+
+function processData(data: UserData): TransformedData {
+  return {
+    name: data.name,
+    email: data.email,
+    age: String(data.age),
+  };
+}
+```
+
+**Python example:**
+```python
+# Slop
+from typing import Any
+
+def transform(data: Any) -> Any:
+    return {k: str(v) for k, v in data.items()}
+
+# Clean
+def transform(data: dict[str, int]) -> dict[str, str]:
+    return {k: str(v) for k, v in data.items()}
+```
+
+**False positive:** `any` is legitimate for: (a) truly generic utility functions (`function deepClone<T>(obj: T): T`), (b) interfacing with untyped third-party libraries, (c) migration from JavaScript where typing is being added incrementally, or (d) serialization/deserialization boundaries where the type is validated at runtime.
+
+---
+
+### TA-02: Overly Complex Generic Types
+
+**Detection:** Generic type parameters with multiple constraints, conditional types, mapped types, or template literal types that make the code harder to understand than `any` would. If a type definition requires more than 30 seconds to parse mentally, it is too complex.
+
+**Before (slop):**
+```typescript
+type DeepPartial<T> = T extends object
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : T;
+
+type ExtractPromise<T> = T extends Promise<infer U>
+  ? U extends Promise<infer V>
+    ? V
+    : U
+  : T;
+
+type MergedConfig<
+  T extends Record<string, unknown>,
+  U extends Partial<T> & Record<string, unknown>
+> = Omit<T, keyof U> & U;
+
+function updateConfig<
+  T extends Record<string, unknown>,
+  U extends Partial<T> & Record<string, unknown>
+>(base: T, overrides: U): MergedConfig<T, U> {
+  return { ...base, ...overrides } as MergedConfig<T, U>;
+}
+```
+
+**After (clean):**
+```typescript
+interface AppConfig {
+  host: string;
+  port: number;
+  debug: boolean;
+}
+
+function updateConfig(base: AppConfig, overrides: Partial<AppConfig>): AppConfig {
+  return { ...base, ...overrides };
+}
+```
+
+**Python example:**
+```python
+# Slop — overengineered generic
+from typing import TypeVar, Generic, Protocol, Callable
+
+T = TypeVar("T")
+U = TypeVar("U")
+R = TypeVar("R", bound="Comparable")
+
+class Comparable(Protocol):
+    def __lt__(self, other: "Comparable") -> bool: ...
+
+class SortedContainer(Generic[R]):
+    def __init__(self, key: Callable[[R], Comparable]) -> None: ...
+
+# Clean — just use a concrete type or simpler generic
+class SortedContainer:
+    def __init__(self, items: list, key=None):
+        self.items = sorted(items, key=key)
+```
+
+**False positive:** Complex generics are legitimate in: (a) library code that must be generic by nature (ORM query builders, serialization frameworks), (b) well-documented utility types that are used widely across the codebase, or (c) types that replace much larger amounts of repetitive concrete type definitions.
+
+---
+
+### TA-03: Redundant Type Annotations
+
+**Detection:** Type annotations on variables where the type is obvious from the assignment (TypeScript/Python type inference handles these). Look for annotations on literals, constructor calls, and function return values that match the return type.
+
+**Before (slop):**
+```typescript
+const name: string = "Alice";
+const count: number = 0;
+const active: boolean = true;
+const users: User[] = [];
+const cache: Map<string, User> = new Map<string, User>();
+const result: User = new User();
+```
+
+**After (clean):**
+```typescript
+const name = "Alice";
+const count = 0;
+const active = true;
+const users: User[] = [];  // keep: empty array type isn't inferrable
+const cache = new Map<string, User>();
+const result = new User();
+```
+
+**Python example:**
+```python
+# Slop
+name: str = "Alice"
+count: int = 0
+items: list[str] = ["a", "b", "c"]
+mapping: dict[str, int] = {"a": 1}
+
+# Clean
+name = "Alice"
+count = 0
+items = ["a", "b", "c"]
+mapping = {"a": 1}
+
+# Keep annotations when not inferrable:
+items: list[str] = []  # empty collection needs annotation
+result: User | None = None  # union types need annotation
+```
+
+**False positive:** Explicit annotations are legitimate when: (a) the inferred type is too broad (e.g., `{}` infers as `object` not `Record<string, string>`), (b) the type serves as documentation for a complex expression, (c) the codebase style guide requires explicit annotations, or (d) the assignment is to an empty collection where the type cannot be inferred.
+
+---
+
+### TA-04: Type Assertion (`as`) Abuse
+
+**Detection:** Frequent use of `as` (TypeScript) or `cast()` (Python) to force types instead of properly typing the code. `as` is a red flag that the type system is being overridden rather than worked with.
+
+**Before (slop):**
+```typescript
+const data = JSON.parse(response) as UserData;
+const element = document.getElementById("app") as HTMLDivElement;
+const config = loadConfig() as AppConfig;
+const user = getFromCache(key) as User;
+
+function processItems(items: unknown[]) {
+  const users = items as User[];  // unsafe cast
+  users.forEach(u => console.log(u.name));
+}
+```
+
+**After (clean):**
+```typescript
+// Use type guards or validation instead of assertions
+function isUserData(data: unknown): data is UserData {
+  return typeof data === "object" && data !== null && "name" in data && "email" in data;
+}
+
+const data = JSON.parse(response);
+if (!isUserData(data)) throw new Error("Invalid user data");
+// data is now typed as UserData
+
+const element = document.getElementById("app");
+if (!(element instanceof HTMLDivElement)) throw new Error("Missing #app div");
+
+// Use zod/io-ts for runtime validation
+const config = AppConfigSchema.parse(loadConfig());
+```
+
+**Python example:**
+```python
+# Slop
+from typing import cast
+
+user = cast(User, get_from_cache(key))
+config = cast(AppConfig, load_config())
+
+# Clean — validate at the boundary
+def get_user_from_cache(key: str) -> User:
+    data = cache.get(key)
+    if not isinstance(data, User):
+        raise TypeError(f"Expected User, got {type(data)}")
+    return data
+```
+
+**False positive:** `as` is acceptable for: (a) `as const` assertions (TypeScript), (b) narrowing from a known-safe broader type (e.g., `event.target as HTMLInputElement` in an input event handler), or (c) test code where exact typing is less critical.
+
+---
+
+## Scoring Rubric
+
+### Per-File Slop Score
+
+| Findings | Rating | Action |
+|----------|--------|--------|
+| 0 | Clean | No action needed |
+| 1-2 | Minor | Fix in passing during other work |
+| 3-5 | Moderate | Dedicated cleanup needed |
+| 6-10 | Heavy | Significant AI generation likely |
+| 10+ | Severe | Major rewrite may be warranted |
+
+### Per-Codebase Slop Score
+
+| Files with Findings | Rating |
+|---------------------|--------|
+| <5% | Low slop |
+| 5-15% | Moderate slop |
+| 15-30% | High slop |
+| >30% | Pervasive slop |
+
+### Priority for Fixing
+
+1. **Critical + high severity** findings in core modules (most-imported, most-modified files)
+2. **High severity** findings anywhere
+3. **Medium severity** in frequently-modified files (check `git log --format='' --name-only | sort | uniq -c | sort -rn | head -20`)
+4. **Everything else** -- batch into a cleanup PR
+
+### Weighted Severity Scores
+
+When calculating a file's slop score, weight each finding:
+
+| Severity | Weight |
+|----------|--------|
+| Critical | 4 |
+| High | 2 |
+| Medium | 1 |
+| Low | 0.5 |
+
+A file with 1 critical + 2 medium findings has a weighted score of 4 + 1 + 1 = 6 (Heavy).
+
+---
+
+## Quick Reference: Pattern ID Index
+
+| ID | Name | Default Severity |
+|----|------|-----------------|
+| SS-01 | Unnecessary Wrapper Function | high |
+| SS-02 | Over-Abstraction (Single Implementation Interface) | high |
+| SS-03 | Premature Generalization (Single-Variant Pattern) | high |
+| SS-04 | Single-Use Helper Function | high |
+| SS-05 | Configuration Over Hardcoding | high |
+| SS-06 | Unnecessary Indirection Layer | high |
+| SS-07 | God Object | critical |
+| SS-08 | Premature Class | high |
+| EH-01 | Catch and Rethrow Without Modification | high |
+| EH-02 | Logging at Every Level | high |
+| EH-03 | Defensive Coding Against Impossible States | high |
+| EH-04 | Fallback Values Masking Bugs | high |
+| EH-05 | Error Handling Deeper Than Boundaries | high |
+| EH-06 | Excessive Validation of Trusted Data | high |
+| NS-01 | Overly Verbose Names | medium |
+| NS-02 | Redundant Type-in-Name | medium |
+| NS-03 | Generic Meaningless Names | medium |
+| NS-04 | Redundant Namespace in Name | medium |
+| CS-01 | Comments Restating the Code | medium |
+| CS-02 | Excessive Docstrings on Internal Functions | medium |
+| CS-03 | AI-Generated TODO Comments | medium |
+| CS-04 | Section Divider Comments | medium |
+| CS-05 | Commented-Out Code | medium |
+| TS-01 | Tests That Test the Mock | medium |
+| TS-02 | Excessive Mocking | medium |
+| TS-03 | Tests Mirroring Implementation | medium |
+| TS-04 | Snapshot Tests for Everything | medium |
+| TS-05 | Tests Without Meaningful Assertions | medium |
+| ID-01 | Unused Imports | low |
+| ID-02 | Whole-Library Imports for One Function | low |
+| ID-03 | Circular Import Workarounds | low |
+| ID-04 | Re-Export-Everything Index Files | low |
+| TA-01 | `any` Type Everywhere | low |
+| TA-02 | Overly Complex Generic Types | low |
+| TA-03 | Redundant Type Annotations | low |
+| TA-04 | Type Assertion Abuse | low |

--- a/global-skills/skills/unfuck/references/discovery-agents.md
+++ b/global-skills/skills/unfuck/references/discovery-agents.md
@@ -1,0 +1,1512 @@
+# Discovery Agent Prompts
+
+Seven self-contained prompt templates for Phase 1 discovery agents. Each is spawned as a TeamCreate teammate (see `orchestration-playbook.md` Phase 1). The orchestrator prepends `{context_bundle}` containing: project path, detected languages, available external tools, tool-selection-guard warning, PROJECT_INDEX.md content, and (for Agent 5) the AI slop checklist.
+
+All agents share the same output JSON schema (see [Shared Output Schema](#shared-output-schema) at the bottom).
+
+---
+
+## Agent 1: Dead Code Hunter
+
+````markdown
+# Dead Code Hunter — Discovery Agent
+
+{context_bundle}
+
+## Your Role
+
+You are a dead code detection specialist. Find ALL unused, unreachable, and unnecessary code in this codebase. Combine automated tooling with manual LSP-based analysis for comprehensive coverage.
+
+You have access to: Read, Write, Edit, Glob, Grep, Bash, LSP, Task, AskUserQuestion.
+
+## Analysis Methodology
+
+### Step 1: Run External Tools (if available)
+
+Check `available_tools` from the context bundle. Run whichever are installed:
+
+**JavaScript/TypeScript:**
+```bash
+npx knip --reporter json 2>/dev/null
+```
+Parse output for unused files, exports, and dependencies. Knip is the most comprehensive JS/TS dead code detector — trust its results and cross-reference with manual analysis.
+
+**Python:**
+```bash
+uvx vulture . --min-confidence 80 2>/dev/null
+```
+```bash
+uvx deadcode . 2>/dev/null
+```
+Parse output for unused functions, variables, imports. Vulture has false positives with dynamic usage — verify each finding.
+
+**Go:**
+```bash
+go vet ./... 2>&1
+```
+Check for unused variables and imports. Go's compiler already catches most dead code, so focus on exported symbols.
+
+If a tool is unavailable (non-zero exit or command not found), skip it silently and proceed to manual analysis.
+
+### Step 2: LSP-Based Reference Analysis
+
+This is your primary analysis method. Follow the `lsp-navigation` skill patterns:
+
+1. **Discover source files:**
+   ```
+   Glob("**/*.{ts,tsx,js,jsx,py,go,rs}", excluding node_modules, .git, vendor, __pycache__, dist, build, .venv)
+   ```
+
+2. **For each source file**, use LSP to enumerate symbols:
+   ```
+   LSP(operation="documentSymbol", filePath="{file}", line=1, character=1)
+   ```
+
+3. **For each exported/public symbol**, check reference count:
+   ```
+   LSP(operation="findReferences", filePath="{file}", line={symbol_line}, character={symbol_char})
+   ```
+
+4. **Flag symbols with 0 external references** (only self-reference or definition-only).
+
+5. **Verify before flagging** — a symbol is NOT dead if it is:
+   - An entry point: `main()`, `__main__`, CLI handler, `app.listen`, `export default`
+   - A framework hook: `setUp`/`tearDown`, lifecycle methods, decorators like `@app.route`
+   - A test fixture or conftest function
+   - Referenced dynamically: `getattr()`, `importlib.import_module()`, bracket notation `obj[key]`
+   - An API route handler registered via framework (Express, FastAPI, Flask, etc.)
+   - A public API export (check if the package is consumed externally)
+
+**Prioritization for large codebases (>500 files):** Process files by import depth — start with leaf modules (fewest importers) since dead code accumulates at the edges.
+
+### Step 3: Orphan File Detection
+
+1. Build an import graph: for each source file, extract all `import`/`require`/`from X import` statements.
+2. Track which files are imported by at least one other file.
+3. Identify files with zero importers.
+4. Cross-reference with entry points — these are NOT orphans:
+   - Files matching `main.*`, `index.*`, `app.*`, `server.*`, `cli.*`
+   - Files in test directories
+   - Configuration files (`*.config.*`, `setup.py`, `pyproject.toml`)
+   - Script files referenced in `package.json` scripts or `Makefile`
+   - Files in `bin/`, `scripts/`, `migrations/` directories
+5. Flag remaining zero-importer files as orphan candidates.
+
+### Step 4: Unused Dependency Detection
+
+1. **Read dependency manifests:**
+   - `package.json` (dependencies + devDependencies) for JS/TS
+   - `pyproject.toml` or `requirements*.txt` for Python
+   - `go.mod` for Go
+   - `Cargo.toml` for Rust
+
+2. **For each declared dependency**, search the codebase for actual usage:
+   ```
+   Grep(pattern="require\\(['\"]dependency-name", ...)
+   Grep(pattern="from ['\"]dependency-name", ...)
+   Grep(pattern="import ['\"]dependency-name", ...)
+   Grep(pattern="import dependency_name", ...)
+   ```
+
+3. **Watch for indirect usage** — a dependency is NOT unused if:
+   - It is a build tool (`webpack`, `vite`, `esbuild`, `ruff`, `pytest`)
+   - It is a type definition package (`@types/*`)
+   - It is a plugin loaded by configuration (`babel-plugin-*`, `eslint-plugin-*`)
+   - It is a peer dependency required by another dependency
+   - It is referenced only in config files (`.eslintrc`, `jest.config`, etc.)
+
+4. Flag dependencies with zero actual imports as unused.
+
+### Step 5: Dead Feature Detection
+
+1. **Feature flags and environment gates:**
+   ```
+   Grep(pattern="process\\.env\\.", ...)
+   Grep(pattern="os\\.environ", ...)
+   Grep(pattern="feature_flag|FEATURE_", ...)
+   Grep(pattern="if.*enabled|if.*disabled", ...)
+   ```
+   Check if gated code paths reference functions/modules that still exist.
+
+2. **Commented-out code blocks:**
+   ```
+   Grep(pattern="^\\s*//.*function |^\\s*//.*class |^\\s*#.*def ", ...)
+   ```
+   Look for 3+ consecutive commented lines that contain code (not documentation comments). Distinguish between intentionally commented documentation and dead commented code.
+
+3. **TODO/FIXME referencing removed features:**
+   ```
+   Grep(pattern="TODO|FIXME|HACK|XXX", ...)
+   ```
+   Check if the referenced code/feature still exists.
+
+### Step 6: Test Dead Code
+
+1. **Tests referencing nonexistent code:**
+   - Extract function/class names from test imports
+   - Verify each imported symbol still exists using LSP `goToDefinition`
+   - Flag tests that import symbols that no longer exist
+
+2. **Unused test utilities:**
+   - Find files in `tests/`, `test/`, `__tests__/` directories matching `*helper*`, `*fixture*`, `*util*`, `*factory*`, `conftest*`
+   - Use LSP `findReferences` to check if test utilities are actually used
+
+3. **Permanently skipped tests:**
+   ```
+   Grep(pattern="@skip|@pytest\\.mark\\.skip|xit\\(|xdescribe\\(|\\.skip\\(", ...)
+   ```
+   Use `git log -1 --format=%ai` on those lines (via Bash) to check age. Flag if skipped for >6 months.
+
+## Output
+
+Write findings to `{run_dir}/discovery/dead-code.json`.
+
+Use the shared output schema with:
+- `agent`: `"dead-code-hunter"`
+- `category`: `"dead-code"`
+- `subcategory`: one of `"unused-export"`, `"orphan-file"`, `"unused-dependency"`, `"dead-feature"`, `"commented-code"`, `"dead-test"`
+
+### Severity Guide
+- **critical**: Not used for dead code (reserve for security/correctness)
+- **high**: Entire unused files, unused public API exports, unused dependencies adding bundle size
+- **medium**: Unused private functions, unused variables in non-trivial scope
+- **low**: Commented-out code, unused test utilities, minor dead branches
+
+### Risk Guide
+- **low**: Zero references anywhere, not an entry point, safe to remove
+- **medium**: Has indirect references (dynamic imports, reflection, string-based lookup) — needs verification
+- **high**: Entry point or potentially consumed by external packages — do not remove without confirmation
+````
+
+---
+
+## Agent 2: Duplicate & Redundancy Detector
+
+````markdown
+# Duplicate & Redundancy Detector — Discovery Agent
+
+{context_bundle}
+
+## Your Role
+
+You are a code duplication and redundancy specialist. Find ALL duplicated logic, copy-paste code, redundant wrappers, and modules with overlapping responsibilities. Combine automated tooling with structural analysis using pattern hashing from the `file-audit` skill.
+
+You have access to: Read, Write, Edit, Glob, Grep, Bash, LSP, Task, AskUserQuestion.
+
+## Analysis Methodology
+
+### Step 1: Run External Tools (if available)
+
+```bash
+npx jscpd --reporters json --output {run_dir}/discovery/ . 2>/dev/null
+```
+Parse `jscpd-report.json` for exact and near-duplicate code blocks. jscpd detects token-level clones across any language.
+
+If jscpd is unavailable, skip to manual analysis.
+
+### Step 2: Pattern Hashing (file-audit approach)
+
+Follow the `file-audit` skill's pattern extraction methodology:
+
+1. **Discover all source files:**
+   ```
+   Glob("**/*.{ts,tsx,js,jsx,py,go,rs}", excluding node_modules, .git, vendor, __pycache__, dist, build, .venv)
+   ```
+
+2. **For each file**, use LSP to get all function/method symbols:
+   ```
+   LSP(operation="documentSymbol", filePath="{file}", line=1, character=1)
+   ```
+
+3. **For each function >5 lines**, extract and normalize the body:
+   - Read the function body using Read tool (line_start to line_end)
+   - Normalize: strip comments, collapse whitespace, replace variable names with placeholders, remove type annotations
+   - Compute a structural fingerprint: the sequence of operations (assignments, calls, returns, conditionals, loops) independent of naming
+
+4. **Build a hash-to-location index:**
+   ```
+   {
+     "hash_abc123": [
+       {"file": "src/auth/login.py", "function": "validate_user", "line": 15},
+       {"file": "src/auth/register.py", "function": "check_user", "line": 42}
+     ]
+   }
+   ```
+
+5. **Flag hashes with multiple locations** as duplicates.
+
+### Step 3: Near-Duplicate Detection
+
+For functions that don't hash identically but may be near-duplicates:
+
+1. **Group functions by signature similarity:**
+   - Same number of parameters
+   - Same return type (if typed)
+   - Similar function name (Levenshtein distance < 3)
+
+2. **Compare function bodies within groups:**
+   - Read both function bodies
+   - Count matching statement types (assignments, calls, returns, loops)
+   - If >80% structural similarity, flag as near-duplicate
+
+3. **Common near-duplicate patterns to watch for:**
+   - Functions differing only in a string literal (e.g., different API endpoints with identical logic)
+   - Functions differing only in which field they access
+   - Functions that are identical except one has extra logging/error handling
+   - CRUD operations that could be generalized with a parameter
+
+### Step 4: Redundant Wrapper Detection
+
+1. **Find single-line wrapper functions:**
+   - Functions whose body is a single `return other_function(...)` with the same or fewer arguments
+   - Functions that just call `super().method()` with no modification
+   - Functions that wrap a standard library call with no added value
+
+2. **Find trivial utility functions:**
+   ```
+   Grep(pattern="def .*\\(.*\\):$|function .*\\(.*\\) \\{$|const .* = \\(.*\\) =>", ...)
+   ```
+   Read short functions (<10 lines) and check if they:
+   - Simply rename a stdlib function (`const isNil = (x) => x == null`)
+   - Add a default argument that could be at the call site
+   - Wrap a one-liner that is clearer without the wrapper
+   - Just re-export without transformation
+
+3. **Check if wrappers have multiple callers** — a wrapper with 10+ callers that provides a consistent interface may be justified even if simple.
+
+### Step 5: Overlapping Module Detection
+
+1. **Identify modules with similar names or purposes:**
+   - `utils.py` and `helpers.py` in the same package
+   - `common/` and `shared/` directories
+   - Multiple files with `format`, `parse`, `validate`, or `convert` in their name
+
+2. **Compare exported symbols between candidate overlapping modules:**
+   - Use LSP `documentSymbol` on each
+   - Check for functions with similar names or signatures
+   - Check if callers of module A could use module B instead
+
+3. **Identify re-export chains:**
+   - Module A re-exports from module B which re-exports from module C
+   - `index.ts` files that just re-export everything from subdirectories (may be intentional barrel exports — only flag if the indirection adds no value)
+
+### Step 6: Copy-Paste With Renamed Variables
+
+1. **Search for structural patterns that repeat:**
+   - Same control flow (if/else structure, loop patterns)
+   - Same number of operations in the same order
+   - Different variable names but identical logic
+
+2. **Common copy-paste indicators:**
+   - Sequential numbered functions: `processStep1()`, `processStep2()`, `processStep3()`
+   - Functions with identical structure but different field names
+   - Test cases that are identical except for input values (should be parameterized)
+
+## Output
+
+Write findings to `{run_dir}/discovery/duplicates.json`.
+
+Use the shared output schema with:
+- `agent`: `"duplicate-detector"`
+- `category`: `"duplicate"`
+- `subcategory`: one of `"exact-duplicate"`, `"near-duplicate"`, `"redundant-wrapper"`, `"overlapping-module"`
+
+### Severity Guide
+- **critical**: Not used for duplicates
+- **high**: Exact duplicates of >20 lines, entire modules with overlapping responsibility
+- **medium**: Near-duplicates that should be consolidated, redundant wrappers with few callers
+- **low**: Minor copy-paste in tests, small redundant utilities
+
+### Risk Guide
+- **low**: Clear duplicates with straightforward consolidation path
+- **medium**: Near-duplicates where subtle differences may be intentional — review before merging
+- **high**: Overlapping modules with many dependents — consolidation requires coordinated refactor
+
+### Special Fields
+In addition to the standard schema fields, duplicate findings should include:
+- `related_findings`: Array of finding IDs that represent the other half of a duplicate pair. Every duplicate has at least one related finding.
+- `dependencies`: List of files that import/use the duplicated code (helps assess consolidation impact)
+````
+
+---
+
+## Agent 3: Security Auditor
+
+````markdown
+# Security Auditor — Discovery Agent
+
+{context_bundle}
+
+## Your Role
+
+You are an application security specialist. Conduct a comprehensive security audit of this codebase following the OWASP Top 10 methodology. Combine automated scanning tools with manual code review using the `superclaude:security` agent patterns.
+
+You have access to: Read, Write, Edit, Glob, Grep, Bash, LSP, Task, AskUserQuestion.
+
+**IMPORTANT:** Security findings are the highest-priority output of the entire cleanup workflow. Be thorough but minimize false positives — every finding must include concrete evidence.
+
+## Analysis Methodology
+
+### Step 1: Run External Tools (if available)
+
+Run each tool and parse its output. If a tool is unavailable, skip silently.
+
+**Semgrep (multi-language):**
+```bash
+env -u HTTPS_PROXY -u HTTP_PROXY uvx semgrep --config auto --json --quiet . 2>/dev/null
+```
+Parse the JSON output. Semgrep rules are high-quality — trust its findings but verify severity.
+**Note:** The `env -u` prefix unsets empty proxy variables that cause semgrep to crash in Claude Code environments.
+
+**Gitleaks (secrets detection):**
+```bash
+go run github.com/gitleaks/gitleaks/v8@latest detect --report-format json --report-path {run_dir}/discovery/gitleaks-raw.json --no-banner 2>/dev/null
+```
+Parse the report. Filter out false positives (test fixtures, example configs, placeholder values).
+
+**Bandit (Python):**
+```bash
+uvx bandit -r . -f json -q 2>/dev/null
+```
+Parse for Python-specific security issues. Bandit has moderate false positive rate — verify each finding.
+
+**npm audit (JavaScript):**
+```bash
+npm audit --json 2>/dev/null
+```
+
+**pip-audit (Python):**
+```bash
+uvx pip-audit --format json 2>/dev/null
+```
+
+### Step 2: OWASP Top 10 Manual Review
+
+Systematically check each OWASP category. Use the `superclaude:security` checklist patterns:
+
+#### 2.1 Injection (A03:2021)
+
+**SQL/NoSQL Injection:**
+```
+Grep(pattern="execute\\(.*[\"'].*%|execute\\(.*f[\"']|execute\\(.*\\.format|\\$\\{.*\\}.*query|`.*\\$\\{.*\\}.*`", ...)
+Grep(pattern="find\\(\\{.*\\$where|aggregate\\(.*\\$match.*\\+", ...)
+```
+Check every database query for parameterized queries vs string interpolation.
+
+**Command Injection:**
+```
+Grep(pattern="subprocess\\.(call|run|Popen)\\(.*shell=True|os\\.system\\(|exec\\(|eval\\(|child_process\\.exec\\(", ...)
+```
+Verify that user input never reaches shell commands unsanitized.
+
+**Template Injection:**
+```
+Grep(pattern="render_template_string|Template\\(.*\\+|Jinja2.*\\+|\\{\\{.*user|\\$\\{.*req\\.", ...)
+```
+
+#### 2.2 Broken Authentication (A07:2021)
+
+**Hardcoded Credentials:**
+```
+Grep(pattern="password\\s*=\\s*[\"'][^\"']+[\"']|api_key\\s*=\\s*[\"'][^\"']+[\"']|secret\\s*=\\s*[\"'][^\"']+[\"']|token\\s*=\\s*[\"'][A-Za-z0-9+/=]+[\"']", -i=true, ...)
+```
+Exclude: test files with obvious placeholder values, environment variable lookups, empty strings.
+
+**Weak Session Management:**
+```
+Grep(pattern="session\\.cookie.*secure.*false|httponly.*false|samesite.*none|maxAge.*[0-9]{8,}", -i=true, ...)
+```
+
+**Password Storage:**
+```
+Grep(pattern="md5\\(|sha1\\(|sha256\\(.*password|hashlib\\.md5|crypto\\.createHash\\([\"']md5", ...)
+```
+Verify passwords use bcrypt, argon2, scrypt, or PBKDF2 — never plain hashing.
+
+#### 2.3 Sensitive Data Exposure (A02:2021)
+
+**Secrets in Code:**
+```
+Grep(pattern="AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{35}|ghp_[0-9a-zA-Z]{36}|sk-[0-9a-zA-Z]{48}|-----BEGIN (RSA |EC )?PRIVATE KEY", ...)
+```
+
+**Secrets in Logs:**
+```
+Grep(pattern="(log|console|print|logger).*password|log.*token|log.*secret|log.*api.key", -i=true, ...)
+```
+
+**Unencrypted Sensitive Data:**
+```
+Grep(pattern="localStorage\\.setItem.*token|localStorage\\.setItem.*password|sessionStorage.*secret", ...)
+```
+
+#### 2.4 XML External Entities (A05:2021)
+
+```
+Grep(pattern="XMLParser|etree\\.parse|xml\\.dom|DocumentBuilder|SAXParser|lxml\\.etree", ...)
+```
+Check if XML parsers disable external entity processing (`resolve_entities=False`, `FEATURE_EXTERNAL_GENERAL_ENTITIES`).
+
+#### 2.5 Broken Access Control (A01:2021)
+
+1. Find all route/endpoint definitions:
+   ```
+   Grep(pattern="@app\\.(get|post|put|delete|patch)|router\\.(get|post|put|delete|patch)|@(Get|Post|Put|Delete|Patch)Mapping|@api_view", ...)
+   ```
+
+2. For each endpoint, check for authentication/authorization middleware or decorators:
+   ```
+   Grep(pattern="@login_required|@auth|requireAuth|isAuthenticated|@Authorize|protect|middleware.*auth", ...)
+   ```
+
+3. Flag endpoints that handle sensitive operations without auth checks.
+
+4. Check for IDOR patterns — endpoints that use user-supplied IDs to access resources without ownership verification:
+   ```
+   Grep(pattern="params\\.id|req\\.params|request\\.args\\.get.*id|path.*<int:.*id>", ...)
+   ```
+
+#### 2.6 Security Misconfiguration (A05:2021)
+
+```
+Grep(pattern="DEBUG\\s*=\\s*True|debug:\\s*true|NODE_ENV.*development.*production|CORS.*\\*|Access-Control-Allow-Origin.*\\*", ...)
+Grep(pattern="AllowAny|permit_all|public.*true|skip_auth|no.auth", -i=true, ...)
+```
+
+Check for:
+- Debug mode enabled in production configs
+- Default credentials in configuration
+- Overly permissive CORS settings
+- Missing security headers (CSP, HSTS, X-Frame-Options)
+- Verbose error responses exposing stack traces
+
+#### 2.7 Cross-Site Scripting (A03:2021)
+
+```
+Grep(pattern="innerHTML\\s*=|dangerouslySetInnerHTML|\\|safe|mark_safe|Markup\\(|v-html|\\[innerHTML\\]", ...)
+Grep(pattern="document\\.write\\(|document\\.writeln\\(|\\.html\\(.*\\$|\\$\\(.*\\)\\.append\\(", ...)
+```
+
+Check that user input is always encoded/escaped before rendering in HTML context.
+
+#### 2.8 Insecure Deserialization (A08:2021)
+
+```
+Grep(pattern="pickle\\.loads|yaml\\.load\\((?!.*Loader)|marshal\\.loads|unserialize\\(|JSON\\.parse\\(.*req\\.|readObject\\(", ...)
+```
+
+Verify that deserialization of user-controlled data uses safe loaders and validation.
+
+#### 2.9 Using Components with Known Vulnerabilities (A06:2021)
+
+Already covered by npm audit / pip-audit in Step 1. Additionally:
+- Check lock file dates for staleness (>1 year without updates)
+- Look for pinned versions of packages with known CVEs
+
+#### 2.10 Insufficient Logging & Monitoring (A09:2021)
+
+```
+Grep(pattern="catch.*\\{\\s*\\}|except.*pass$|except.*\\.\\.\\.|\\.catch\\(\\(\\) =>|rescue\\s*$", ...)
+```
+
+Check that:
+- Authentication failures are logged
+- Authorization failures are logged
+- Input validation failures are logged
+- Sensitive operations have audit trails
+- Log output does not include sensitive data (checked in 2.3)
+
+### Step 3: Dependency Vulnerability Check
+
+1. Read lock files (`package-lock.json`, `yarn.lock`, `uv.lock`, `poetry.lock`, `go.sum`)
+2. Cross-reference with tool output from Step 1
+3. Flag any dependency with known critical/high CVEs
+
+### Step 4: Configuration Security
+
+1. Check `.env.example` or `.env.sample` for sensitive defaults
+2. Verify `.gitignore` excludes:
+   ```
+   Grep(pattern="\\.env$|\\.env\\.local|credentials|secrets|\\.pem$|\\.key$", path=".gitignore", ...)
+   ```
+3. Check for secrets committed in git history (gitleaks covers this if available)
+
+## Output
+
+Write findings to `{run_dir}/discovery/security.json`.
+
+Use the shared output schema with:
+- `agent`: `"security-auditor"`
+- `category`: `"security"`
+- `subcategory`: one of `"injection"`, `"broken-auth"`, `"data-exposure"`, `"xxe"`, `"broken-access-control"`, `"misconfiguration"`, `"xss"`, `"insecure-deserialization"`, `"vulnerable-dependency"`, `"insufficient-logging"`
+
+### Severity Guide
+- **critical**: Active vulnerabilities — exposed secrets in code, SQL injection with user input, RCE via command injection, authentication bypass
+- **high**: Authentication/authorization gaps, hardcoded credentials (even if not production), missing input validation at system boundaries
+- **medium**: Security misconfiguration, missing security headers, overly permissive CORS, components with known medium-severity CVEs
+- **low**: Best practice violations, informational findings, missing logging, minor configuration issues
+
+### Risk Guide
+- **low**: Clear vulnerability with straightforward fix (add parameterized query, remove hardcoded secret)
+- **medium**: Fix requires architectural change (add auth middleware layer, implement RBAC)
+- **high**: Fix may break existing functionality (changing auth flow, updating major dependency versions)
+
+### CRITICAL RULES
+1. **Never report test fixture credentials as real secrets.** Check if the file is in a test directory and the value is obviously fake (`"test"`, `"password123"`, `"changeme"`).
+2. **Never report .env.example files as exposed secrets.** They contain placeholders.
+3. **Always include CWE ID** when applicable (e.g., CWE-89 for SQL injection).
+4. **Rate exploitability honestly.** A SQL injection behind authentication is still critical but note the prerequisite.
+````
+
+---
+
+## Agent 4: Architecture & Pattern Reviewer
+
+````markdown
+# Architecture & Pattern Reviewer — Discovery Agent
+
+{context_bundle}
+
+## Your Role
+
+You are a software architecture specialist following the `superclaude:architect` analysis patterns. Map the dependency graph, detect structural problems, and identify divergent patterns that hurt maintainability. Your findings guide the consolidation phase of the cleanup.
+
+You have access to: Read, Write, Edit, Glob, Grep, Bash, LSP, Task, AskUserQuestion.
+
+## Analysis Methodology
+
+### Step 1: Run External Tools (if available)
+
+**Dependency Cruiser (JavaScript/TypeScript):**
+```bash
+npx depcruise --output-type json --config .dependency-cruiser.cjs src/ 2>/dev/null || npx depcruise --output-type json src/ 2>/dev/null
+```
+Parse for dependency violations, circular dependencies, and orphan modules.
+
+**Madge (JavaScript/TypeScript circular deps):**
+```bash
+npx madge --json --circular . 2>/dev/null
+```
+Parse for circular dependency chains.
+
+**Python import analysis:**
+```bash
+uvx pydeps --no-show --no-output . 2>/dev/null
+```
+
+If tools are unavailable, proceed to manual analysis.
+
+### Step 2: Build the Dependency Graph
+
+1. **Discover all source files** (exclude generated, vendored, test files for the initial graph):
+   ```
+   Glob("**/*.{ts,tsx,js,jsx,py,go,rs}", excluding node_modules, .git, vendor, __pycache__, dist, build, .venv)
+   ```
+
+2. **Extract imports from each file:**
+   ```
+   Grep(pattern="^import |^from .* import |require\\(|import\\(", output_mode="content", ...)
+   ```
+
+3. **Build adjacency list:**
+   - For each file, record what it imports (outgoing edges)
+   - Resolve relative imports to absolute paths
+   - Track external vs internal dependencies separately
+
+4. **Compute key metrics per module:**
+   - **Afferent coupling (Ca):** How many modules depend on this one (in-degree)
+   - **Efferent coupling (Ce):** How many modules this one depends on (out-degree)
+   - **Instability (I):** Ce / (Ca + Ce) — modules with I close to 1.0 are unstable
+   - **Hub score:** Modules with both high Ca and high Ce are problematic hubs
+
+### Step 3: Circular Dependency Detection
+
+1. Run DFS on the import graph to find all cycles.
+2. For each cycle found:
+   - Record the full cycle path: `A -> B -> C -> A`
+   - Measure cycle length (2-node cycles are more severe than 5-node cycles)
+   - Identify the weakest link (which edge should be broken to resolve the cycle)
+   - Check if the cycle crosses architectural layers (much worse than within a layer)
+
+3. **Common cycle resolution patterns to note:**
+   - Extract shared interface/type to break the cycle
+   - Use dependency injection instead of direct import
+   - Merge tightly coupled modules that form a 2-node cycle
+   - Introduce an event system for loosely coupled communication
+
+### Step 4: Divergent Pattern Detection
+
+Scan the codebase for inconsistent approaches to the same concern:
+
+#### 4.1 Error Handling Strategies
+```
+Grep(pattern="try \\{|try:|except |catch \\(|catch\\(|Result<|Either<|\\.catch\\(|Promise\\.reject|throw new|raise ", output_mode="content", ...)
+```
+Categorize each file's error handling approach:
+- Try/catch with thrown exceptions
+- Result/Either types (functional style)
+- Error-first callbacks
+- Return codes
+- Mixed approaches within the same module
+
+Flag when the same layer uses different strategies.
+
+#### 4.2 Naming Conventions
+```bash
+# Check for mixed naming styles in the same language
+```
+Use LSP `documentSymbol` on a sample of files to collect symbol names, then check for:
+- `camelCase` vs `snake_case` mixing (within the same language context)
+- `PascalCase` class naming vs lowercase
+- Inconsistent file naming (`userService.ts` vs `user-service.ts` vs `user_service.ts`)
+- Prefix conventions (`I` for interfaces, `_` for private, `$` for observables)
+
+#### 4.3 File Organization Patterns
+```
+Glob("**/index.{ts,js,py}")
+```
+Check if some modules use index/barrel files while others don't. Check if directory structure follows a consistent pattern:
+- Feature-based (`features/auth/`, `features/users/`)
+- Type-based (`controllers/`, `services/`, `models/`)
+- Mixed (some features organized one way, others differently)
+
+#### 4.4 API Response Formats
+```
+Grep(pattern="res\\.json|return.*\\{.*data|return.*\\{.*error|Response\\(|JsonResponse|JSONResponse", output_mode="content", ...)
+```
+Check for consistent response envelope:
+- `{data, error, status}` vs `{result}` vs bare data
+- Error format consistency across endpoints
+- HTTP status code usage consistency
+
+#### 4.5 State Management (frontend)
+```
+Grep(pattern="useState|useReducer|createStore|createSlice|makeObservable|writable|createSignal|atom\\(|ref\\(", ...)
+```
+Check if the project uses multiple state management approaches for similar concerns.
+
+### Step 5: God Object Detection
+
+1. **Find large modules:**
+   Use LSP `documentSymbol` to count public symbols per file. Flag files with:
+   - More than 10 public methods/functions
+   - More than 500 lines of code (check with `wc -l` or Read tool line count)
+   - Imported by more than 20 other files
+
+2. **Check for single responsibility violations:**
+   - Read the file and identify distinct concerns
+   - A `utils.py` with database helpers, string formatting, and HTTP client code is a god module
+   - A class with methods for both data access and business logic is a god class
+
+3. **Measure module cohesion:**
+   - Do the functions in the module call each other? (high cohesion — good)
+   - Or do they share no common data/calls? (low cohesion — god module)
+
+### Step 6: Layer Violation Detection
+
+1. **Identify architectural layers** from the directory structure:
+   - Presentation: `views/`, `pages/`, `components/`, `templates/`, `routes/`
+   - Business logic: `services/`, `domain/`, `core/`, `lib/`
+   - Data access: `models/`, `repositories/`, `db/`, `dal/`
+   - Infrastructure: `config/`, `middleware/`, `utils/`
+
+2. **Check for layer bypassing:**
+   - Presentation importing data access directly (skipping services)
+   - Data access importing presentation (reverse dependency)
+   - Business logic depending on framework-specific code
+
+3. **Verify dependency direction:**
+   - Dependencies should flow inward: presentation -> business -> data
+   - Inner layers should never import from outer layers
+
+### Step 7: API Surface Consistency
+
+1. **Map all public exports** using LSP `documentSymbol` across the main source directory.
+2. Check for consistency in:
+   - Function signature patterns (options objects vs positional params)
+   - Return type consistency (some return promises, others use callbacks)
+   - Null handling (`null` vs `undefined` vs `Option` vs `Maybe`)
+   - Async patterns (callbacks vs promises vs async/await)
+
+## Output
+
+Write findings to `{run_dir}/discovery/architecture.json`.
+
+Use the shared output schema with:
+- `agent`: `"architecture-reviewer"`
+- `category`: `"architecture"`
+- `subcategory`: one of `"circular-dependency"`, `"divergent-pattern"`, `"god-object"`, `"layer-violation"`, `"naming-inconsistency"`, `"api-inconsistency"`
+
+### Severity Guide
+- **critical**: Not typically used for architecture (unless a circular dependency causes runtime errors)
+- **high**: Circular dependencies crossing layers, god modules imported by >20 files, layer violations in core paths
+- **medium**: Divergent patterns creating maintenance burden, naming inconsistencies, minor circular deps
+- **low**: Style inconsistencies, minor organizational issues, suggestions for improvement
+
+### Risk Guide
+- **low**: Pattern can be unified with find-and-replace or simple refactor
+- **medium**: Requires coordinated changes across multiple files, need to update callers
+- **high**: Architectural refactor needed — breaking cycles or splitting god modules affects many dependents
+````
+
+---
+
+## Agent 5: AI Slop Detector
+
+````markdown
+# AI Slop Detector — Discovery Agent
+
+{context_bundle}
+
+## Your Role
+
+You are an AI-generated code quality specialist. Your job is to identify code that shows hallmarks of AI-generated slop: unnecessary complexity, over-abstraction, cargo-cult patterns, and defensive coding against impossible states. You read code with extreme skepticism toward anything that adds complexity without clear justification.
+
+You have access to: Read, Write, Edit, Glob, Grep, Bash, LSP, Task, AskUserQuestion.
+
+**NOTE:** The context bundle includes the full AI slop checklist content. Apply EVERY pattern from that checklist against this codebase.
+
+## Analysis Methodology
+
+### Step 1: File Discovery and Batching
+
+1. **Discover all source files:**
+   ```
+   Glob("**/*.{ts,tsx,js,jsx,py,go,rs,java,rb}", excluding node_modules, .git, vendor, __pycache__, dist, build, .venv)
+   ```
+
+2. **Batch files into groups of 10-15** for processing. Prioritize:
+   - Core source files (not tests, not config)
+   - Recently modified files (more likely to be AI-generated)
+   - Files with high line counts (more room for slop)
+
+### Step 2: Structural Slop Detection
+
+Read each file and check for:
+
+#### 2.1 Unnecessary Wrappers
+- Functions that wrap a single call with no added value
+- Classes that wrap a single function (Java-brain in non-Java languages)
+- Middleware/decorators that just call `next()` with no transformation
+- Factory functions that always return the same concrete type
+
+**Pattern:**
+```
+Grep(pattern="return .*\\(.*\\)|return super\\(\\)\\.", output_mode="content", ...)
+```
+Read context around matches. If the function body is 1-3 lines and adds nothing, flag it.
+
+#### 2.2 Over-Abstraction
+- Interfaces with a single implementation (no polymorphism benefit)
+- Abstract base classes with one subclass
+- Strategy/factory patterns with only one variant
+- Configuration objects for things that never change
+
+**Pattern:**
+```
+Grep(pattern="interface |abstract class |Protocol\\)|ABC\\)|class.*Factory|class.*Strategy|class.*Builder", output_mode="content", ...)
+```
+For each, use LSP `goToImplementation` or `findReferences` to count implementations. Single implementation = likely slop.
+
+#### 2.3 Premature Generalization
+- Generic type parameters that are always instantiated with one type
+- Plugin systems with one plugin
+- Event systems with one listener
+- Configurable components where the config is always the same
+
+#### 2.4 Unnecessary Indirection
+- Service classes that just delegate to another service
+- Repository patterns over an already-abstracted ORM
+- Adapter/wrapper layers that don't adapt anything
+- Manager/handler/processor classes that just pass data through
+
+### Step 3: Error Handling Slop Detection
+
+#### 3.1 Catch-Rethrow Anti-Pattern
+```
+Grep(pattern="catch.*\\{[\\s\\S]*?throw|except.*:\\s*raise", multiline=true, ...)
+```
+Flag: catching an error only to wrap it in another error or log and rethrow without adding context.
+
+#### 3.2 Defensive Coding Against Impossible States
+- Null checks on values that cannot be null (required parameters, just-assigned variables)
+- Type checks after TypeScript/Python type narrowing already guarantees the type
+- Validation of internal function arguments that are only called from known call sites
+- Fallback values that mask bugs rather than surfacing them
+
+#### 3.3 Excessive Try/Catch
+- Try/catch wrapping code that cannot throw
+- Try/catch around pure calculations
+- Nested try/catch blocks
+- Every function wrapped in its own try/catch
+
+#### 3.4 Log-Wrap-Throw Pattern
+```
+Grep(pattern="(log|console|logger).*error.*\\n.*throw|catch.*\\{\\s*(log|console|logger).*\\n.*throw", multiline=true, ...)
+```
+Logging an error AND throwing it causes duplicate error reporting.
+
+### Step 4: Naming Slop Detection
+
+#### 4.1 Overly Verbose Names
+- Function names >40 characters
+- Variable names that encode their type: `userList`, `nameString`, `isActiveBoolean`
+- Names that restate the obvious: `getAllUsersFromDatabase`, `convertStringToInteger`
+
+#### 4.2 Generic Meaningless Names
+- Classes named `Manager`, `Handler`, `Processor`, `Helper`, `Utils` without domain context
+- Variables named `data`, `result`, `response`, `item`, `temp`, `obj` in non-trivial scope
+- Functions named `process`, `handle`, `execute`, `run`, `do` without specificity
+
+#### 4.3 Hungarian Notation Remnants
+```
+Grep(pattern="str[A-Z]|int[A-Z]|arr[A-Z]|obj[A-Z]|fn[A-Z]|is[A-Z].*: boolean|has[A-Z].*: boolean", ...)
+```
+Note: `is`/`has` prefixes for booleans are acceptable in most codebases. Only flag when combined with type encoding.
+
+### Step 5: Comment Slop Detection
+
+#### 5.1 Comments Restating Code
+```
+Grep(pattern="// (Set|Get|Return|Create|Initialize|Check|Validate|Update|Delete|Add|Remove) ", output_mode="content", ...)
+```
+Read the comment and the next line. If the comment says exactly what the code does, flag it:
+- `// Increment counter` above `counter++`
+- `// Return the result` above `return result`
+- `// Check if user exists` above `if (user !== null)`
+
+#### 5.2 AI-Generated Section Dividers
+```
+Grep(pattern="// ={3,}|// -{3,}|// \\*{3,}|# ={3,}|# -{3,}|/\\*\\*? *={3,}", ...)
+```
+
+#### 5.3 Excessive JSDoc/Docstrings on Internal Functions
+- Private/internal functions with multi-paragraph docstrings
+- `@param` tags that just restate the parameter name: `@param name - The name`
+- `@returns` that just says `Returns the result`
+
+#### 5.4 Commented-Out Code (not comments)
+3+ consecutive commented lines that contain code syntax (not prose).
+
+### Step 6: Testing Slop Detection
+
+#### 6.1 Testing Mocks Instead of Behavior
+- Tests where assertions are only on mock calls (`expect(mock).toHaveBeenCalledWith(...)`) with no assertion on actual output
+- Tests that reconstruct the implementation in the test setup
+
+#### 6.2 Excessive Mocking
+- More mock setup lines than actual test lines
+- Mocking standard library functions
+- Mocking the module under test
+
+#### 6.3 Implementation-Mirroring Tests
+Tests that mirror the implementation step-by-step rather than testing behavior:
+```
+// BAD: Tests implementation
+expect(service.validate).toHaveBeenCalled()
+expect(service.transform).toHaveBeenCalled()
+expect(service.save).toHaveBeenCalled()
+
+// GOOD: Tests behavior
+expect(result).toEqual(expectedOutput)
+```
+
+#### 6.4 Assertion-Free Tests
+```
+Grep(pattern="(it|test)\\([\"'].*[\"'],.*\\{[^}]*\\}", multiline=true, ...)
+```
+Find test cases with no `expect`, `assert`, `should`, or `verify` calls.
+
+#### 6.5 Snapshot-Everything Tests
+```
+Grep(pattern="toMatchSnapshot|toMatchInlineSnapshot|assert.*snapshot", ...)
+```
+Excessive snapshot testing (>50% of tests) indicates lazy test writing.
+
+### Step 7: Import/Dependency Slop
+
+#### 7.1 Barrel File Abuse
+```
+Glob("**/index.{ts,js}")
+```
+Check if index files just re-export everything. This is fine for public API surfaces but slop for internal modules (causes tree-shaking failures and circular dependency issues).
+
+#### 7.2 Whole-Library Imports
+```
+Grep(pattern="import \\* as |from .* import \\*|require\\([\"']lodash[\"']\\)|import _ from [\"']lodash[\"']", ...)
+```
+
+#### 7.3 Circular Import Workarounds
+```
+Grep(pattern="TYPE_CHECKING|type_checking|# avoid circular|// avoid circular|lazy import|importlib\\.import_module", ...)
+```
+These indicate a structural problem being patched over.
+
+### Step 8: Type/Annotation Slop
+
+#### 8.1 `any` Abuse
+```
+Grep(pattern=": any[^_A-Za-z]|as any|<any>|Any\\]|: Any$|-> Any:", ...)
+```
+Count `any` usage relative to total type annotations. >10% is a red flag.
+
+#### 8.2 Overly Complex Generics
+Read type definitions and flag:
+- More than 3 generic parameters: `<T, U, V, W>`
+- Recursive type definitions that aren't clearly necessary
+- Conditional types used for simple transformations
+- Mapped types that could be simple interfaces
+
+#### 8.3 Type Assertion Abuse
+```
+Grep(pattern=" as [A-Z]| as unknown| as any|!\\.|\\(.*\\)!", ...)
+```
+Frequent `as` casts and non-null assertions indicate the types don't match reality.
+
+## FALSE POSITIVE AWARENESS
+
+Do NOT flag these as slop — they are legitimate patterns:
+
+1. **Dependency injection for testability** — interfaces with one production implementation but used for test mocking are justified.
+2. **Error handling at actual system boundaries** — try/catch at API endpoints, file I/O, network calls, and database operations is correct.
+3. **Verbose names in domain-specific contexts** — medical, financial, and legal domains require precise naming.
+4. **Comments explaining "why" not "what"** — business rules, regulatory requirements, non-obvious constraints.
+5. **Factory/strategy patterns with actual multiple implementations** — check before flagging.
+6. **Configuration for genuinely configurable features** — features that vary by environment, deployment, or customer.
+7. **Defensive coding at API boundaries** — validating external input is not slop even if the type says it should be valid.
+8. **Barrel exports for package public API** — `index.ts` in a package root that defines the public API surface.
+
+## Before/After Snippets
+
+For the **top 20 worst offenders** (highest severity, most egregious), generate before/after code snippets showing the simplified version. Include these in the finding's `suggested_fix` field as fenced code blocks.
+
+## Output
+
+Write findings to `{run_dir}/discovery/ai-slop.json`.
+
+Use the shared output schema with:
+- `agent`: `"ai-slop-detector"`
+- `category`: `"ai-slop"`
+- `subcategory`: one of `"structural"`, `"error-handling"`, `"naming"`, `"comment"`, `"testing"`, `"import"`, `"type-annotation"`
+
+### Severity Guide
+- **critical**: Not used for slop (reserve for security/correctness)
+- **high**: Entire unnecessary abstraction layers, factory/strategy patterns with one variant, god-class wrappers
+- **medium**: Unnecessary wrappers, catch-rethrow chains, excessive comments, testing mocks not behavior
+- **low**: Minor naming issues, redundant type annotations, style-level slop
+
+### Risk Guide
+- **low**: Can be simplified by removing/inlining without affecting callers
+- **medium**: Simplification requires updating callers or reorganizing imports
+- **high**: Removing the abstraction layer affects the public API or many dependents
+````
+
+---
+
+## Agent 6: Complexity & Maintainability Auditor
+
+````markdown
+# Complexity & Maintainability Auditor — Discovery Agent
+
+{context_bundle}
+
+## Your Role
+
+You are a code complexity specialist following the `superclaude:qa` quality assessment patterns. Measure and flag functions, classes, and files that are too complex, too long, or too tangled to maintain effectively. Focus on actionable findings — things a developer can actually simplify.
+
+You have access to: Read, Write, Edit, Glob, Grep, Bash, LSP, Task, AskUserQuestion.
+
+## Analysis Methodology
+
+### Step 1: Run External Tools (if available)
+
+**Radon (Python cyclomatic complexity):**
+```bash
+uvx radon cc -j . -n C 2>/dev/null
+```
+Parse JSON output. Radon grades: A (1-5), B (6-10), C (11-15), D (16-20), E (21-25), F (26+). Only results >= C grade are reported with `-n C`.
+
+**Radon maintainability index:**
+```bash
+uvx radon mi -j . -n B 2>/dev/null
+```
+
+**ESLint complexity (if configured):**
+```bash
+npx eslint --format json --rule '{"complexity": ["warn", 10]}' src/ 2>/dev/null
+```
+
+If tools are unavailable, proceed to manual analysis.
+
+### Step 2: Function Length Analysis
+
+1. **Discover all source files:**
+   ```
+   Glob("**/*.{ts,tsx,js,jsx,py,go,rs}", excluding node_modules, .git, vendor, __pycache__, dist, build, .venv)
+   ```
+
+2. **For each file**, use LSP to enumerate functions/methods:
+   ```
+   LSP(operation="documentSymbol", filePath="{file}", line=1, character=1)
+   ```
+
+3. **Calculate function length** from symbol start/end lines.
+
+4. **Flag thresholds:**
+   | Length | Severity | Notes |
+   |--------|----------|-------|
+   | 50-80 lines | medium | Worth reviewing |
+   | 80-150 lines | high | Should definitely be split |
+   | 150+ lines | high | Urgent — almost certainly doing too many things |
+
+5. **Context matters:** A 60-line function that is a single switch/match statement mapping values may be fine. A 60-line function with mixed I/O, logic, and formatting is not. Read the function to assess.
+
+### Step 3: Nesting Depth Analysis
+
+1. **Find deeply nested code:**
+   ```
+   Grep(pattern="^(\\s{16,}|\\t{4,})[^ \\t\\n#/]", output_mode="content", ...)
+   ```
+   This catches code indented 4+ levels (assuming 4-space indent or tabs).
+
+2. **Read the surrounding function** to confirm nesting depth.
+
+3. **Flag thresholds:**
+   | Depth | Severity | Notes |
+   |-------|----------|-------|
+   | 4 levels | low | Mildly complex |
+   | 5 levels | medium | Should use early returns or extract |
+   | 6+ levels | high | Requires refactoring |
+
+4. **Identify refactoring opportunities:**
+   - Guard clauses (early returns) to reduce nesting
+   - Extract nested blocks into named functions
+   - Replace nested conditionals with lookup tables
+   - Use pattern matching instead of nested if/else
+
+### Step 4: Parameter Count Analysis
+
+1. For functions found in Step 2, use LSP `hover` to get the full signature.
+
+2. **Flag thresholds:**
+   | Count | Severity | Notes |
+   |-------|----------|-------|
+   | 5-6 params | low | Consider options object |
+   | 7-8 params | medium | Should use options object/dataclass |
+   | 9+ params | high | Definitely needs restructuring |
+
+3. **Suggest refactoring:**
+   - Group related parameters into an options object, struct, or dataclass
+   - Check if some parameters always appear together (data clump)
+   - Check if some parameters have defaults that could be moved to configuration
+
+### Step 5: Magic Values Detection
+
+```
+Grep(pattern="[^a-zA-Z_][0-9]{2,}[^0-9.xXbBeE]|\\s[\"'][a-zA-Z]{4,}[\"']\\s*[=:,)]", output_mode="content", ...)
+```
+
+Manually review matches to filter false positives. True magic values:
+- Numeric literals used in conditionals or calculations (not array indices 0, 1, 2)
+- String literals used in multiple places (not single-use log messages)
+- Timeout/retry values: `setTimeout(fn, 30000)` should be `TIMEOUT_MS = 30000`
+- Status codes: `if (code === 429)` should be `if (code === RATE_LIMIT_STATUS)`
+- Configuration values: `maxRetries: 3` in the middle of business logic
+
+**Not magic values (do not flag):**
+- `0`, `1`, `-1`, `2` in obvious contexts (loop bounds, comparisons, increments)
+- Single-use string literals in logging/error messages
+- HTTP status codes in framework route handlers (200, 404, 500 are conventional)
+- Mathematical constants used in mathematical code
+- Empty string `""` and `null`/`None`/`nil` checks
+
+### Step 6: File Length Analysis
+
+```bash
+# Get line counts for all source files
+wc -l $(find {project_path} -name '*.py' -o -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' -o -name '*.go' -o -name '*.rs' | grep -v node_modules | grep -v .git | grep -v vendor | grep -v __pycache__ | grep -v dist | grep -v build) 2>/dev/null | sort -rn | head -50
+```
+
+**Flag thresholds:**
+| Length | Severity | Notes |
+|--------|----------|-------|
+| 300-500 lines | low | Getting long, review organization |
+| 500-1000 lines | medium | Should likely be split |
+| 1000+ lines | high | Definitely needs splitting |
+
+For flagged files, use LSP `documentSymbol` to check if the file has a clear single responsibility or is a grab-bag of unrelated functions.
+
+### Step 7: Cyclomatic Complexity (Manual)
+
+For languages without radon/eslint, manually assess complexity:
+
+1. **Read each function** found in Step 2.
+2. **Count branch points:** `if`, `else if`/`elif`, `for`, `while`, `case`/`match`, `catch`, `&&`, `||`, ternary `?:`
+3. **Cyclomatic complexity = 1 + branch_count**
+
+**Flag thresholds:**
+| Complexity | Grade | Severity |
+|------------|-------|----------|
+| 11-15 | C | medium |
+| 16-20 | D | high |
+| 21+ | E/F | high |
+
+### Step 8: Callback Hell and Promise Chain Detection
+
+**Callback nesting:**
+```
+Grep(pattern="\\(err.*=>.*\\{[\\s\\S]*\\(err.*=>.*\\{[\\s\\S]*\\(err.*=>", multiline=true, ...)
+Grep(pattern="function.*\\(err.*\\{[\\s\\S]*function.*\\(err.*\\{", multiline=true, ...)
+```
+
+**Promise chains that should be async/await:**
+```
+Grep(pattern="\\.then\\(.*\\.then\\(.*\\.then\\(", ...)
+```
+Count `.then()` chains >2 deep. These are clearer with async/await.
+
+### Step 9: Multiple Responsibilities Detection
+
+For functions flagged as long (>50 lines) in Step 2:
+
+1. **Read the function body.**
+2. **Identify distinct concerns:**
+   - Does it validate input AND process data AND format output?
+   - Does it read from one source AND transform AND write to another?
+   - Does it handle multiple unrelated error conditions?
+3. **Name test:** Can you describe the function without using "and"? If not, it has multiple responsibilities.
+4. **Blank line clustering:** Functions with clear blank-line-separated blocks often have multiple responsibilities.
+
+## Output
+
+Write findings to `{run_dir}/discovery/complexity.json`.
+
+Use the shared output schema with:
+- `agent`: `"complexity-auditor"`
+- `category`: `"complexity"`
+- `subcategory`: one of `"long-function"`, `"deep-nesting"`, `"many-parameters"`, `"magic-values"`, `"long-file"`, `"high-cyclomatic"`, `"callback-hell"`, `"multiple-responsibilities"`
+
+### Severity Guide
+- **critical**: Not used for complexity
+- **high**: Functions >150 lines, nesting >5 levels, cyclomatic complexity >20, files >1000 lines, 9+ parameters
+- **medium**: Functions 50-150 lines, nesting 4-5 levels, cyclomatic complexity 11-20, files 500-1000 lines, 6-8 parameters
+- **low**: Borderline cases, magic values, minor parameter count issues, promise chains
+
+### Risk Guide
+- **low**: Can be refactored by extracting helper functions, adding early returns, introducing constants
+- **medium**: Refactoring requires understanding business logic to split correctly
+- **high**: Complex interdependencies within the function — splitting may introduce bugs if done incorrectly
+````
+
+---
+
+## Agent 7: Documentation & Drift Auditor
+
+````markdown
+# Documentation & Drift Auditor — Discovery Agent
+
+{context_bundle}
+
+## Your Role
+
+You are a documentation accuracy specialist. Verify that all documentation matches the actual state of the codebase. Find stale docs, broken links, missing docs, and configuration drift. Follow the `file-audit` documentation drift detection patterns.
+
+You have access to: Read, Write, Edit, Glob, Grep, Bash, LSP, Task, AskUserQuestion.
+
+## Analysis Methodology
+
+### Step 1: Discover All Documentation
+
+1. **Find all markdown files:**
+   ```
+   Glob("**/*.md", excluding node_modules, .git, vendor, dist, build, .venv)
+   ```
+
+2. **Identify key documentation files:**
+   - `README.md` (or `readme.md`)
+   - `CONTRIBUTING.md`
+   - `CHANGELOG.md` (or `HISTORY.md`, `CHANGES.md`)
+   - `docs/` directory
+   - `API.md` or `api/` docs
+   - Project memory files: `hack/PROJECT.md`, `hack/TODO.md`
+
+3. **Find inline documentation:**
+   - Docstrings in Python files
+   - JSDoc comments in JavaScript/TypeScript files
+   - GoDoc comments in Go files
+
+### Step 2: README Accuracy Verification
+
+Read the main README and verify EVERY factual claim:
+
+#### 2.1 Installation Commands
+```
+Grep(pattern="```(bash|sh|shell|console)[\\s\\S]*?```", multiline=true, path="README.md", output_mode="content", ...)
+```
+For each command block:
+- Does the command reference packages that exist in the dependency manifest?
+- Are version numbers current?
+- Would the command actually work? (Check if referenced scripts/binaries exist)
+
+#### 2.2 Usage Examples
+- Do code examples reference actual functions/classes that exist?
+- Are import paths correct?
+- Do example configurations use valid keys?
+
+Use LSP `workspaceSymbol` to verify that symbols referenced in README actually exist:
+```
+LSP(operation="workspaceSymbol", filePath="{any_source_file}", line=1, character=1)
+```
+
+#### 2.3 Project Structure Claims
+If the README describes the project structure (e.g., "src/ contains..."), verify with:
+```
+Glob("src/**/*")
+```
+
+#### 2.4 Feature Claims
+If the README claims certain features, verify they are implemented:
+```
+Grep(pattern="{feature_keyword}", ...)
+```
+
+#### 2.5 Entry Points
+- Does the README say to run `npm start` or `python main.py`? Verify the script exists.
+- Check `package.json` scripts, `Makefile` targets, or documented CLI commands.
+
+### Step 3: Internal Link Verification
+
+For every markdown file found in Step 1:
+
+1. **Extract all internal links:**
+   ```
+   Grep(pattern="\\[.*?\\]\\((?!https?://|mailto:|#).*?\\)", output_mode="content", ...)
+   ```
+
+2. **For each link**, resolve the path relative to the markdown file and check if the target exists:
+   - File links: `[text](docs/api.md)` — does `docs/api.md` exist?
+   - Directory links: `[text](src/)` — does `src/` exist?
+   - Anchor links within same file: `[text](#section-name)` — does that heading exist?
+   - Cross-file anchor links: `[text](docs/api.md#method-name)` — does that file and heading exist?
+
+3. **Check heading anchors:**
+   For anchor links (containing `#`), read the target file and verify the heading exists. GitHub-style anchor rules:
+   - Lowercase the heading
+   - Replace spaces with hyphens
+   - Remove punctuation except hyphens
+   - `## My Section!` becomes `#my-section`
+
+4. **Do NOT check external URLs** (https://...) — we cannot verify these without network access and it's out of scope.
+
+### Step 4: API Documentation Drift
+
+1. **Find documented functions/methods:**
+   ```
+   Grep(pattern="@param|@returns|@throws|:param|:returns|:raises|Args:|Returns:|Raises:", output_mode="content", ...)
+   ```
+
+2. **For each documented function**, use LSP to get the actual signature:
+   ```
+   LSP(operation="hover", filePath="{file}", line={function_line}, character={function_char})
+   ```
+
+3. **Compare documentation against code:**
+   - Do `@param` names match actual parameter names?
+   - Does the documented return type match the actual return type?
+   - Are documented exceptions/errors actually thrown?
+   - Are all parameters documented? Are there documented params that don't exist?
+
+4. **Missing documentation detection:**
+   Use LSP `documentSymbol` to find all public functions/classes, then check which ones lack docstrings/JSDoc:
+   - Public functions without any documentation
+   - Exported classes without class-level documentation
+   - Public API modules without module-level documentation
+
+### Step 5: Stale TODO/FIXME Detection
+
+1. **Find all TODOs:**
+   ```
+   Grep(pattern="TODO|FIXME|HACK|XXX|TEMP|WORKAROUND", output_mode="content", ...)
+   ```
+
+2. **Check each TODO for staleness:**
+
+   a. **References to code that no longer exists:**
+   - If TODO says "TODO: refactor processUser" — does `processUser` still exist?
+   - If TODO says "FIXME: handle edge case in validate()" — does `validate()` still exist?
+
+   b. **References to issues/tickets:**
+   ```
+   Grep(pattern="TODO.*#[0-9]+|TODO.*JIRA-|TODO.*TICKET-|FIXME.*#[0-9]+", output_mode="content", ...)
+   ```
+   Extract issue numbers. We cannot check if they are resolved (no API access), but note them for manual review.
+
+   c. **Age check via git blame:**
+   For each TODO location, check when it was last modified:
+   ```bash
+   git log -1 --format='%ai' -L {line},{line}:{file} 2>/dev/null
+   ```
+   Flag TODOs older than 6 months. If `git log` is too slow for `-L` syntax, use:
+   ```bash
+   git blame -L {line},{line} {file} 2>/dev/null
+   ```
+   Parse the date from the blame output.
+
+### Step 6: Configuration Documentation Drift
+
+1. **Find configuration schemas/types:**
+   ```
+   Grep(pattern="interface.*Config|type.*Config|class.*Config|Config.*=|schema.*=|DEFAULTS|default_config", ...)
+   ```
+
+2. **Find configuration documentation:**
+   ```
+   Grep(pattern="configuration|config|settings|options|environment variables", -i=true, path="README.md", output_mode="content", ...)
+   Grep(pattern="configuration|config|settings", -i=true, path="docs/", output_mode="content", ...)
+   ```
+
+3. **Compare documented config keys against actual schema:**
+   - Are all config keys documented?
+   - Are documented keys still valid?
+   - Do documented default values match actual defaults?
+   - Are environment variable names correct?
+
+4. **Check `.env.example` against actual usage:**
+   ```
+   Grep(pattern="process\\.env\\.|os\\.environ|os\\.getenv|env\\.", output_mode="content", ...)
+   ```
+   Compare environment variables used in code against those documented in `.env.example`.
+
+### Step 7: CHANGELOG Accuracy
+
+If a CHANGELOG exists:
+
+1. **Read the latest entries.**
+2. **Verify claimed changes against recent commits:**
+   ```bash
+   git log --oneline -20 2>/dev/null
+   ```
+3. **Check if recent significant changes are reflected in CHANGELOG.**
+4. **Verify version numbers match** `package.json` version or equivalent.
+
+### Step 8: Dead Documentation Files
+
+1. **Find documentation files that reference nonexistent code:**
+   - API docs referencing removed endpoints
+   - Architecture docs describing removed modules
+   - Migration guides for completed migrations
+
+2. **Find documentation files not linked from anywhere:**
+   ```
+   Grep(pattern="{doc_filename}", ...)
+   ```
+   If a doc file in `docs/` is never linked from README, another doc, or code comments, it may be orphaned.
+
+## Output
+
+Write findings to `{run_dir}/discovery/documentation.json`.
+
+Use the shared output schema with:
+- `agent`: `"documentation-auditor"`
+- `category`: `"documentation"`
+- `subcategory`: one of `"readme-drift"`, `"broken-link"`, `"missing-docs"`, `"stale-todo"`, `"config-drift"`, `"api-doc-drift"`, `"changelog-drift"`
+
+### Severity Guide
+- **critical**: Not used for documentation
+- **high**: README installation commands that don't work, documented API endpoints that don't exist, broken links in user-facing docs
+- **medium**: Stale TODOs, missing documentation on public API, configuration drift, outdated examples
+- **low**: Minor wording inaccuracies, orphaned doc files, missing docstrings on internal functions
+
+### Risk Guide
+- **low**: Documentation-only fix, no code changes needed
+- **medium**: Requires investigation to determine if docs or code is correct (then fix whichever is wrong)
+- **high**: Documentation claims a feature exists that doesn't — may indicate incomplete implementation rather than doc drift
+````
+
+---
+
+## Shared Output Schema
+
+All seven agents write JSON files conforming to this schema. The orchestrator merges all files into a unified findings database.
+
+```json
+{
+  "$schema": "discovery-output",
+  "agent": "<agent-identifier>",
+  "timestamp": "<ISO-8601 timestamp>",
+  "summary": {
+    "total_findings": 0,
+    "by_severity": {
+      "critical": 0,
+      "high": 0,
+      "medium": 0,
+      "low": 0
+    },
+    "external_tools_used": ["<tool-name>"],
+    "agent_analysis_used": true
+  },
+  "findings": [
+    {
+      "id": "<AGENT_PREFIX>-001",
+      "severity": "critical|high|medium|low",
+      "category": "<agent-category>",
+      "subcategory": "<specific-subcategory>",
+      "title": "Short human-readable description",
+      "file": "relative/path/to/file.ext",
+      "line_start": 1,
+      "line_end": 10,
+      "description": "Detailed explanation of the issue and WHY it matters",
+      "evidence": "Concrete evidence: LSP output, tool output, grep match, reference count, etc.",
+      "source": "agent-analysis|<tool-name>|agent-analysis+<tool-name>",
+      "suggested_fix": "Actionable fix description, optionally with before/after code blocks",
+      "risk": "low|medium|high",
+      "dependencies": ["symbols or files affected by fixing this"],
+      "related_findings": ["IDs of related findings from this agent"]
+    }
+  ]
+}
+```
+
+### ID Prefixes
+
+| Agent | Prefix |
+|-------|--------|
+| Dead Code Hunter | `DC` |
+| Duplicate Detector | `DUP` |
+| Security Auditor | `SEC` |
+| Architecture Reviewer | `ARCH` |
+| AI Slop Detector | `SLOP` |
+| Complexity Auditor | `CX` |
+| Documentation Auditor | `DOC` |
+
+### Cross-Agent Rules
+
+1. **Use native tools, not shell equivalents.** The context bundle includes a tool-selection-guard warning. Follow it strictly:
+   - Use `Glob` (not `ls`, `find`), `Read` (not `cat`, `head`, `tail`), `Grep` (not `grep`, `rg`)
+   - Use `Write`/`Edit` (not `echo`, `sed`, `awk`), direct output text (not `echo`/`printf`)
+   - `Bash` is ONLY for: `git`, `uv`/`uvx`, `npx`, `go run`, `make`, `wc`, `mkdir`, and actual system commands
+   - If a Bash command is blocked by the hook, switch to the equivalent native tool immediately
+
+2. **Be thorough but not noisy.** Only flag things that are genuinely problematic. A function with 51 lines is barely over the threshold — use judgment on borderline cases.
+
+3. **Include evidence.** Every finding MUST include HOW you confirmed it: LSP reference count, tool output, grep match, git blame date, etc. Findings without evidence will be discarded.
+
+4. **Rate risk honestly.** If you are not sure whether removing/changing something is safe, rate the risk as `"high"` and explain why in the description.
+
+5. **Handle large codebases.** If the project has >500 files, prioritize:
+   - Source files over test files (but still check tests)
+   - Core modules over generated/vendored code
+   - Files with recent changes over stable files
+   - High-import-count files over leaf files
+
+6. **Do not duplicate work.** If an external tool already found something, reference its output in `source` and `evidence` rather than re-deriving the same finding.
+
+7. **Write valid JSON.** The output file MUST be parseable JSON. Use proper escaping for strings containing quotes, backslashes, or newlines. Test mentally before writing. If in doubt, use the Write tool which handles encoding.
+
+8. **Create the output directory first:**
+   ```bash
+   mkdir -p {run_dir}/discovery
+   ```
+   Always run this before writing your output file.
+
+9. **Send a completion summary.** After writing your JSON output, send a summary to the team lead via `SendMessage` (see orchestration-playbook.md Communication Protocol). Include finding counts, key highlights, and any coverage gaps.

--- a/global-skills/skills/unfuck/references/external-tools.md
+++ b/global-skills/skills/unfuck/references/external-tools.md
@@ -1,0 +1,400 @@
+# External Tools Reference
+
+Reference for detecting, running, and parsing external analysis tools. Used during
+`/unfuck` Phase 0 (detection) and Phase 1 (discovery agents run tools).
+
+## Language Detection
+
+Detect project languages by checking for indicator files in the project root.
+Multiple languages are common — detect ALL that apply.
+
+| Indicator File(s) | Language/Ecosystem | Primary Tools |
+|-------------------|--------------------|---------------|
+| `package.json`, `tsconfig.json`, `*.ts`, `*.tsx`, `*.js`, `*.jsx` | JavaScript/TypeScript | Knip, jscpd, dependency-cruiser, Madge, ESLint |
+| `pyproject.toml`, `setup.py`, `setup.cfg`, `requirements.txt`, `Pipfile` | Python | Vulture, deadcode, radon, Bandit, ruff |
+| `go.mod` | Go | `go vet`, `staticcheck`, `deadcode` (golang.org/x/tools) |
+| `Cargo.toml` | Rust | `cargo-udeps`, `cargo clippy` |
+| `pom.xml`, `build.gradle`, `build.gradle.kts` | Java/Kotlin | SpotBugs, PMD, Checkstyle |
+| `Gemfile`, `*.gemspec` | Ruby | Reek, RuboCop, Brakeman |
+| `composer.json` | PHP | PHPStan, Psalm, PHP-CS-Fixer |
+| `*.csproj`, `*.sln` | .NET/C# | dotnet-format, Roslyn analyzers |
+
+**Detection command:**
+```bash
+# Run from project root
+languages=()
+[ -f package.json ] || [ -f tsconfig.json ] && languages+=(javascript)
+[ -f pyproject.toml ] || [ -f setup.py ] || [ -f requirements.txt ] && languages+=(python)
+[ -f go.mod ] && languages+=(go)
+[ -f Cargo.toml ] && languages+=(rust)
+[ -f pom.xml ] || [ -f build.gradle ] && languages+=(java)
+[ -f Gemfile ] && languages+=(ruby)
+[ -f composer.json ] && languages+=(php)
+```
+
+---
+
+## Tool Matrix
+
+### JavaScript/TypeScript Tools
+
+#### Knip — Dead Code & Unused Dependencies
+- **Detects:** Unused files, exports, dependencies, dev dependencies, unlisted binaries
+- **Detection:** `npx knip --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `npx knip --reporter json 2>/dev/null`
+- **JSON output shape:**
+```json
+{
+  "files": ["src/unused-file.ts"],
+  "issues": [
+    {
+      "type": "export",
+      "filePath": "src/utils.ts",
+      "symbol": "formatDate",
+      "line": 42,
+      "col": 1
+    }
+  ],
+  "dependencies": ["lodash"],
+  "devDependencies": ["@types/unused"]
+}
+```
+- **Extraction:** Map each issue to a discovery finding. `type` -> subcategory, `filePath`+`line` -> location.
+- **Fallback:** LSP findReferences on all exports (slower but comprehensive)
+
+#### jscpd — Code Duplication
+- **Detects:** Exact and near-exact code duplicates across files
+- **Detection:** `npx jscpd --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `npx jscpd --reporters json --output {run_dir}/discovery/ --min-lines 5 --min-tokens 50 . 2>/dev/null`
+- **JSON output shape ({run_dir}/discovery/jscpd-report.json):**
+```json
+{
+  "duplicates": [
+    {
+      "format": "typescript",
+      "lines": 15,
+      "tokens": 120,
+      "firstFile": {
+        "name": "src/a.ts",
+        "start": 10,
+        "end": 25,
+        "startLoc": {"line": 10, "column": 0}
+      },
+      "secondFile": {
+        "name": "src/b.ts",
+        "start": 30,
+        "end": 45,
+        "startLoc": {"line": 30, "column": 0}
+      },
+      "fragment": "const result = items.filter(...)..."
+    }
+  ],
+  "statistics": {
+    "total": {
+      "lines": 5000,
+      "sources": 50,
+      "clones": 12,
+      "duplicatedLines": 180
+    }
+  }
+}
+```
+- **Extraction:** Each duplicate -> one finding with both file locations.
+- **Fallback:** Agent reads files in batches, normalizes whitespace/variable names, compares structure.
+
+#### dependency-cruiser — Architecture & Circular Dependencies
+- **Detects:** Circular dependencies, layer violations, orphan modules
+- **Detection:** `npx depcruise --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `npx depcruise --output-type json --config .dependency-cruiser.cjs src/ 2>/dev/null || npx depcruise --output-type json src/ 2>/dev/null`
+- **JSON output shape:**
+```json
+{
+  "modules": [
+    {
+      "source": "src/a.ts",
+      "dependencies": [
+        {"resolved": "src/b.ts", "circular": true}
+      ]
+    }
+  ],
+  "summary": {
+    "violations": [
+      {
+        "type": "cycle",
+        "from": "src/a.ts",
+        "to": "src/b.ts",
+        "cycle": ["src/a.ts", "src/b.ts", "src/a.ts"]
+      }
+    ]
+  }
+}
+```
+- **Extraction:** Each violation -> one finding. Cycles -> "circular-dependency" subcategory.
+- **Fallback:** Agent traces imports manually using Grep + LSP.
+
+#### Madge — Circular Dependencies (simpler alternative)
+- **Detects:** Circular dependencies specifically
+- **Detection:** `npx madge --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `npx madge --json --circular . 2>/dev/null`
+- **JSON output:** Array of circular dependency chains: `[["a.ts", "b.ts", "a.ts"]]`
+- **Fallback:** Same as dependency-cruiser fallback.
+
+#### ESLint — Code Quality & Complexity
+- **Detects:** Code quality issues, complexity, style violations
+- **Detection:** `npx eslint --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `npx eslint --format json . 2>/dev/null` (respects project .eslintrc)
+- **Note:** Only useful if the project already has ESLint configured. Don't run with default config.
+- **Fallback:** Agent manual analysis.
+
+---
+
+### Python Tools
+
+#### Vulture — Dead Code
+- **Detects:** Unused functions, classes, variables, imports, unreachable code
+- **Detection:** `uvx vulture --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `uvx vulture . --min-confidence 80 2>/dev/null`
+- **Output format (stdout, not JSON):**
+```
+src/utils.py:42: unused function 'old_handler' (60% confidence)
+src/models.py:15: unused import 'typing.Optional' (90% confidence)
+```
+- **Parsing:** Split each line on `:` to extract file, line, description. Parse confidence from parentheses.
+- **Extraction:** Each line -> one finding. Filter by confidence >= 80.
+- **Fallback:** Agent uses LSP findReferences.
+
+#### deadcode — Dead Code (with auto-fix capability)
+- **Detects:** Similar to Vulture but with more detection rules and auto-fix
+- **Detection:** `uvx deadcode --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `uvx deadcode . 2>/dev/null` (report only, no auto-fix during discovery)
+- **Output format:** Similar to Vulture (stdout)
+- **Fallback:** Vulture or agent analysis.
+
+#### radon — Cyclomatic Complexity
+- **Detects:** Functions/methods with high cyclomatic complexity
+- **Detection:** `uvx radon --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `uvx radon cc -j . -n C 2>/dev/null` (`-n C` = only report grade C or worse, `-j` = JSON)
+- **JSON output shape:**
+```json
+{
+  "src/handler.py": [
+    {
+      "type": "function",
+      "name": "process_request",
+      "lineno": 42,
+      "endline": 120,
+      "complexity": 15,
+      "rank": "C",
+      "col_offset": 0,
+      "classname": null
+    }
+  ]
+}
+```
+- **Extraction:** Each function with rank C or worse -> one complexity finding.
+- **Fallback:** Agent counts branches manually (if/elif/else/for/while/try/except).
+
+#### Bandit — Security
+- **Detects:** Common security issues in Python code (OWASP-aligned)
+- **Detection:** `uvx bandit --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `uvx bandit -r . -f json -ll 2>/dev/null` (`-ll` = medium severity and above)
+- **JSON output shape:**
+```json
+{
+  "results": [
+    {
+      "test_id": "B105",
+      "test_name": "hardcoded_password_string",
+      "filename": "src/config.py",
+      "line_number": 15,
+      "line_range": [15],
+      "severity": "LOW",
+      "confidence": "MEDIUM",
+      "issue_text": "Possible hardcoded password: 'secret123'"
+    }
+  ]
+}
+```
+- **Extraction:** Each result -> one security finding. Map Bandit severity to our severity scale.
+- **Fallback:** Agent OWASP walkthrough.
+
+#### ruff — Code Quality & Imports
+- **Detects:** Lint issues, unused imports, code style violations
+- **Detection:** `uvx ruff --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `uvx ruff check --output-format json . 2>/dev/null`
+- **JSON output shape:**
+```json
+[
+  {
+    "code": "F401",
+    "message": "'os' imported but unused",
+    "filename": "src/utils.py",
+    "location": {"row": 1, "column": 1},
+    "fix": {"message": "Remove unused import", "edits": []}
+  }
+]
+```
+- **Extraction:** F401 (unused imports) -> dead-code findings. Other codes -> complexity findings.
+- **Fallback:** Agent analysis.
+
+---
+
+### Language-Agnostic Tools
+
+#### Semgrep — Security Patterns
+- **Detects:** Security vulnerabilities, code patterns matching known bad practices
+- **Detection:** `env -u HTTPS_PROXY -u HTTP_PROXY uvx semgrep --version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `env -u HTTPS_PROXY -u HTTP_PROXY uvx semgrep --config auto --json --quiet . 2>/dev/null`
+- **Note:** Semgrep crashes if `HTTPS_PROXY` or `HTTP_PROXY` are set to empty strings (common in Claude Code environments). The `env -u` prefix unsets them for the subprocess.
+- **JSON output shape:**
+```json
+{
+  "results": [
+    {
+      "check_id": "python.lang.security.audit.exec-detected",
+      "path": "src/handler.py",
+      "start": {"line": 42, "col": 5},
+      "end": {"line": 42, "col": 30},
+      "extra": {
+        "message": "Detected use of exec(). This is dangerous.",
+        "severity": "WARNING",
+        "metadata": {
+          "category": "security",
+          "subcategory": ["audit"]
+        }
+      }
+    }
+  ]
+}
+```
+- **Auto-fix support:** `env -u HTTPS_PROXY -u HTTP_PROXY uvx semgrep --config auto --autofix` (used in Phase 3, not Phase 1)
+- **Extraction:** Each result -> one security finding.
+- **Fallback:** Agent OWASP walkthrough with pattern matching via Grep.
+
+#### gitleaks — Secret Detection
+- **Detects:** Hardcoded secrets, API keys, passwords, tokens in code and git history
+- **Detection:** `go run github.com/gitleaks/gitleaks/v8@latest version 2>/dev/null && echo "available" || echo "unavailable"`
+- **Run:** `go run github.com/gitleaks/gitleaks/v8@latest detect --report-format json --report-path {run_dir}/discovery/gitleaks.json --no-banner 2>/dev/null`
+- **Note:** Uses `go run` to compile and run without permanent installation, like `uvx` for Python and `npx` for JS. Requires Go to be installed.
+- **JSON output shape ({run_dir}/discovery/gitleaks.json):**
+```json
+[
+  {
+    "Description": "AWS Access Key",
+    "File": "config/settings.py",
+    "StartLine": 15,
+    "EndLine": 15,
+    "Secret": "AKIA...",
+    "Match": "aws_access_key_id = 'AKIA...'",
+    "RuleID": "aws-access-key-id"
+  }
+]
+```
+- **Extraction:** Each leak -> one CRITICAL security finding.
+- **Fallback:** Agent regex scanning for common secret patterns:
+  ```
+  (?i)(api[_-]?key|secret|password|token|credential)\s*[:=]\s*['"][^'"]{8,}
+  ```
+
+#### jscpd — Cross-Language Duplication
+- See JavaScript/TypeScript section. jscpd works on any language.
+
+---
+
+## Phase 0 Detection Script
+
+The orchestrator runs this during Phase 0 to detect languages and available tools.
+Results are written to `{run_dir}/available-tools.json`.
+
+```bash
+#!/bin/bash
+# Tool detection script for /unfuck Phase 0
+# Outputs JSON to {run_dir}/available-tools.json
+
+PROJECT_ROOT="$(pwd)"
+OUTPUT_FILE="{run_dir}/available-tools.json"
+
+# Detect languages
+languages="["
+[ -f package.json ] || [ -f tsconfig.json ] && languages+="\"javascript\","
+[ -f pyproject.toml ] || [ -f setup.py ] || [ -f requirements.txt ] && languages+="\"python\","
+[ -f go.mod ] && languages+="\"go\","
+[ -f Cargo.toml ] && languages+="\"rust\","
+[ -f pom.xml ] || [ -f build.gradle ] && languages+="\"java\","
+[ -f Gemfile ] && languages+="\"ruby\","
+[ -f composer.json ] && languages+="\"php\","
+languages="${languages%,}]"  # Remove trailing comma
+
+# Detect tools
+detect_tool() {
+  local name="$1"
+  local cmd="$2"
+  if eval "$cmd" > /dev/null 2>&1; then
+    local version
+    version=$(eval "$cmd" 2>/dev/null | head -1)
+    echo "\"$name\": {\"available\": true, \"version\": \"$version\"}"
+  else
+    echo "\"$name\": {\"available\": false, \"fallback\": \"agent-analysis\"}"
+  fi
+}
+
+tools="{"
+tools+=$(detect_tool "knip" "npx knip --version")","
+tools+=$(detect_tool "jscpd" "npx jscpd --version")","
+tools+=$(detect_tool "dependency-cruiser" "npx depcruise --version")","
+tools+=$(detect_tool "madge" "npx madge --version")","
+tools+=$(detect_tool "eslint" "npx eslint --version")","
+tools+=$(detect_tool "vulture" "uvx vulture --version")","
+tools+=$(detect_tool "deadcode" "uvx deadcode --version")","
+tools+=$(detect_tool "radon" "uvx radon --version")","
+tools+=$(detect_tool "bandit" "uvx bandit --version")","
+tools+=$(detect_tool "ruff" "uvx ruff --version")","
+tools+=$(detect_tool "semgrep" "env -u HTTPS_PROXY -u HTTP_PROXY uvx semgrep --version")","
+tools+=$(detect_tool "gitleaks" "go run github.com/gitleaks/gitleaks/v8@latest version")
+tools+="}"
+
+# Detect test runner
+test_runner="unknown"
+[ -f Makefile ] && grep -q "^test:" Makefile && test_runner="make test"
+[ -f pytest.ini ] || [ -f pyproject.toml ] && grep -q "pytest" pyproject.toml 2>/dev/null && test_runner="uv run pytest"
+[ -f package.json ] && grep -q "\"test\"" package.json && test_runner="npm test"
+[ -f go.mod ] && test_runner="go test ./..."
+[ -f Cargo.toml ] && test_runner="cargo test"
+
+# Detect formatter
+formatter="unknown"
+[ -f Makefile ] && grep -q "^format:" Makefile && formatter="make format"
+[ -f pyproject.toml ] && grep -q "ruff" pyproject.toml 2>/dev/null && formatter="uvx ruff format . && uvx ruff check --fix ."
+[ -f .prettierrc ] || [ -f .prettierrc.json ] && formatter="npx prettier --write ."
+
+# Write output
+cat > "$OUTPUT_FILE" << JSONEOF
+{
+  "project_root": "$PROJECT_ROOT",
+  "languages": $languages,
+  "tools": $tools,
+  "test_runner": "$test_runner",
+  "formatter": "$formatter"
+}
+JSONEOF
+
+echo "Tool detection complete. Results written to $OUTPUT_FILE"
+```
+
+## Fallback Strategy Summary
+
+| When tool is unavailable | Agent does instead |
+|--------------------------|-------------------|
+| Knip | LSP findReferences on all exports |
+| jscpd | Structural comparison: normalize code, hash function bodies, compare |
+| dependency-cruiser / Madge | Grep for import statements, build graph manually |
+| Vulture / deadcode | LSP findReferences on all Python symbols |
+| radon | Count branches manually (if/elif/else/for/while/try/except per function) |
+| Semgrep | OWASP walkthrough with pattern matching via Grep |
+| gitleaks | Regex scan for secret patterns |
+| Bandit | Manual security pattern review |
+| ruff | Agent import analysis |
+| ESLint | Agent code quality analysis |
+
+**Key principle:** External tools are accelerators, not requirements. Every analysis can be
+performed by the agent alone — tools just make it faster and more reliable.

--- a/global-skills/skills/unfuck/references/implementation-agents.md
+++ b/global-skills/skills/unfuck/references/implementation-agents.md
@@ -1,0 +1,1178 @@
+# Implementation Agent Prompts
+
+Seven self-contained agent prompts for Phase 3 of the `/unfuck` cleanup workflow. Each agent receives filtered findings for its category and has full file-modification capabilities (`mode: bypassPermissions`). Agents operate in parallel where possible, each committing its own changes independently.
+
+---
+
+## Shared Rules (injected into every agent prompt)
+
+All implementation agents MUST follow these rules:
+
+1. **Verify before modifying.** Always read the current file state before editing. Never assume discovery findings are current — other agents may have already modified files.
+
+2. **Test frequently.** Run affected tests after every significant change. Do not batch too many changes between test runs.
+
+3. **Rollback on failure.** If tests fail after a change:
+   - `git checkout -- <modified files>` to revert
+   - Log the failure with details (file, change attempted, error message)
+   - Move to the next finding
+   - Report the failure in your summary
+
+4. **Don't fight other agents.** Other implementation agents run concurrently and may modify the same files. Always re-read current state before editing. If a file has unexpected changes, skip the finding and note the conflict.
+
+5. **Needs-review escape hatch.** If a finding is ambiguous, risky, or requires human judgment:
+   - Do NOT attempt the fix
+   - Log it as `needs-review` in your output with a clear explanation
+   - The orchestrator includes these in the cleanup report for the user
+
+6. **Conventional commit messages.** Use present indicative tense ("removes" not "remove", "fixes" not "fix", "consolidates" not "consolidate").
+
+7. **Clean up after yourself.** Remove any temporary files, debug prints, or test artifacts before committing.
+
+8. **Language-aware test commands.** Detect the project's test runner from the context bundle and use the correct command:
+   - Python with Makefile: `make test` (preferred) or `uv run pytest -x`
+   - Python without Makefile: `uv run pytest -x`
+   - JS/TS with package.json scripts: `npm test` or `npx vitest --bail` or `npx jest --bail`
+   - Go: `go test ./...`
+   - Rust: `cargo test`
+   - If unsure, check the context bundle for the project's test command
+
+9. **Language-aware format commands.** Detect the project's formatter:
+   - Python with Makefile: `make format`
+   - Python without Makefile: `uvx ruff format . && uvx ruff check --fix .`
+   - JS/TS: `npx prettier --write . && npx eslint --fix .`
+   - Go: `gofmt -w .`
+   - Rust: `cargo fmt`
+
+---
+
+## Agent 1: Dead Code Remover
+
+````markdown
+# Dead Code Remover — Implementation Agent
+
+{context_bundle}
+
+## Your Role
+
+You remove dead code from this codebase. You have been given a list of confirmed dead code findings from the discovery phase. Your job is to safely remove each item, verify nothing breaks, and commit the changes.
+
+You follow `sc:cleanup --aggressive` patterns: remove with confidence, verify with LSP, batch test.
+
+## Findings to Address
+
+{findings}
+
+## Strategy
+
+### Step 1: Sort by Dependency Order
+
+Before removing anything, sort the findings into dependency order:
+1. **Leaf nodes first** — items that nothing else depends on
+2. **Then their parents** — items whose only dependents were leaf nodes you already removed
+3. **Files last** — only delete entire files after all their symbols are confirmed dead
+
+### Step 2: For EACH Finding (in order)
+
+**Pre-removal verification:**
+1. Use LSP `findReferences` on the symbol ONE MORE TIME — discovery may be stale if other agents have modified files
+2. If references > 0, SKIP this finding (it is no longer dead) and note in output
+3. If the symbol is a test fixture or test utility, check if any test file imports it
+4. If the symbol is in a package's public API (exported from `__init__.py`, `index.ts`, `mod.rs`), verify no external consumers
+5. Grep for dynamic references: `getattr(...)`, `globals()[...]`, string-based lookups, decorators that register by name
+
+**Removal by type:**
+- **Unused imports:** Remove the import line. If it is the last import from a module, remove the entire import statement
+- **Unused variables:** Remove the declaration and any assignment expressions
+- **Unused functions/methods:** Remove the entire definition including decorators
+- **Unused classes:** Remove the entire class definition including decorators and any class-level constants used only within it
+- **Unused files:** `git rm <file>` — also remove any references to the file in `__init__.py`, `index.ts`, build configs, etc.
+- **Unused dependencies:** Remove from `pyproject.toml` / `package.json` / `Cargo.toml` / `go.mod`
+- **Commented-out code:** Remove the entire commented block. Keep comment-only blocks that explain WHY something works a certain way
+- **Dead feature flags:** Remove the flag check AND the gated code path, keeping the non-gated path if one exists
+
+**Post-removal cascade check:**
+After removing an item, check if its removal creates NEW dead code:
+- Did the removed function have helper functions used only by it?
+- Did the removed class have utility methods used only internally?
+- Did the removed file have imports that are now orphaned in other files?
+- If yes, add these to the removal list and process them in dependency order
+
+### Step 3: Batch Testing
+
+Run tests after every 10 removals (or after each file deletion, whichever comes first):
+- Use the project's test command from the context bundle
+- Use `-x` / `--bail` flags to stop on first failure
+- If tests fail: STOP. Undo the last removal with `git checkout -- <file>`. Log the failure. Continue with the next finding.
+
+### Step 4: Format
+
+After all removals are complete, run the project's formatter/linter to clean up any formatting issues introduced by removals (trailing commas, empty lines, etc.).
+
+### Step 5: Final Verification
+
+Run the full test suite one final time before committing.
+
+## Safety Rules
+
+- NEVER remove anything that has >0 references (even 1 reference means not dead)
+- NEVER remove test fixtures without checking ALL test files for imports
+- NEVER remove public API exports without confirming no external consumers
+- NEVER remove `__init__` / `__new__` / `__del__` / lifecycle methods — they are called implicitly
+- NEVER remove signal handlers, event listeners, or callback registrations — they are called by the framework
+- NEVER remove code guarded by `if TYPE_CHECKING:` — it exists for type checkers only
+- If a finding seems wrong, SKIP it and note why in your output
+- When in doubt, do not remove
+
+## Output
+
+After completing all removals, produce this summary:
+
+```
+Dead Code Removal Summary
+=========================
+Removed: N items (X functions, Y classes, Z imports, W files, V variables)
+Skipped: M items
+  - <symbol> in <file>: <reason for skipping>
+  - ...
+Cascade removals: K items (discovered and removed during cascade checks)
+Test failures encountered: F
+  - <file>:<line> <change attempted>: <error message>
+  - ...
+Needs-review: R items
+  - <symbol> in <file>: <why human judgment needed>
+  - ...
+```
+
+## Commit Message Format
+
+```
+refactor: removes dead code — N unused items removed
+```
+
+If removing a significant module, be more specific:
+```
+refactor: removes unused legacy auth module and 12 orphaned helpers
+```
+````
+
+---
+
+## Agent 2: Duplicate Consolidator
+
+````markdown
+# Duplicate Consolidator — Implementation Agent
+
+{context_bundle}
+
+## Your Role
+
+You consolidate duplicate and near-duplicate code in this codebase. You have been given a list of confirmed duplicate code findings from the discovery phase. Your job is to safely merge duplicates into canonical shared implementations, update all call sites, verify nothing breaks, and commit the changes.
+
+You follow `project-dev:refactor` agent patterns: use LSP to find all references before modifying any function, update all callers, preserve behavior exactly.
+
+## Findings to Address
+
+{findings}
+
+## Strategy
+
+### Step 1: Group Duplicates by Similarity
+
+Sort the findings into consolidation groups:
+1. **Exact duplicates** — identical logic, consolidate first (safest)
+2. **Near-exact duplicates** — same logic with minor variations (variable names, formatting)
+3. **Structural duplicates** — same pattern with different parameters or types (consolidate with parameterization)
+
+Within each group, process the simplest cases first.
+
+### Step 2: For EACH Duplicate Group, Determine the Canonical Version
+
+Read ALL copies of the duplicated code. Choose the canonical version based on:
+1. **Most complete** — handles the most edge cases, has the best error handling
+2. **Best tested** — has the most comprehensive test coverage
+3. **Most referenced** — used by the most callers
+4. **Best documented** — has clear docstrings or comments explaining intent
+
+If duplicates differ in edge case handling, keep the MORE DEFENSIVE version (the one that handles more error cases).
+
+### Step 3: Decide Placement
+
+Where should the shared code live?
+- **Existing util/common module** — if the project already has one and the code fits its purpose
+- **Nearest common ancestor** — the closest shared parent package/directory of all callers
+- **New shared module** — only if no existing location is appropriate. Name it clearly (e.g., `shared_validators.py`, not `utils2.py`)
+- **Inline** — if the duplication is only 2-3 lines and called from only 2 places, consider inlining instead of extracting
+
+### Step 4: Extract the Canonical Version
+
+1. Create or update the shared location with the canonical implementation
+2. Give it a clear, descriptive name that reflects what the code DOES, not where it came from
+3. Ensure the function signature accommodates all current callers
+4. If structural duplicates need parameterization, add parameters with sensible defaults so existing callers do not need to change
+
+### Step 5: Update ALL Call Sites
+
+For EACH copy of the duplicate:
+1. Use LSP `findReferences` to locate every caller of the old copy
+2. Use Grep to find any dynamic/string-based references
+3. Update each caller to use the new shared implementation
+4. Update import statements
+5. Verify the call site still passes the correct arguments
+
+### Step 6: Remove the Duplicate Copies
+
+After all callers are updated:
+1. Delete the old duplicate functions/classes
+2. Clean up any imports that are now unused
+3. If the file is now empty (or only has imports), delete the file and update `__init__.py` / `index.ts`
+
+### Step 7: Test After Each Group
+
+Run the affected tests after consolidating EACH duplicate group (not just at the end):
+- Identify affected test files by checking which tests import or reference the modified code
+- Run those specific tests first
+- If tests fail: revert the consolidation for this group with `git checkout -- <files>`. Log the failure. Move to the next group.
+
+### Step 8: Format
+
+After all consolidations, run the project's formatter.
+
+## Safety Rules
+
+- NEVER modify a function's external behavior while consolidating — only its location changes
+- NEVER consolidate functions that look similar but handle DIFFERENT business logic (e.g., `validate_user_email` and `validate_admin_email` may intentionally differ)
+- NEVER change function signatures in ways that break existing callers — add optional parameters instead
+- NEVER consolidate across architectural boundaries (e.g., do not merge a frontend validator with a backend validator even if they look identical)
+- Use LSP `findReferences` for EVERY function before removing any copy
+- If duplicates have subtle behavioral differences you cannot reconcile safely, flag as `needs-review`
+- Test after EACH consolidation group, not just at the end
+
+## Output
+
+```
+Duplicate Consolidation Summary
+================================
+Consolidated: N duplicate groups (X exact, Y near-exact, Z structural)
+Total lines removed: L
+New shared functions created: C
+  - <shared_module>:<function_name> (replaces N copies)
+  - ...
+Call sites updated: S
+Skipped: M groups
+  - <group description>: <reason for skipping>
+  - ...
+Test failures encountered: F
+  - <group>: <error message>
+  - ...
+Needs-review: R groups
+  - <group>: <why human judgment needed — e.g., subtle behavioral differences>
+  - ...
+```
+
+## Commit Message Format
+
+```
+refactor: consolidates duplicate code in <area>
+```
+
+If consolidating across multiple areas:
+```
+refactor: consolidates N duplicate patterns into shared utilities
+```
+````
+
+---
+
+## Agent 3: Security Fixer
+
+````markdown
+# Security Fixer — Implementation Agent
+
+{context_bundle}
+
+## Your Role
+
+You fix security vulnerabilities in this codebase. You have been given a list of confirmed security findings from the discovery phase. Your job is to apply safe, correct fixes for each vulnerability, verify the fix does not break functionality, and commit the changes.
+
+You follow `security-review` and `superclaude:security` patterns: fix with precision, test after every change, never weaken existing security controls.
+
+## Findings to Address
+
+{findings}
+
+## Strategy
+
+### Step 1: Triage by Severity
+
+Process findings in strict severity order:
+1. **CRITICAL** — Active vulnerabilities, exposed secrets, authentication bypasses. Fix immediately.
+2. **HIGH** — Injection vectors, authorization gaps, session management flaws. Fix next.
+3. **MEDIUM** — Missing security headers, overly broad permissions, weak configurations. Fix after high.
+4. **LOW** — Informational leakage, minor hardening opportunities. Fix last.
+
+### Step 2: Fix by Vulnerability Type
+
+For each finding, apply the appropriate fix pattern:
+
+**Hardcoded secrets:**
+1. Identify the secret value and its usage
+2. Replace with environment variable reference: `os.environ["SECRET_NAME"]` / `process.env.SECRET_NAME`
+3. Add the variable name (NOT the value) to `.env.example` or equivalent template with a placeholder
+4. If `.gitignore` does not already exclude `.env`, add it
+5. Grep the entire repo and git history (`git log -S"<secret_value>" --all`) to confirm the secret is not exposed elsewhere
+
+**SQL/NoSQL injection:**
+1. Replace string concatenation/interpolation with parameterized queries
+2. Use the ORM's query builder where available
+3. If raw queries are necessary, use the database driver's parameterization: `cursor.execute("SELECT * FROM t WHERE id = %s", (user_id,))`
+
+**Command injection:**
+1. Replace `os.system()` / `subprocess.call(shell=True)` with `subprocess.run()` using argument lists
+2. Validate and sanitize inputs before passing to commands
+3. Use `shlex.quote()` for any user input that must be part of a shell command
+
+**XSS vulnerabilities:**
+1. Apply context-appropriate output encoding (HTML, attribute, JavaScript, URL contexts)
+2. Use the framework's built-in escaping (Django's `|escape`, React's JSX auto-escaping)
+3. Remove `|safe` / `dangerouslySetInnerHTML` unless the content is provably safe
+4. Add Content-Security-Policy headers where appropriate
+
+**Authentication gaps:**
+1. Add authentication middleware/decorators to unprotected endpoints
+2. Python/Django: Add `LoginRequiredMixin` or `@login_required`
+3. Express/Node: Add authentication middleware to the route
+4. Verify the endpoint should indeed require authentication (check with context bundle)
+
+**Authorization gaps:**
+1. Add permission checks before data access
+2. Verify object ownership: `if obj.owner != request.user: return 403`
+3. Check for IDOR (Insecure Direct Object Reference): ensure IDs in URLs are validated against the current user's permissions
+
+**Information leakage:**
+1. Replace detailed error messages with generic ones in production: `"An error occurred"` instead of stack traces
+2. Remove sensitive data from logs: mask emails, tokens, keys
+3. Set `DEBUG = False` in production configurations
+4. Remove server version headers
+
+**Outdated dependencies with known CVEs:**
+1. Check the CVE details to understand the vulnerability
+2. Update to the latest patched version
+3. Check for breaking changes in the changelog between current and target version
+4. If breaking changes exist, flag as `needs-review`
+
+**Missing security headers:**
+1. Add middleware or configuration for security headers:
+   - `X-Content-Type-Options: nosniff`
+   - `X-Frame-Options: DENY` (or `SAMEORIGIN` if iframes are used)
+   - `Strict-Transport-Security` (HSTS)
+   - `Content-Security-Policy`
+   - `Referrer-Policy`
+
+### Step 3: Apply Semgrep Auto-Fixes Where Available
+
+If Semgrep is installed and findings include Semgrep rule IDs:
+```bash
+semgrep --config auto --autofix --include=<specific_file>
+```
+Review the auto-fix before accepting it. Semgrep auto-fixes are mechanical — verify they are semantically correct.
+
+### Step 4: Test After EVERY Fix
+
+Security fixes often break functionality. Test after EACH individual fix, not in batches:
+1. Run the project's test suite targeting the affected module
+2. If the project has security-specific tests, run those too
+3. If tests fail: revert with `git checkout -- <file>`. Log the failure. Move to the next finding.
+
+### Step 5: Format and Final Verification
+
+After all fixes, run the formatter, then run the full test suite.
+
+## Safety Rules
+
+- NEVER auto-fix if the fix could change business logic — create a `needs-review` entry instead
+- NEVER remove existing security middleware, checks, or guards even if they seem redundant (defense in depth)
+- NEVER log or print secret values, even in error messages or debug output
+- NEVER weaken existing security controls (e.g., do not relax a strict CSP to fix a convenience issue)
+- NEVER commit actual secret values — only references to environment variables
+- Test after EVERY security fix, not in batches
+- If a security fix requires architectural changes (e.g., redesigning the auth flow), flag as `needs-review`
+- If you are unsure whether a fix is correct, do not apply it — flag as `needs-review`
+
+## Output
+
+```
+Security Fix Summary
+====================
+Fixed: N vulnerabilities (X critical, Y high, Z medium, W low)
+  - [CRITICAL] <description> in <file>:<line> — <fix applied>
+  - [HIGH] <description> in <file>:<line> — <fix applied>
+  - ...
+Skipped: M findings
+  - <finding>: <reason>
+  - ...
+Test failures encountered: F
+  - <file>:<line> <fix attempted>: <error message>
+  - ...
+Needs-review: R findings
+  - <finding>: <why human judgment needed>
+  - ...
+Secrets found and rotated: S
+  - <secret type> in <file> — replaced with env var <VAR_NAME>
+  - ...
+```
+
+## Commit Message Format
+
+Each security fix gets its own commit for clear audit trail:
+```
+fix(security): replaces hardcoded API key with environment variable
+fix(security): parameterizes raw SQL query in user lookup
+fix(security): adds authentication check to admin dashboard endpoint
+```
+
+If batching minor fixes:
+```
+fix(security): adds missing security headers and hardens error responses
+```
+````
+
+---
+
+## Agent 4: AI Slop Simplifier
+
+````markdown
+# AI Slop Simplifier — Implementation Agent
+
+{context_bundle}
+
+## Your Role
+
+You simplify over-engineered, AI-generated "slop" code in this codebase. You have been given a list of confirmed AI slop findings from the discovery phase. Your job is to replace unnecessarily complex patterns with simpler, more direct implementations that preserve the same behavior.
+
+You follow `code-simplifier` agent patterns (preserve functionality, enhance clarity) and `sc:improve --type maintainability` patterns (reduce indirection, improve readability).
+
+This is nuanced work requiring strong pattern recognition. You must understand WHAT the code does before simplifying HOW it does it.
+
+## Findings to Address
+
+{findings}
+
+## Strategy
+
+### Step 1: Prioritize by Severity
+
+Process findings from highest to lowest severity:
+1. **High severity** — Unnecessary abstractions that actively harm readability (factory patterns with 1 variant, interfaces with 1 implementor)
+2. **Medium severity** — Verbose patterns that add noise (restating comments, type-in-name, catch-and-rethrow)
+3. **Low severity** — Minor verbosity (overly long variable names, unnecessary intermediate variables)
+
+### Step 2: Understand Before Simplifying
+
+For EACH finding:
+1. Read the entire function/class, not just the flagged lines
+2. Read the callers (use LSP `findReferences`)
+3. Understand the data flow — what goes in, what comes out, what side effects occur
+4. Generate the simplified replacement MENTALLY before making any edit
+5. Verify the simplification preserves the exact same observable behavior
+
+### Step 3: Apply Simplification Patterns
+
+**Unnecessary wrapper function (single-use, adds no logic):**
+- If called from 1 place: inline the wrapper body at the call site, delete the wrapper
+- If called from multiple places: keep the function but simplify its body
+```python
+# Before (slop)
+def get_user_data_from_database(user_id):
+    return database.query(User, id=user_id)
+# After
+user = database.query(User, id=user_id)  # inlined at call site
+```
+
+**Over-abstraction (interface/protocol with 1 implementor):**
+- Remove the interface/protocol/ABC
+- Use the concrete class directly everywhere
+- Keep the interface ONLY if there is a clear, documented plan for future implementors
+
+**Premature generalization (strategy/factory/builder with 1 variant):**
+- Replace with direct implementation
+- Remove the factory/strategy infrastructure
+```python
+# Before (slop)
+class UserValidatorFactory:
+    @staticmethod
+    def create(type):
+        if type == "standard":
+            return StandardUserValidator()
+        raise ValueError(f"Unknown type: {type}")
+# After
+validator = StandardUserValidator()  # used directly
+```
+
+**Single-use helper function:**
+- Inline the helper body at its single call site
+- Delete the helper function
+
+**Catch-and-rethrow (catches exception only to re-raise it):**
+- Remove the try/catch block entirely, let the exception propagate naturally
+- EXCEPTION: keep if the catch block adds context (e.g., wraps in a domain-specific exception with additional info)
+```python
+# Before (slop)
+try:
+    result = process(data)
+except ValueError:
+    raise  # pointless
+# After
+result = process(data)
+```
+
+**Impossible-state checks:**
+- Remove checks for conditions that cannot occur given the code flow
+- VERIFY the state is truly impossible by tracing all paths to the check
+```python
+# Before (slop — user already validated non-null 3 lines above)
+if user is None:
+    raise RuntimeError("User cannot be None")  # impossible here
+```
+
+**Verbose variable names:**
+- Shorten while preserving clarity
+- `currentUserAuthenticationToken` becomes `auth_token`
+- `temporaryDatabaseConnectionString` becomes `db_conn_str`
+- Keep domain-specific terms: `encrypted_private_key` stays as-is
+
+**Restating comments (comment says what the code already says):**
+- Delete the comment entirely
+- Keep any comment that explains WHY, not WHAT
+```python
+# Before (slop)
+# Increment the counter by one
+counter += 1
+# After
+counter += 1
+```
+
+**Type-in-name (variable name includes its type):**
+- Remove the type suffix
+- `user_list` becomes `users`
+- `name_string` becomes `name`
+- `config_dict` becomes `config`
+- `is_active_boolean` becomes `is_active`
+
+**Testing mocks that mock the thing being tested:**
+- Rewrite the test to test real behavior
+- Flag as `needs-review` if the test is complex and you are unsure of the intended behavior
+
+**Unnecessary intermediate variables:**
+- If a variable is assigned once and used once on the very next line, inline it
+- EXCEPTION: keep if the variable name adds clarity to an otherwise opaque expression
+
+**Over-commented obvious code:**
+- Remove comments on self-explanatory lines
+- Keep comments that explain business rules, workarounds, or non-obvious decisions
+
+### Step 4: Verify Each Simplification
+
+After each simplification:
+1. Re-read the surrounding code — does it still make sense in context?
+2. Check that no callers are broken (LSP `findReferences`)
+3. Run affected tests after every 5 simplifications
+
+### Step 5: Format and Final Verification
+
+After all simplifications, run the project's formatter, then the full test suite.
+
+## Safety Rules
+
+- NEVER simplify code at system boundaries (API handlers, file I/O, network calls, database queries) — these need their verbosity for error handling
+- NEVER remove error handling that catches errors from external sources (network, filesystem, user input, database)
+- NEVER remove logging that records security events, errors, or audit trails
+- NEVER simplify code that handles concurrent access (locks, semaphores, atomic operations)
+- NEVER simplify code in hot paths without understanding performance implications
+- NEVER change the public API of a module (exported function names, parameter types, return types)
+- If a simplification would change how errors propagate to callers, flag as `needs-review`
+- If you are unsure whether a pattern is slop or intentional design, flag as `needs-review`
+- Test after every 5 simplifications
+
+## Output
+
+```
+AI Slop Simplification Summary
+================================
+Simplified: N findings
+  - <file>:<line> — <pattern type>: <brief description of change>
+  - ...
+Total lines removed: L (net reduction)
+Skipped: M findings
+  - <finding>: <reason>
+  - ...
+Test failures encountered: F
+  - <file>:<line> <simplification attempted>: <error message>
+  - ...
+Needs-review: R findings
+  - <finding>: <why human judgment needed>
+  - ...
+```
+
+## Commit Message Format
+
+```
+refactor: simplifies over-engineered code — N patterns reduced
+```
+
+If focused on a specific area:
+```
+refactor: simplifies unnecessary abstractions in authentication module
+```
+````
+
+---
+
+## Agent 5: Architecture Unifier
+
+````markdown
+# Architecture Unifier — Implementation Agent
+
+{context_bundle}
+
+## Your Role
+
+You unify inconsistent architectural patterns across this codebase. You have been given a list of confirmed architectural inconsistency findings from the discovery phase. Your job is to standardize patterns, break circular dependencies, fix layer violations, and bring structural consistency to the codebase.
+
+You follow `project-dev:refactor` agent patterns for safe structural changes and `superclaude:architect` principles: prefer simple solutions, ensure clear boundaries, apply YAGNI.
+
+## Findings to Address
+
+{findings}
+
+## Strategy
+
+### Step 1: Fix Circular Dependencies FIRST
+
+Circular dependencies block other changes and cause the most subtle breakage. Fix them before anything else.
+
+For each circular dependency:
+1. Map the full cycle: A imports B, B imports C, C imports A
+2. Identify the shared types/interfaces that create the cycle
+3. Break the cycle using one of these strategies (in order of preference):
+   a. **Extract shared types** — Move shared types/interfaces into a separate `types.py` / `types.ts` / `interfaces.go` module that both sides import
+   b. **Dependency inversion** — Have the lower-level module define an interface, and the higher-level module provide the implementation
+   c. **Lazy imports** — Use import-at-use-time only as a last resort (Python: import inside function body)
+4. Verify the cycle is broken: check that no circular import paths remain
+5. Run the FULL test suite — circular dependency fixes affect import ordering across the entire project
+
+### Step 2: Standardize Divergent Patterns
+
+For each pattern inconsistency finding:
+
+1. **Identify the dominant pattern** — the one used in the majority of places
+2. **Identify minority patterns** — alternatives used in fewer places
+3. **Evaluate which is better** — if the minority pattern is objectively better (simpler, more idiomatic, safer), adopt it as the standard instead
+4. **Migrate minority to match dominant:**
+   a. Read all instances of the minority pattern
+   b. Use LSP `findReferences` to locate all callers/consumers
+   c. Transform each instance to match the dominant pattern
+   d. Update all callers if the interface changes
+   e. Run affected tests after each migration
+
+**Common pattern standardizations:**
+- Error handling: standardize on one approach (e.g., all exceptions vs all result types, not a mix)
+- Configuration loading: standardize on one method (e.g., all environment variables, not some env vars and some config files)
+- Logging: standardize on one logger pattern (e.g., `logger = logging.getLogger(__name__)` everywhere)
+- API response format: standardize on one shape (e.g., `{"data": ..., "error": ...}` everywhere)
+- File organization: standardize on one module layout (e.g., all services in `services/`, not some in `services/` and some in `utils/`)
+
+### Step 3: Fix Layer Violations
+
+For each layer violation:
+1. Identify the correct layer for the code (presentation, business logic, data access, infrastructure)
+2. Move the code to the correct module/directory
+3. Update all imports across the codebase (use LSP `findReferences` + Grep)
+4. If moving creates a new module, ensure it follows the project's naming conventions
+5. Run the full test suite after each move
+
+### Step 4: Consolidate God Objects
+
+For each god object (class/module with too many responsibilities):
+1. Identify the distinct responsibilities within the object
+2. Group related methods/attributes into logical clusters
+3. Extract each cluster into a focused module/class with a single responsibility
+4. Update the original god object to delegate to the new modules
+5. Update all callers (use LSP `findReferences`)
+6. Run affected tests after each extraction
+
+### Step 5: Standardize Naming Conventions
+
+For each naming inconsistency:
+1. Identify the dominant naming convention (e.g., `snake_case` vs `camelCase`, `get_X` vs `fetch_X`)
+2. Rename outliers to match the dominant convention
+3. Use LSP `findReferences` to find ALL references before renaming
+4. Update all references in code, tests, documentation, and configuration
+5. Run tests after each batch of renames
+
+### Step 6: Format and Final Verification
+
+After all unification changes, run the formatter, then the full test suite.
+
+## Safety Rules
+
+- Use LSP `findReferences` for EVERY rename or move — no exceptions
+- Architecture changes affect many files — run the FULL test suite after each change, not just affected tests
+- If fixing a circular dependency requires adding a new module, ensure it is properly integrated (added to `__init__.py`, build configs, etc.)
+- NEVER change the external behavior of any function while unifying its implementation pattern
+- NEVER unify patterns across intentional boundaries (e.g., different microservices may intentionally use different patterns)
+- If unifying a pattern would require changing >20 files, flag as `needs-review` first
+- If a naming convention is language-idiomatic in its context (e.g., `camelCase` in JavaScript, `snake_case` in Python), do not cross-language standardize
+- When in doubt about which pattern should be dominant, flag as `needs-review`
+
+## Output
+
+```
+Architecture Unification Summary
+==================================
+Circular dependencies broken: N
+  - <cycle description> — <strategy used>
+  - ...
+Patterns standardized: P
+  - <pattern type>: migrated M instances to match dominant pattern
+  - ...
+Layer violations fixed: L
+  - <code> moved from <source> to <destination>
+  - ...
+God objects split: G
+  - <object> split into N focused modules
+  - ...
+Naming conventions unified: C renames
+Skipped: S findings
+  - <finding>: <reason>
+  - ...
+Test failures encountered: F
+  - <change>: <error message>
+  - ...
+Needs-review: R findings
+  - <finding>: <why human judgment needed>
+  - ...
+```
+
+## Commit Message Format
+
+```
+refactor: unifies error handling pattern across codebase
+refactor: breaks circular dependency between auth and user modules
+refactor: standardizes service layer naming conventions
+refactor: extracts focused modules from UserManager god object
+```
+
+If a single commit covers multiple unification types:
+```
+refactor: unifies architectural patterns — N inconsistencies resolved
+```
+````
+
+---
+
+## Agent 6: Documentation Updater
+
+````markdown
+# Documentation Updater — Implementation Agent
+
+{context_bundle}
+
+## Your Role
+
+You update documentation to match the current state of the codebase. You have been given a list of documentation findings from the discovery phase, plus you must account for changes made by the other implementation agents running concurrently. Your job is to ensure documentation accurately reflects the code.
+
+You follow `docs-sync` skill patterns: detect drift between code and docs, auto-update with precision, match the project's existing documentation style.
+
+## Findings to Address
+
+{findings}
+
+## Strategy
+
+### Step 1: Update README and Top-Level Documentation
+
+For each README issue:
+1. **Fix incorrect commands** — read the actual `Makefile`, `package.json`, or build configs to verify the correct commands, then test them by running them
+2. **Fix incorrect entry points** — check actual main files (`main.py`, `index.ts`, `cmd/main.go`) and update references
+3. **Fix incorrect configuration documentation** — read actual config files and update the documented options
+4. **Remove sections about deleted features** — check if referenced files/modules still exist. If they were removed (by the Dead Code Remover or otherwise), remove their documentation
+5. **Update installation instructions** — verify they work by reading dependency files
+
+### Step 2: Fix Broken Internal Links
+
+For each broken link:
+1. Check if the target file was moved — search for the filename in the current directory structure
+2. If moved: update the link path
+3. If deleted: remove the link and any surrounding text that references the deleted content
+4. If the link target is a heading within a file, verify the heading still exists (headings may have been renamed)
+
+### Step 3: Sync with Other Agents' Changes
+
+Re-read files that other implementation agents may have modified:
+1. Check git status for recently modified files
+2. If the Dead Code Remover deleted files/functions, remove their documentation
+3. If the Duplicate Consolidator moved code, update references to new locations
+4. If the Architecture Unifier renamed or restructured modules, update all references
+
+### Step 4: Add Minimal Documentation for Undocumented Public APIs
+
+Only document public APIs that meet ALL of these criteria:
+- Exported from the module (in `__init__.py`, `index.ts`, `mod.rs`, etc.)
+- Used by code outside their own module
+- Currently have NO documentation (no docstring, JSDoc, or rustdoc)
+
+For each:
+1. Match the project's existing documentation style exactly. If the project uses terse single-line docstrings, write terse single-line docstrings. If the project uses detailed Google-style docstrings, write Google-style docstrings.
+2. Focus on WHAT the function does and WHY it exists, not HOW it works
+3. Document parameters and return values only if the types are not self-explanatory
+4. Do NOT add docstrings to private/internal functions
+
+### Step 5: Clean Up Stale TODOs and FIXMEs
+
+For each TODO/FIXME:
+1. **References deleted code:** Remove the TODO entirely
+2. **References a fixed issue:** Remove the FIXME (verify the issue is actually fixed)
+3. **References legitimate future work:** Keep it
+4. **References an external issue tracker:** Check if the issue is still open. If closed, remove the TODO
+5. **Is vague or context-free** (e.g., `# TODO: fix this`): Flag as `needs-review`
+
+### Step 6: Update CHANGELOG (if it exists)
+
+If the project has a CHANGELOG:
+1. Add a new entry for the cleanup changes under an `[Unreleased]` section
+2. Summarize what was cleaned up (dead code removed, duplicates consolidated, security fixes applied, etc.)
+3. Follow the existing CHANGELOG format exactly
+
+### Step 7: Format
+
+After all documentation updates, verify markdown formatting is correct:
+- No broken links (relative paths resolve to existing files)
+- Code blocks use correct language identifiers
+- Tables are properly formatted
+
+## Safety Rules
+
+- Do NOT over-document — match the project's existing documentation density and style
+- Do NOT add docstrings to every function — only undocumented PUBLIC APIs
+- Do NOT modify auto-generated documentation (API docs from code comments, swagger/OpenAPI specs, typedoc output, etc.)
+- Do NOT add documentation for internal helper functions
+- Do NOT change the tone or voice of existing documentation
+- Do NOT add badges, shields, or decorative elements unless the project already uses them
+- Do NOT create new documentation files — only update existing ones (unless the project has zero docs, in which case flag as `needs-review`)
+- Verify every command you document by checking the actual build/config files
+- When in doubt about whether to document something, do not document it
+
+## Output
+
+```
+Documentation Update Summary
+==============================
+Files updated: N
+  - <file>: <changes made>
+  - ...
+Broken links fixed: L
+Stale TODOs removed: T
+  - <file>:<line> — <reason for removal>
+  - ...
+Public APIs documented: A
+  - <module>:<function> — added <style> docstring
+  - ...
+CHANGELOG updated: yes/no
+Skipped: S findings
+  - <finding>: <reason>
+  - ...
+Needs-review: R findings
+  - <finding>: <why human judgment needed>
+  - ...
+```
+
+## Commit Message Format
+
+```
+docs: syncs documentation with code changes
+```
+
+If updating specific areas:
+```
+docs: updates README commands and removes stale API references
+```
+````
+
+---
+
+## Agent 7: Complexity Reducer
+
+````markdown
+# Complexity Reducer — Implementation Agent
+
+{context_bundle}
+
+## Your Role
+
+You reduce code complexity in this codebase. You have been given a list of confirmed complexity findings from the discovery phase (long functions, deep nesting, magic values, long parameter lists, etc.). Your job is to refactor each finding into simpler, more readable code while preserving exact behavior.
+
+You follow `sc:improve --type maintainability` patterns and `project-dev:refactor` agent patterns: extract clearly, name descriptively, verify with LSP, test after each change.
+
+## Findings to Address
+
+{findings}
+
+## Strategy
+
+### Step 1: Prioritize by Impact
+
+Process findings that provide the most readability improvement first:
+1. **Long functions (>50 lines)** — highest impact, often contain multiple extractable sections
+2. **Deep nesting (>4 levels)** — second highest, significantly reduces cognitive load
+3. **Magic numbers/strings** — medium impact, improves maintainability
+4. **Long parameter lists (>5 params)** — medium impact, improves call-site readability
+5. **Nested ternaries** — medium impact, improves debuggability
+6. **Long files (>500 lines)** — lowest priority, most risk (many cross-file changes)
+
+### Step 2: Refactor Long Functions
+
+For each function >50 lines:
+1. Read the entire function and identify logical sections (usually separated by blank lines or comments)
+2. For each section, determine:
+   - What data does it need (inputs)?
+   - What data does it produce (outputs)?
+   - Does it have side effects?
+3. Extract each section into a well-named helper function:
+   - Name reflects WHAT the section does, not HOW (e.g., `validate_input` not `check_and_raise`)
+   - Parameters are the section's inputs
+   - Return value is the section's output
+   - Side effects are documented in the docstring
+4. Keep the original function as a coordinator that calls the extracted helpers in order
+5. Verify with LSP `findReferences` that the original function's callers are unaffected
+
+```python
+# Before
+def process_order(order):
+    # 80 lines of validation, pricing, inventory, notification
+
+# After
+def process_order(order):
+    validated = validate_order(order)
+    priced = calculate_pricing(validated)
+    reserve_inventory(priced)
+    notify_customer(priced)
+    return priced
+
+def validate_order(order):
+    # 20 lines
+
+def calculate_pricing(order):
+    # 25 lines
+
+def reserve_inventory(order):
+    # 15 lines
+
+def notify_customer(order):
+    # 20 lines
+```
+
+### Step 3: Flatten Deep Nesting
+
+For each deeply nested block (>4 levels):
+1. **Convert to early returns / guard clauses** — invert the condition, return/raise/continue early
+2. **Extract nested blocks into functions** — if the nested block is a logical unit
+3. **Replace nested loops with comprehensions or utility functions** — if the language supports it
+4. **Use `match`/`switch` statements** — when nesting comes from chained elif/else if
+
+```python
+# Before (4 levels deep)
+def process(data):
+    if data is not None:
+        if data.is_valid():
+            if data.has_permission():
+                if data.is_ready():
+                    return do_work(data)
+                else:
+                    raise NotReadyError()
+            else:
+                raise PermissionError()
+        else:
+            raise ValidationError()
+    else:
+        raise ValueError("No data")
+
+# After (flat with guard clauses)
+def process(data):
+    if data is None:
+        raise ValueError("No data")
+    if not data.is_valid():
+        raise ValidationError()
+    if not data.has_permission():
+        raise PermissionError()
+    if not data.is_ready():
+        raise NotReadyError()
+    return do_work(data)
+```
+
+### Step 4: Replace Magic Numbers and Strings
+
+For each magic value:
+1. Determine what the value represents in context
+2. Create a named constant at module level with a descriptive name
+3. Use `UPPER_SNAKE_CASE` for constants
+4. Use enums or frozen sets for related groups of values
+5. Replace ALL occurrences of the magic value (use Grep to find them all)
+
+```python
+# Before
+if retries > 3:
+    time.sleep(30)
+    if response.status_code == 429:
+        ...
+
+# After
+MAX_RETRIES = 3
+RETRY_BACKOFF_SECONDS = 30
+HTTP_TOO_MANY_REQUESTS = 429  # or use http.HTTPStatus
+
+if retries > MAX_RETRIES:
+    time.sleep(RETRY_BACKOFF_SECONDS)
+    if response.status_code == HTTP_TOO_MANY_REQUESTS:
+        ...
+```
+
+### Step 5: Convert Long Parameter Lists
+
+For each function with >5 parameters:
+1. Group related parameters into a config/options object:
+   - Python: `@dataclass` or `TypedDict`
+   - TypeScript: `interface` or type alias
+   - Go: `struct`
+   - Rust: `struct`
+2. Give the grouped object a clear name reflecting what it configures
+3. Update ALL callers (use LSP `findReferences`)
+4. Provide sensible defaults where appropriate
+
+```python
+# Before
+def send_email(to, cc, bcc, subject, body, attachments, reply_to, priority):
+    ...
+
+# After
+@dataclass
+class EmailMessage:
+    to: str
+    subject: str
+    body: str
+    cc: str | None = None
+    bcc: str | None = None
+    attachments: list[Path] | None = None
+    reply_to: str | None = None
+    priority: str = "normal"
+
+def send_email(message: EmailMessage):
+    ...
+```
+
+### Step 6: Convert Nested Ternaries
+
+For each nested ternary:
+1. Replace with an if/else chain or match statement
+2. Prioritize readability over brevity
+3. If the logic is selecting from multiple options, use a dictionary lookup
+
+```python
+# Before
+result = "high" if score > 90 else "medium" if score > 70 else "low" if score > 50 else "fail"
+
+# After
+if score > 90:
+    result = "high"
+elif score > 70:
+    result = "medium"
+elif score > 50:
+    result = "low"
+else:
+    result = "fail"
+```
+
+### Step 7: Split Long Files
+
+For each file >500 lines:
+1. Read the entire file and identify natural module boundaries (groups of related classes, functions, or constants)
+2. Sketch the split plan BEFORE making any changes:
+   - Which groups become separate files?
+   - What should each new file be named?
+   - Will the split create circular imports?
+3. If the split would create circular dependencies, flag as `needs-review`
+4. Extract each group into its own file
+5. Update the original file to re-export from the new files (maintain backward compatibility)
+6. Update ALL imports across the codebase (use LSP `findReferences` + Grep)
+7. Run the FULL test suite after each file split
+
+### Step 8: Test After Each Refactoring
+
+Run affected tests after EACH individual refactoring (each function extraction, each nesting fix, each file split):
+- NOT in batches — complexity refactoring can introduce subtle bugs
+- If tests fail: revert with `git checkout -- <files>`. Log the failure. Move to next finding.
+
+### Step 9: Format and Final Verification
+
+After all refactorings, run the formatter, then the full test suite.
+
+## Safety Rules
+
+- Use LSP `findReferences` when extracting, renaming, or moving any symbol
+- Each extraction MUST be a standalone, testable change — do not combine multiple refactorings into one edit
+- Run tests after EACH refactoring, not just at the end
+- NEVER change the observable behavior of any function while reducing its complexity
+- NEVER change the public API (function names, parameters, return types) without updating all callers
+- NEVER extract a function if the extracted code relies on local variables that would require passing >5 parameters (that trades one complexity for another)
+- NEVER split a file if the result would create circular dependencies — flag as `needs-review`
+- When extracting guard clauses, ensure the error types and messages are preserved exactly
+- When replacing magic values, verify the constant is not already defined elsewhere in the codebase (avoid duplicating constants)
+- If a complexity finding is in performance-critical code (tight loops, hot paths), flag as `needs-review` — extraction can impact performance
+
+## Output
+
+```
+Complexity Reduction Summary
+==============================
+Long functions refactored: N (extracted M helper functions)
+  - <file>:<function> — split into N functions: <names>
+  - ...
+Deep nesting flattened: D
+  - <file>:<function> — reduced from N levels to M levels
+  - ...
+Magic values extracted: V (created C named constants)
+  - <file>:<line> — <value> becomes <CONSTANT_NAME>
+  - ...
+Long parameter lists simplified: P
+  - <file>:<function> — N params grouped into <TypeName>
+  - ...
+Nested ternaries converted: T
+Long files split: S
+  - <file> — split into N files: <names>
+  - ...
+Total lines added/removed: +A/-R (net change: +/-N)
+Skipped: K findings
+  - <finding>: <reason>
+  - ...
+Test failures encountered: F
+  - <refactoring>: <error message>
+  - ...
+Needs-review: Q findings
+  - <finding>: <why human judgment needed>
+  - ...
+```
+
+## Commit Message Format
+
+```
+refactor: reduces complexity in <module> — extracts N helper functions
+refactor: flattens nested conditionals in <module> with guard clauses
+refactor: extracts magic constants in <module>
+refactor: splits <file> into focused modules
+```
+
+If a single commit covers multiple complexity reductions:
+```
+refactor: reduces complexity across <area> — N functions simplified
+```
+````

--- a/global-skills/skills/unfuck/references/orchestration-playbook.md
+++ b/global-skills/skills/unfuck/references/orchestration-playbook.md
@@ -1,0 +1,851 @@
+# Orchestration Playbook
+
+This is the complete coordination reference for the `/unfuck` cleanup skill. The orchestrator agent reads this file and SKILL.md -- nothing else. Every phase, every agent spawn, every decision point is documented here.
+
+---
+
+## Phase Overview
+
+| Phase | Name | Mode | Duration |
+|-------|------|------|----------|
+| 0 | Index & Setup | Orchestrator direct | ~30s |
+| 1 | Discovery | 7 parallel agents | Variable |
+| 2 | Synthesis & Planning | Orchestrator direct | ~60s |
+| 3 | Implementation | Sequential agents per category | Variable |
+| 4 | Verification & Report | Orchestrator direct + test agent | ~60s |
+
+---
+
+## Phase 0: Index & Setup
+
+### Run directory
+
+All artifacts for a single `/unfuck` run go under a date-scoped directory so multiple runs don't clash:
+
+```
+{run_dir} = hack/unfuck/YYYY-MM-DD
+```
+
+Use today's actual date (e.g., `hack/unfuck/2026-02-18`). If the directory already exists (re-run scenario), append a sequence number: `hack/unfuck/2026-02-18-2`.
+
+All paths in this playbook use `{run_dir}` to refer to this directory. The orchestrator resolves it once and passes the resolved path to all agents via the context bundle.
+
+### Step 0.1: Generate repo index
+
+Invoke the `sc:index-repo` skill via the Skill tool. This creates `PROJECT_INDEX.md` at the project root, giving every agent a ~3K-token project reference instead of reading the full codebase.
+
+```
+Skill(skill="sc:index-repo")
+```
+
+Wait for completion. Read the generated `PROJECT_INDEX.md`.
+
+### Step 0.2: Detect project languages
+
+Check the project root for language indicator files. Use Glob to detect:
+
+| Indicator Files | Language |
+|----------------|----------|
+| `package.json` / `tsconfig.json` / `*.ts` / `*.tsx` | JavaScript/TypeScript |
+| `pyproject.toml` / `setup.py` / `setup.cfg` / `requirements.txt` | Python |
+| `go.mod` | Go |
+| `Cargo.toml` | Rust |
+| `pom.xml` / `build.gradle` | Java/Kotlin |
+| `Gemfile` | Ruby |
+| `composer.json` | PHP |
+| `*.csproj` / `*.sln` | .NET |
+
+Multiple languages are common. Store the list of detected languages.
+
+### Step 0.3: Detect available external tools
+
+For each tool relevant to the detected languages (see `references/external-tools.md`), check availability using Bash:
+
+```bash
+command -v knip 2>/dev/null && knip --version || echo "NOT_AVAILABLE"
+command -v semgrep 2>/dev/null && semgrep --version || echo "NOT_AVAILABLE"
+# ... repeat for each tool from external-tools.md
+```
+
+Also check npx-based tools:
+```bash
+npx knip --version 2>/dev/null || echo "NOT_AVAILABLE"
+```
+
+Write results to `{run_dir}/available-tools.json`:
+```json
+{
+  "languages": ["python", "typescript"],
+  "tools": {
+    "knip": {"available": true, "version": "5.1.0"},
+    "semgrep": {"available": false, "fallback": "agent-analysis"},
+    "ruff": {"available": true, "version": "0.8.0"},
+    "vulture": {"available": false, "fallback": "agent-analysis"},
+    "ts-prune": {"available": false, "fallback": "knip"}
+  }
+}
+```
+
+If a tool is unavailable, record its fallback from `references/external-tools.md`. The fallback is either another tool or `"agent-analysis"` (manual analysis by the discovery agent).
+
+### Step 0.4: Create feature branch
+
+```bash
+git switch -c cleanup/unfuck-YYYY-MM-DD
+```
+
+Use today's actual date. If the branch already exists (re-run scenario), append a sequence number: `cleanup/unfuck-YYYY-MM-DD-2`.
+
+### Step 0.5: Create output directories
+
+```bash
+mkdir -p {run_dir}/discovery
+```
+
+This creates:
+- `{run_dir}/` -- root for all unfuck artifacts for this run
+- `{run_dir}/discovery/` -- Phase 1 agent outputs
+
+### Step 0.6: Create team
+
+```
+TeamCreate(team_name="unfuck-cleanup", description="Comprehensive repo cleanup swarm")
+```
+
+### Step 0.7: Prepare agent context bundle
+
+Build a context string that will be prepended to every discovery agent prompt. The context bundle contains:
+
+```
+=== UNFUCK CLEANUP CONTEXT ===
+Project path: /absolute/path/to/project
+Languages: python, typescript
+Run directory: {run_dir}
+Available tools: <contents of {run_dir}/available-tools.json>
+
+IMPORTANT — Tool Selection Guard:
+This repo has a tool-selection-guard hook. You MUST use native tools:
+- Glob (not ls/find), Read (not cat/head/tail), Grep (not grep/rg)
+- Write/Edit (not echo/sed/awk), direct output text (not echo/printf)
+- Bash is ONLY for: git, uv/uvx, npx, go run, make, and system commands
+If a Bash command is blocked, switch to the equivalent native tool.
+
+=== PROJECT INDEX ===
+<contents of PROJECT_INDEX.md, truncated to 3K tokens if needed>
+=== END CONTEXT ===
+```
+
+Read `PROJECT_INDEX.md` content. If it exceeds ~3,000 tokens (~12,000 characters), truncate to the summary and directory structure sections only.
+
+Store this context string for use in Phase 1.
+
+---
+
+## Phase 1: Discovery (7 Parallel Teammates)
+
+Spawn all 7 agents as **TeamCreate teammates** in a single message. Each teammate runs in its own independent context window, writes its JSON findings to disk, and sends a brief summary to the team lead via `SendMessage`. This avoids context pressure on the orchestrator — the orchestrator never calls `TaskOutput` or reads full agent transcripts.
+
+**Why teammates, not background Tasks:** Background `Task(run_in_background=true)` agents dump their full output into the orchestrator's context when checked via `TaskOutput`. With 7 agents producing detailed findings, this causes context overflow. TeamCreate teammates have independent context windows and communicate via short `SendMessage` summaries.
+
+### Agent Roster
+
+| # | Agent Name | Agent Type | Model | Output File |
+|---|-----------|-----------|-------|-------------|
+| 1 | dead-code-hunter | general-purpose | sonnet | `{run_dir}/discovery/dead-code.json` |
+| 2 | duplicate-detector | general-purpose | sonnet | `{run_dir}/discovery/duplicates.json` |
+| 3 | security-auditor | general-purpose | sonnet | `{run_dir}/discovery/security.json` |
+| 4 | architecture-reviewer | general-purpose | sonnet | `{run_dir}/discovery/architecture.json` |
+| 5 | ai-slop-detector | general-purpose | opus | `{run_dir}/discovery/ai-slop.json` |
+| 6 | complexity-auditor | general-purpose | sonnet | `{run_dir}/discovery/complexity.json` |
+| 7 | documentation-auditor | general-purpose | sonnet | `{run_dir}/discovery/documentation.json` |
+
+**Note:** The ai-slop-detector uses `opus` because detecting AI-generated patterns, unnecessary abstractions, and over-engineering requires stronger judgment. All other agents use `sonnet` for cost efficiency.
+
+### Launching Pattern
+
+In a single message, issue 7 parallel Task calls with `team_name` to spawn as teammates:
+
+```
+Task(name="dead-code-hunter", subagent_type="general-purpose", model="sonnet",
+     team_name="unfuck-cleanup", mode="bypassPermissions",
+     prompt="[context bundle]\n\n[Agent 1 prompt from discovery-agents.md]")
+
+Task(name="duplicate-detector", subagent_type="general-purpose", model="sonnet",
+     team_name="unfuck-cleanup", mode="bypassPermissions",
+     prompt="[context bundle]\n\n[Agent 2 prompt from discovery-agents.md]")
+
+Task(name="security-auditor", subagent_type="general-purpose", model="sonnet",
+     team_name="unfuck-cleanup", mode="bypassPermissions",
+     prompt="[context bundle]\n\n[Agent 3 prompt from discovery-agents.md]")
+
+Task(name="architecture-reviewer", subagent_type="general-purpose", model="sonnet",
+     team_name="unfuck-cleanup", mode="bypassPermissions",
+     prompt="[context bundle]\n\n[Agent 4 prompt from discovery-agents.md]")
+
+Task(name="ai-slop-detector", subagent_type="general-purpose", model="opus",
+     team_name="unfuck-cleanup", mode="bypassPermissions",
+     prompt="[context bundle]\n\n[Agent 5 prompt from discovery-agents.md]")
+
+Task(name="complexity-auditor", subagent_type="general-purpose", model="sonnet",
+     team_name="unfuck-cleanup", mode="bypassPermissions",
+     prompt="[context bundle]\n\n[Agent 6 prompt from discovery-agents.md]")
+
+Task(name="documentation-auditor", subagent_type="general-purpose", model="sonnet",
+     team_name="unfuck-cleanup", mode="bypassPermissions",
+     prompt="[context bundle]\n\n[Agent 7 prompt from discovery-agents.md]")
+```
+
+### Communication Protocol
+
+Each teammate, after writing its JSON output file, sends a summary to the team lead:
+
+```
+SendMessage(type="message", recipient="team-lead",
+  content="[Agent name] complete. Results: {run_dir}/discovery/[file].json\n\n
+    Summary: N findings (X critical, Y high, Z medium, W low)\n
+    Key findings: [1-3 sentence highlights]\n
+    External tools used: [list]\n
+    Gaps: [any analysis areas that couldn't be covered]",
+  summary="[Agent name]: N findings")
+```
+
+The orchestrator receives these summaries as automatic message deliveries — no polling or TaskOutput needed. Each summary is ~200 tokens instead of ~5,000+ tokens for a full agent transcript.
+
+### Monitoring
+
+Teammates send messages automatically when complete and go idle. The orchestrator receives these as new conversation turns. Track completion by counting received summaries — when all 7 are received (or after a reasonable wait), proceed to Phase 2.
+
+**If a teammate fails or goes idle without sending results:**
+1. Check if the JSON output file exists via `Glob("{run_dir}/discovery/*.json")`
+2. If the file exists, read it directly — the teammate may have written output before failing
+3. If the file is missing, note the gap and proceed with available results
+4. Partial coverage is better than blocking
+
+**Expected outputs:** Each teammate writes a JSON file following the shared discovery output schema (defined at the end of this document). The orchestrator validates that each file is valid JSON and contains the required fields before proceeding to Phase 2.
+
+### Team Shutdown
+
+After Phase 2 synthesis is complete and all discovery JSON files have been read, shut down the discovery teammates:
+
+```
+SendMessage(type="shutdown_request", recipient="dead-code-hunter",
+  content="Discovery phase complete, shutting down")
+# ... repeat for each teammate
+```
+
+This frees resources before Phase 3 implementation agents are spawned.
+
+---
+
+## Phase 2: Synthesis & Planning
+
+The orchestrator performs this phase directly. No subagents.
+
+### Step 2.1: Read all discovery files
+
+Read all 7 discovery output files in parallel:
+
+```
+Read {run_dir}/discovery/dead-code.json
+Read {run_dir}/discovery/duplicates.json
+Read {run_dir}/discovery/security.json
+Read {run_dir}/discovery/architecture.json
+Read {run_dir}/discovery/ai-slop.json
+Read {run_dir}/discovery/complexity.json
+Read {run_dir}/discovery/documentation.json
+```
+
+If a file is missing (agent failed), skip it and note the gap.
+
+### Step 2.2: Deduplicate findings
+
+Many findings will overlap across agents. Apply these dedup rules:
+
+| Overlap Pattern | Resolution |
+|----------------|------------|
+| Same file + same line range across agents | Merge into one finding, keep the more detailed description |
+| Dead code + architecture finding for same symbol | Merge into architecture (broader context wins) |
+| Security + any other category overlap | Security takes priority, absorb the other finding |
+| AI slop + complexity for same function | Merge into AI slop (more actionable category) |
+| Duplicate + dead code for same function | If the function is unused everywhere, keep as dead code; if used once, keep as duplicate |
+
+### Step 2.3: Cross-reference findings
+
+Look for these compound patterns that change the fix strategy:
+
+| Pattern | Tag | Meaning |
+|---------|-----|---------|
+| Dead code agent found unused function AND architecture agent found it's part of a divergent pattern | `dead-divergent` | Safe to remove -- the divergent pattern confirms it's abandoned |
+| Duplicate detector found copy-paste AND ai-slop found over-abstraction in same area | `consolidation-candidate` | Extract a shared utility rather than choosing one copy |
+| Security agent found issue AND architecture agent found the pattern is used elsewhere | `systemic-security` | Fix ALL instances of the pattern, not just the flagged one |
+| Complexity finding AND the function has zero test coverage | `risky-refactor` | Flag for user review before implementation |
+
+Add appropriate tags to each finding's `related_findings` array.
+
+### Step 2.4: Prioritize and group
+
+Assign findings to implementation categories in this priority order:
+
+| Priority | Category | Rationale |
+|----------|----------|-----------|
+| 1 | **Security** | Critical fixes, highest value, often smallest changes |
+| 2 | **Dead code** | Safest changes (deletion), reduces surface area for everything after |
+| 3 | **Duplicates** | Fewer copies = fewer places to fix in remaining categories |
+| 4 | **AI slop** | Simplification makes remaining refactoring easier |
+| 5 | **Complexity** | Refactoring is cleaner after slop removal |
+| 6 | **Architecture** | Structural changes last, most risk, benefits from prior cleanup |
+| 7 | **Documentation** | Always last -- reflects all prior changes accurately |
+
+Within each category, order findings by severity (critical > high > medium > low), then by risk of fix (low > medium > high).
+
+### Step 2.5: Generate cleanup plan
+
+Write `{run_dir}/cleanup-plan.md`:
+
+```markdown
+# Cleanup Plan
+
+Generated: YYYY-MM-DD
+Project: <project name from PROJECT_INDEX.md>
+Languages: <detected languages>
+Tools used: <list of available tools that were actually used by agents>
+
+## Summary
+- Total findings: N
+- By severity: N critical, N high, N medium, N low
+- By category: N dead-code, N duplicates, N security, N ai-slop, N complexity, N architecture, N documentation
+- Estimated risk: low/medium/high per category
+
+## Category 1: Security (N findings)
+
+### Finding S-001: <title>
+- **Severity:** critical|high|medium|low
+- **File:** path/to/file.py:42-58
+- **Description:** <what's wrong>
+- **Evidence:** <how it was detected>
+- **Source:** <agent name> + <tool name if applicable>
+- **Suggested fix:** <from implementation-agents.md strategy>
+- **Risk:** low|medium|high (risk of the fix breaking something)
+- **Tags:** systemic-security (if cross-referenced)
+
+### Finding S-002: ...
+
+## Category 2: Dead Code (N findings)
+...
+
+## Category 3: Duplicates (N findings)
+...
+
+## Category 4: AI Slop (N findings)
+...
+
+## Category 5: Complexity (N findings)
+...
+
+## Category 6: Architecture (N findings)
+...
+
+## Category 7: Documentation (N findings)
+...
+
+## Deferred Items
+Items intentionally excluded (too risky for automated cleanup):
+- <item>: <reason>
+```
+
+### Step 2.6: Create task list
+
+Create one TaskCreate per implementation category that has findings:
+
+```
+TaskCreate("Fix security findings", "Apply N security fixes from cleanup-plan.md Category 1")
+TaskCreate("Remove dead code", "Remove N dead code items from cleanup-plan.md Category 2")
+TaskCreate("Consolidate duplicates", "Consolidate N duplicate patterns from cleanup-plan.md Category 3")
+TaskCreate("Simplify AI slop", "Simplify N over-engineered patterns from cleanup-plan.md Category 4")
+TaskCreate("Reduce complexity", "Reduce complexity in N functions from cleanup-plan.md Category 5")
+TaskCreate("Unify architecture", "Unify N architectural patterns from cleanup-plan.md Category 6")
+TaskCreate("Sync documentation", "Update N documentation items from cleanup-plan.md Category 7")
+```
+
+Skip categories with zero findings.
+
+### Step 2.7: User checkpoint
+
+Use AskUserQuestion if ANY of these conditions are true:
+
+| Condition | Why |
+|-----------|-----|
+| Any finding proposes deleting a public API export | Could break downstream consumers |
+| Any finding proposes changing an architectural pattern used in 5+ files | High blast radius |
+| Any security finding requires a policy decision | e.g., "secrets in env vars or vault?" |
+| Total findings exceed 100 | Confirm user wants full cleanup |
+| Any finding is ambiguous | Multiple valid interpretations |
+| Any `risky-refactor` tagged findings exist | Needs human judgment |
+
+AskUserQuestion format:
+
+```
+AskUserQuestion(
+  questions=[{
+    "question": "The cleanup plan includes N findings across M categories. [specific concern if applicable]. How should we proceed?",
+    "header": "Cleanup Scope",
+    "options": [
+      {"label": "Full cleanup", "description": "Apply all N findings across M categories"},
+      {"label": "Skip [risky category]", "description": "Apply all except [category] (N findings deferred)"},
+      {"label": "Security + dead code only", "description": "Conservative cleanup — only the safest categories"},
+      {"label": "Review plan first", "description": "I'll review {run_dir}/cleanup-plan.md before proceeding"}
+    ],
+    "multiSelect": false
+  }]
+)
+```
+
+If user selects "Review plan first", wait for their follow-up message before proceeding.
+
+If none of the checkpoint conditions are met, proceed directly to Phase 3 without asking.
+
+---
+
+## Phase 3: Implementation
+
+Execute implementation categories sequentially in priority order. Within each category, a single implementation agent works autonomously.
+
+### Execution Loop
+
+For each category (in priority order from Step 2.4):
+
+#### 3a. Extract findings
+
+Read the category's findings from `{run_dir}/cleanup-plan.md`. Convert them into a structured prompt section.
+
+#### 3b. Spawn implementation agent
+
+```
+Task(name="fix-<category>", subagent_type="general-purpose",
+     mode="bypassPermissions",
+     prompt="[context bundle]\n\n[Implementation agent prompt from references/implementation-agents.md for this category]\n\nFindings to fix:\n[filtered findings from cleanup-plan.md as JSON]")
+```
+
+**Model selection for implementation agents:**
+- `fix-ai-slop` uses `model="opus"` (requires judgment to simplify without losing functionality)
+- All other implementation agents use default model (sonnet)
+
+Do NOT run implementation agents in background -- they must complete sequentially to avoid file conflicts.
+
+#### 3c. Verify results
+
+After each agent completes:
+
+**Run tests:**
+```
+Task(name="verify-<category>", subagent_type="test-execution:test-runner",
+     prompt="Run the full test suite and report pass/fail")
+```
+
+If no test-runner agent type is available, run tests directly via Bash. Auto-detect the test command:
+
+| Check | Command |
+|-------|---------|
+| `Makefile` with `test` target | `make test` |
+| `pyproject.toml` exists | `uv run pytest` |
+| `package.json` with `test` script | `npm test` |
+| `package.json` without `test` script + jest | `npx jest` |
+| `package.json` without `test` script + vitest | `npx vitest run` |
+| `go.mod` exists | `go test ./...` |
+| `Cargo.toml` exists | `cargo test` |
+
+**Run linter/formatter (if available):**
+
+| Check | Command |
+|-------|---------|
+| `pyproject.toml` with ruff | `uv run ruff check . && uv run ruff format --check .` |
+| `Makefile` with `lint` target | `make lint` |
+| `package.json` with `lint` script | `npm run lint` |
+| `.eslintrc*` exists | `npx eslint .` |
+| `Makefile` with `format` target | `make format` (auto-fix) |
+
+#### 3d. Commit or rollback
+
+**If tests pass:**
+```bash
+# Stage only the files this agent modified
+git add <list of modified files>
+git commit -m "$(cat <<'EOF'
+<category-specific commit message>
+EOF
+)"
+```
+
+Mark the category's task as completed:
+```
+TaskUpdate(task_id=<id>, status="completed")
+```
+
+**If tests fail -- rollback:**
+```bash
+git stash push -m "unfuck-<category>-blocked"
+```
+
+Create a blocked task:
+```
+TaskCreate("BLOCKED: <category> -- <failure summary>",
+  "Implementation of <category> caused test failure:\n<test output snippet>\n\nStashed changes: unfuck-<category>-blocked\nManual review needed.\n\nFailed tests:\n<list of failing test names>")
+```
+
+Continue to the next category. Do not retry.
+
+### Commit Message Formats
+
+| Category | Commit Message Format |
+|----------|----------------------|
+| Security | `fix(security): <specific vulnerability description>` |
+| Dead code | `refactor: removes dead code -- N unused items` |
+| Duplicates | `refactor: consolidates duplicate code in <area>` |
+| AI slop | `refactor: simplifies over-engineered code in <area>` |
+| Complexity | `refactor: reduces complexity in <area>` |
+| Architecture | `refactor: unifies <pattern> across codebase` |
+| Documentation | `docs: syncs documentation with code changes` |
+
+If a category has many findings, summarize in the commit message rather than listing each one. Keep commit messages under 72 characters for the subject line; use the body for details.
+
+### Sequential Execution Rationale
+
+Categories execute sequentially because:
+1. Dead code removal changes file contents that later agents need to read
+2. Duplicate consolidation may move code that complexity/architecture agents target
+3. Each commit creates a clean baseline for the next category
+4. Rollback via `git stash` is clean when changes don't interleave
+
+---
+
+## Phase 4: Verification & Report
+
+### Step 4.1: Full test suite
+
+Run the complete test suite one final time. This catches any cross-category regressions that individual category tests might miss.
+
+```
+Task(name="final-verification", subagent_type="test-execution:test-runner",
+     prompt="Run the full test suite. Report all pass/fail results.")
+```
+
+Or via Bash using the auto-detected test command from Phase 3.
+
+If final tests fail, identify which commit introduced the regression:
+```bash
+git log --oneline cleanup/unfuck-YYYY-MM-DD~N..HEAD
+```
+Then bisect or check each commit's changes against the failing tests.
+
+### Step 4.2: Code quality review
+
+Get the list of all modified files across all implementation commits:
+
+```bash
+git diff --name-only $(git merge-base HEAD main)..HEAD
+```
+
+Spawn a code quality review agent:
+
+```
+Task(name="quality-review", subagent_type="general-purpose",
+     prompt="Review these files for code quality issues introduced during cleanup:\n<file list>\n\nCheck for:\n- Broken imports after dead code removal\n- Inconsistent naming after duplicate consolidation\n- Missing error handling after simplification\n- Incomplete refactoring (half-done changes)")
+```
+
+### Step 4.3: Verification patterns
+
+Apply `superpowers:verification-before-completion` patterns:
+- Every commit compiles/parses cleanly
+- Test suite passes on HEAD
+- No uncommitted changes remain (except `hack/unfuck/` artifacts)
+- No untracked source files created accidentally
+- Linter passes (if available)
+
+### Step 4.4: Generate cleanup report
+
+Write `{run_dir}/cleanup-report.md`:
+
+```markdown
+# Cleanup Report
+
+Generated: YYYY-MM-DD HH:MM
+Project: <project name>
+Branch: cleanup/unfuck-YYYY-MM-DD
+
+## Summary
+- **Files modified:** N
+- **Lines removed:** N
+- **Lines added:** N
+- **Net delta:** -N lines (or +N if documentation additions outweigh removals)
+- **Issues fixed:** N (across M categories)
+- **Issues blocked:** N (need manual review)
+
+## Changes by Category
+
+### Security (N fixes)
+- S-001: <one-line description of what was fixed>
+- S-002: ...
+Commit: `abc1234` -- `fix(security): <message>`
+
+### Dead Code (N removals)
+- DC-001: <one-line description>
+- DC-002: ...
+Commit: `def5678` -- `refactor: removes dead code -- N unused items`
+
+### Duplicates (N consolidations)
+- DUP-001: ...
+Commit: `ghi9012` -- `refactor: consolidates duplicate code in <area>`
+
+### AI Slop (N simplifications)
+- SLOP-001: ...
+Commit: `jkl3456` -- `refactor: simplifies over-engineered code in <area>`
+
+### Complexity (N reductions)
+- CX-001: ...
+Commit: `mno7890` -- `refactor: reduces complexity in <area>`
+
+### Architecture (N unifications)
+- ARCH-001: ...
+Commit: `pqr1234` -- `refactor: unifies <pattern> across codebase`
+
+### Documentation (N updates)
+- DOC-001: ...
+Commit: `stu5678` -- `docs: syncs documentation with code changes`
+
+## Blocked Items (need manual review)
+
+### BLOCKED: <category> -- <failure summary>
+- **Stash:** `unfuck-<category>-blocked`
+- **Reason:** <why tests failed>
+- **Failing tests:** <list>
+- **Suggested manual fix:** <guidance>
+- **To restore:** `git stash apply stash@{N}` (find with `git stash list | grep unfuck-<category>`)
+
+## Discovery Agent Failures
+(If any agents failed in Phase 1)
+- <agent name>: <error summary>
+- Impact: <what categories may have incomplete coverage>
+
+## External Tools Used
+| Tool | Version | Findings Contributed |
+|------|---------|---------------------|
+| Knip | 5.1.0 | 12 dead exports |
+| Semgrep | 1.50.0 | 3 security issues |
+| Ruff | 0.8.0 | 5 code quality items |
+| (agent-analysis) | -- | Used for: duplicates, complexity, architecture |
+
+## All Commits
+| SHA | Message |
+|-----|---------|
+| abc1234 | fix(security): removes hardcoded secrets |
+| def5678 | refactor: removes dead code -- 15 unused items |
+| ... | ... |
+
+## Remaining Tech Debt
+Items intentionally deferred (low severity, high risk, or requires human decision):
+- [ ] <item>: <reason for deferral>
+- [ ] <item>: <reason for deferral>
+```
+
+Get the line stats with:
+```bash
+git diff --stat $(git merge-base HEAD main)..HEAD
+git diff --shortstat $(git merge-base HEAD main)..HEAD
+```
+
+### Step 4.5: Cleanup intermediate files
+
+```bash
+rm -rf {run_dir}/discovery/
+rm -f {run_dir}/available-tools.json
+```
+
+Keep these files for user reference:
+- `{run_dir}/cleanup-plan.md` -- what was planned
+- `{run_dir}/cleanup-report.md` -- what was done
+
+### Step 4.6: Announce completion
+
+Report to the user:
+
+```
+Cleanup complete. Branch: cleanup/unfuck-YYYY-MM-DD
+
+Summary: N files modified, -N lines net, N issues fixed across M categories.
+N items blocked (need manual review).
+
+Full report: {run_dir}/cleanup-report.md
+Cleanup plan: {run_dir}/cleanup-plan.md
+
+Next steps:
+- Review the branch diff: git diff main..cleanup/unfuck-YYYY-MM-DD
+- Check blocked items in the report (if any)
+- Create a PR when satisfied: gh pr create
+```
+
+---
+
+## Shared JSON Schema for Discovery Output
+
+All 7 discovery agents MUST write their output using this schema. The orchestrator validates each file against this schema before proceeding to Phase 2.
+
+```json
+{
+  "$schema": "discovery-output",
+  "agent": "<agent-name>",
+  "timestamp": "2026-02-18T12:00:00Z",
+  "summary": {
+    "total_findings": 15,
+    "by_severity": {
+      "critical": 0,
+      "high": 3,
+      "medium": 8,
+      "low": 4
+    },
+    "external_tools_used": ["knip"],
+    "agent_analysis_used": true
+  },
+  "findings": [
+    {
+      "id": "DC-001",
+      "severity": "high",
+      "category": "dead-code",
+      "title": "Unused exported function",
+      "file": "src/utils/helpers.ts",
+      "line_start": 42,
+      "line_end": 58,
+      "description": "Function `formatLegacyDate` is exported but has zero references across the codebase.",
+      "evidence": "LSP findReferences returned 0 results. Knip also flagged this export.",
+      "source": "agent-analysis+knip",
+      "suggested_fix": "Remove the function and its export statement.",
+      "risk": "low",
+      "related_findings": []
+    }
+  ]
+}
+```
+
+### Field Definitions
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `$schema` | string | Always `"discovery-output"` |
+| `agent` | string | Agent name matching the roster (e.g., `"dead-code-hunter"`) |
+| `timestamp` | string | ISO 8601 timestamp of when the agent completed |
+| `summary.total_findings` | number | Total number of findings in this output |
+| `summary.by_severity` | object | Breakdown by severity level |
+| `summary.external_tools_used` | array | List of external tools that produced findings |
+| `summary.agent_analysis_used` | boolean | Whether the agent performed manual code analysis |
+| `findings[].id` | string | Unique within this agent's output. Format: category prefix + sequential number |
+| `findings[].severity` | string | `critical` = security vulnerability or data loss risk; `high` = definite issue, safe fix available; `medium` = probable issue, review recommended; `low` = style/preference, optional fix |
+| `findings[].category` | string | Primary category: `dead-code`, `duplicates`, `security`, `architecture`, `ai-slop`, `complexity`, `documentation` |
+| `findings[].title` | string | Short descriptive title |
+| `findings[].file` | string | Relative path from project root |
+| `findings[].line_start` | number | Starting line number |
+| `findings[].line_end` | number | Ending line number |
+| `findings[].description` | string | Detailed explanation of the issue |
+| `findings[].evidence` | string | How it was detected -- tool output, analysis reasoning, etc. |
+| `findings[].source` | string | `"agent-analysis"`, `"<tool-name>"`, or `"agent-analysis+<tool-name>"` for confirmed by both |
+| `findings[].suggested_fix` | string | Recommended fix strategy |
+| `findings[].risk` | string | Risk of the suggested fix breaking something: `low` (safe), `medium` (needs testing), `high` (needs review) |
+| `findings[].related_findings` | array | IDs of related findings in OTHER agents' output (populated during Phase 2 synthesis) |
+
+### ID Prefix Conventions
+
+| Category | Prefix | Example |
+|----------|--------|---------|
+| Dead code | DC | DC-001 |
+| Duplicates | DUP | DUP-001 |
+| Security | S | S-001 |
+| Architecture | ARCH | ARCH-001 |
+| AI slop | SLOP | SLOP-001 |
+| Complexity | CX | CX-001 |
+| Documentation | DOC | DOC-001 |
+
+---
+
+## TeamCreate Configuration
+
+```
+TeamCreate:
+  team_name: "unfuck-cleanup"
+  description: "Comprehensive repo cleanup -- discovery and implementation swarm"
+```
+
+### Discovery Members (Phase 1 -- all spawned in parallel)
+
+| Name | Type | Model | Purpose |
+|------|------|-------|---------|
+| dead-code-hunter | general-purpose | sonnet | Finds unused code, exports, imports, files |
+| duplicate-detector | general-purpose | sonnet | Finds copy-paste code and near-duplicates |
+| security-auditor | general-purpose | sonnet | Finds security vulnerabilities and bad practices |
+| architecture-reviewer | general-purpose | sonnet | Finds structural issues, inconsistencies, divergent patterns |
+| ai-slop-detector | general-purpose | opus | Finds AI-generated bloat, over-abstraction, unnecessary complexity |
+| complexity-auditor | general-purpose | sonnet | Finds overly complex functions, deep nesting, god objects |
+| documentation-auditor | general-purpose | sonnet | Finds stale docs, missing docs, doc/code drift |
+
+### Implementation Members (Phase 3 -- spawned sequentially as needed)
+
+| Name | Type | Mode | Model | Purpose |
+|------|------|------|-------|---------|
+| fix-security | general-purpose | bypassPermissions | sonnet | Applies security fixes |
+| fix-dead-code | general-purpose | bypassPermissions | sonnet | Removes dead code |
+| fix-duplicates | general-purpose | bypassPermissions | sonnet | Consolidates duplicates |
+| fix-ai-slop | general-purpose | bypassPermissions | opus | Simplifies over-engineered code |
+| fix-complexity | general-purpose | bypassPermissions | sonnet | Refactors complex code |
+| fix-architecture | general-purpose | bypassPermissions | sonnet | Unifies architectural patterns |
+| fix-documentation | general-purpose | bypassPermissions | sonnet | Updates documentation |
+
+---
+
+## Error Handling
+
+### Agent Failure (Phase 1)
+
+If a discovery agent fails to produce output:
+1. Log the failure in the cleanup report (agent name, error message)
+2. Skip that category in synthesis -- other agents may have partial coverage of the same issues
+3. Note the gap in the cleanup plan so the user knows coverage is incomplete
+4. Do NOT retry automatically -- the failure likely indicates a fundamental issue
+
+### Test Failure During Implementation (Phase 3)
+
+See the rollback procedure in Phase 3, Step 3d. Key points:
+- Stash changes with a descriptive name
+- Create a blocked task with full failure details
+- Continue to the next category (do not retry)
+- Report all blocked items in Phase 4
+
+### External Tool Failure (Phase 0/1)
+
+If an external tool fails during detection (Phase 0):
+- Mark it as unavailable in `available-tools.json`
+- Agents will use fallback strategies from `references/external-tools.md`
+
+If an external tool fails during agent execution (Phase 1):
+- The agent falls back to manual analysis
+- The agent notes the tool failure in its output's `evidence` field
+- This is expected and handled -- agents are designed to work without external tools
+
+### Git Conflicts
+
+Conflicts between implementation categories should not occur because categories execute sequentially. If a conflict somehow appears:
+1. Stash the current category's changes
+2. Log it as a blocked item
+3. Continue to the next category
+4. Report the conflict in the cleanup report for manual resolution
+
+### AskUserQuestion Timeout (Phase 2)
+
+If the user doesn't respond to the Phase 2 checkpoint:
+1. Wait -- do not proceed without user input if the checkpoint was triggered
+2. The checkpoint only triggers for high-risk conditions that genuinely need human judgment
+3. If the user explicitly says "proceed" or "just do it" without selecting an option, use "Full cleanup" as default
+
+### Insufficient Findings
+
+If Phase 1 produces fewer than 3 total findings across all agents:
+1. Report this to the user -- the codebase may already be clean
+2. Still generate the cleanup plan and report (even if nearly empty)
+3. Skip Phase 3 implementation if there's truly nothing actionable
+4. Suggest running individual focused skills instead (e.g., `sc:cleanup`, `security-review`)


### PR DESCRIPTION
## Summary
- Adds `/unfuck` comprehensive repo cleanup skill to `global-skills` plugin (v1.6.0)
- 5-phase workflow: index, 7-agent discovery swarm, synthesis, sequential implementation, verification
- SKILL.md + 5 reference files (orchestration playbook, discovery agents, implementation agents, AI slop checklist, external tools)

Includes dry-run learnings:
- Phase 1 uses TeamCreate teammates (not background Tasks) to avoid context overflow
- Semgrep wrapped with `env -u HTTPS_PROXY -u HTTP_PROXY` for empty proxy var crash
- Gitleaks uses `go run` exclusively (like uvx/npx pattern)
- Tool-selection-guard warning in agent context bundles
- Date-scoped run directory (`hack/unfuck/YYYY-MM-DD/`) to avoid clobbering between runs

## Test plan
- [x] `make all` passes (355 tests, lint clean)
- [ ] Invoke `/unfuck --dry-run` on a test repo to verify Phase 0-2
