### PR TITLE
feat(global-hooks): URL fetch guard for authenticated services

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -94,7 +94,7 @@
     },
     {
       "name": "global-hooks",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "source": "./global-hooks",
       "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
       "category": "quality",

--- a/global-hooks/.claude-plugin/plugin.json
+++ b/global-hooks/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "global-hooks",
   "description": "Global hooks for git safety checks, commit message validation, pre-push review, and tool selection",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "author": {
     "name": "wgordon"
   }

--- a/global-hooks/hooks/hooks.json
+++ b/global-hooks/hooks/hooks.json
@@ -48,6 +48,15 @@
         ]
       },
       {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py"
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
@@ -64,6 +73,19 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-commit-message.sh"
+          },
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py"
+          }
+        ]
+      },
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py"
           }
         ]
       }

--- a/global-hooks/hooks/tool-selection-guard.py
+++ b/global-hooks/hooks/tool-selection-guard.py
@@ -9,6 +9,7 @@ guidance toward native tools, auto-approved commands, and simpler patterns.
 Also enforces git safety rules (consolidated from git-safety-check.sh).
 """
 
+import datetime
 import functools
 import json
 import logging
@@ -264,6 +265,240 @@ RULES = [
         "Interactive git add will hang. Use `git add` with specific file paths instead.",
     ),
 ]
+
+# ── Category F: Authenticated URL fetch guard ──
+# Each rule: (name, url_pattern, guidance_message)
+# url_pattern: regex matched against the full URL
+AUTH_URL_RULES = [
+    # GitHub
+    (
+        "github-api",
+        re.compile(r"api\.github\.com"),
+        "This URL targets the GitHub API which requires authentication. "
+        "Use the `gh` CLI instead. Example: `gh api repos/OWNER/REPO`.",
+    ),
+    (
+        "github-auth-content",
+        re.compile(r"github\.com/[^/]+/[^/]+/(settings|pulls|issues|actions|security)"),
+        "This GitHub URL requires authentication to return useful content. "
+        "Use the `gh` CLI instead. Example: `gh pr list`, `gh issue list`, `gh run list`.",
+    ),
+    # GitLab (public)
+    (
+        "gitlab-api",
+        re.compile(r"gitlab\.com/api/"),
+        "This URL targets the GitLab API which requires authentication. "
+        "Use `glab api` instead. Example: `glab api projects/:id/issues`.",
+    ),
+    (
+        "gitlab-raw",
+        re.compile(r"gitlab\.com/.+/(-/raw/|-/blob/)"),
+        "This GitLab URL points to raw/blob content which may require authentication. "
+        "Use `glab` CLI or clone the repo locally.",
+    ),
+    # GitLab (internal — entire domain)
+    (
+        "gitlab-internal",
+        re.compile(r"gitlab\.cee\.redhat\.com"),
+        "This URL is on internal GitLab (SSO-gated). "
+        "Use `glab` CLI with the appropriate remote, or clone the repo locally.",
+    ),
+    # Google
+    (
+        "google-docs",
+        re.compile(r"docs\.google\.com/document/"),
+        "Google Docs requires authentication. "
+        "Use a Google MCP tool or `gcloud` CLI to access document content.",
+    ),
+    (
+        "google-drive",
+        re.compile(r"drive\.google\.com/(file|drive)/"),
+        "Google Drive requires authentication. "
+        "Use a Google MCP tool or `gcloud` CLI to access files.",
+    ),
+    (
+        "google-sheets",
+        re.compile(r"sheets\.google\.com/"),
+        "Google Sheets requires authentication. "
+        "Use a Google MCP tool or `gcloud` CLI to access spreadsheet data.",
+    ),
+    # Atlassian / Jira
+    (
+        "atlassian-api",
+        re.compile(r"[a-z0-9-]+\.atlassian\.net/(rest/api|wiki)/"),
+        "This Atlassian URL requires authentication. Use the Atlassian MCP tools instead.",
+    ),
+    (
+        "jira-server",
+        re.compile(r"jira\.[a-z0-9-]+\.(com|org|net)/"),
+        "This Jira server URL requires authentication. "
+        "Use the `jira` CLI or Atlassian MCP tools instead.",
+    ),
+    # Slack
+    (
+        "slack-api",
+        re.compile(r"(api|hooks)\.slack\.com/"),
+        "This Slack URL requires authentication. "
+        "Use the Slack MCP tools or access Slack via Playwright MCP.",
+    ),
+]
+
+
+_URL_LOG_DIR = os.environ.get("URL_GUARD_LOG_DIR", str(Path.home() / ".claude" / "logs"))
+
+
+def _log_url_event(url, rule_name, action, tool, phase="pre", **extra):
+    """Append a JSONL entry to the URL guard audit log."""
+    try:
+        log_dir = Path(_URL_LOG_DIR)
+        log_dir.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "phase": phase,
+            "url": url,
+            "rule": rule_name,
+            "action": action,
+            "tool": tool,
+            **extra,
+        }
+        with open(log_dir / "url-guard.log", "a") as f:
+            f.write(json.dumps(entry) + "\n")
+    except OSError:
+        pass  # Fail silently — logging should never block the guard
+
+
+def _extract_urls(text):
+    """Extract URLs from a string (command line or text)."""
+    return re.findall(r"https?://[^\s\"'<>]+", text)
+
+
+def _check_url_rules(url):
+    """Check a URL against AUTH_URL_RULES. Returns (name, guidance) or None."""
+    for name, pattern, guidance in AUTH_URL_RULES:
+        if pattern.search(url):
+            return (name, guidance)
+    return None
+
+
+def _check_fetch_command(cmd):
+    """Check curl/wget commands for authenticated URLs. Exits 2 on match.
+
+    Returns True if the command was a curl/wget (so caller knows to log),
+    or False if not a fetch command.
+    """
+    normalized = strip_env_prefix(cmd)
+    if not re.match(r"^\s*(curl|wget)\b", normalized):
+        return False
+
+    # ALLOW_FETCH=1 bypass — agent has considered alternatives
+    if re.match(r"^\s*ALLOW_FETCH=1\s", cmd):
+        urls = _extract_urls(cmd)
+        for url in urls:
+            _log_url_event(url, None, "bypassed", "Bash")
+        return True
+
+    urls = _extract_urls(cmd)
+    for url in urls:
+        result = _check_url_rules(url)
+        if result:
+            rule_name, guidance = result
+            _log_url_event(url, rule_name, "blocked", "Bash")
+            print(
+                f"{guidance}\n"
+                "If you've confirmed raw fetch is appropriate, "
+                "prefix with `ALLOW_FETCH=1`.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        else:
+            _log_url_event(url, None, "allowed", "Bash")
+    return True
+
+
+# Patterns indicating authentication failure in HTTP responses
+_AUTH_FAIL_PATTERNS = [
+    re.compile(r"HTTP/[\d.]+ 401\b"),
+    re.compile(r"HTTP/[\d.]+ 403\b"),
+    re.compile(r"HTTP/[\d.]+ 407\b"),
+    re.compile(r"curl: \(22\).*40[1379]"),
+    re.compile(r"Unauthorized", re.IGNORECASE),
+    re.compile(r"Access Denied", re.IGNORECASE),
+    re.compile(r"Login Required", re.IGNORECASE),
+    re.compile(r"sign.?in", re.IGNORECASE),
+    re.compile(r"SSO.*redirect", re.IGNORECASE),
+]
+
+_HTTP_STATUS_RE = re.compile(r"HTTP/[\d.]+ (\d{3})\b")
+
+
+def _detect_auth_failure(text):
+    """Check response text for auth failure indicators.
+
+    Returns (auth_failed: bool, status_code: int | None).
+    """
+    if not text:
+        return False, None
+
+    status_match = _HTTP_STATUS_RE.search(text)
+    status_code = int(status_match.group(1)) if status_match else None
+
+    for pattern in _AUTH_FAIL_PATTERNS:
+        if pattern.search(text):
+            return True, status_code
+
+    return False, status_code
+
+
+def _handle_post_tool_use(data):
+    """Handle PostToolUse events: log response codes for fetch commands."""
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+    tool_response = data.get("tool_response", {})
+
+    if tool_name == "Bash":
+        command = tool_input.get("command", "")
+        normalized = strip_env_prefix(command)
+        if not re.match(r"^\s*(curl|wget)\b", normalized):
+            return
+        urls = _extract_urls(command)
+        response_text = ""
+        if isinstance(tool_response, dict):
+            response_text = str(tool_response.get("stdout", "")) + str(
+                tool_response.get("stderr", "")
+            )
+        elif isinstance(tool_response, str):
+            response_text = tool_response
+        auth_failed, status_code = _detect_auth_failure(response_text)
+        for url in urls:
+            _log_url_event(
+                url,
+                None,
+                "auth_failed" if auth_failed else "success",
+                "Bash",
+                phase="post",
+                response_code=status_code,
+                auth_failed=auth_failed,
+            )
+    elif tool_name == "WebFetch":
+        url = tool_input.get("url", "")
+        if not url:
+            return
+        response_text = ""
+        if isinstance(tool_response, dict):
+            response_text = str(tool_response)
+        elif isinstance(tool_response, str):
+            response_text = tool_response
+        auth_failed, status_code = _detect_auth_failure(response_text)
+        _log_url_event(
+            url,
+            None,
+            "auth_failed" if auth_failed else "success",
+            "WebFetch",
+            phase="post",
+            response_code=status_code,
+            auth_failed=auth_failed,
+        )
+
 
 # Rules to skip when checking pipe segments — these redirect to native tools
 # (Read, Grep, Glob, Edit, Write) that can't process piped command output.
@@ -928,11 +1163,31 @@ def main():
         )
         sys.exit(0)
 
+    # PostToolUse: observational logging only (no blocking)
+    hook_event = data.get("hook_event_name", "PreToolUse")
+    if hook_event == "PostToolUse":
+        _handle_post_tool_use(data)
+        sys.exit(0)
+
     tool_name = data.get("tool_name", "")
     tool_input = data.get("tool_input", {})
 
     _guard_tmp_path(tool_name, tool_input)
     _guard_plan_mode(tool_name)
+
+    # WebFetch: check URL against auth rules
+    if tool_name == "WebFetch":
+        url = tool_input.get("url", "")
+        if url:
+            result = _check_url_rules(url)
+            if result:
+                rule_name, guidance = result
+                _log_url_event(url, rule_name, "blocked", "WebFetch")
+                print(guidance, file=sys.stderr)
+                sys.exit(2)
+            else:
+                _log_url_event(url, None, "allowed", "WebFetch")
+        sys.exit(0)
 
     if tool_name != "Bash":
         sys.exit(0)
@@ -944,6 +1199,9 @@ def main():
     # Andon cord: GUARD_BYPASS=1 prefix skips all rule checks.
     if command.startswith("GUARD_BYPASS=1 "):
         sys.exit(0)
+
+    # Check curl/wget commands for authenticated URLs (before rule checks)
+    _check_fetch_command(command)
 
     subcmds = split_commands(command)
     fetch_seen = False

--- a/global-hooks/tests/test_tool_selection_guard.py
+++ b/global-hooks/tests/test_tool_selection_guard.py
@@ -407,6 +407,169 @@ class TestPassthrough:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# Category F: URL fetch guard (curl/wget + WebFetch)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def run_webfetch(url: str) -> subprocess.CompletedProcess:
+    """Shorthand: invoke guard as WebFetch tool."""
+    return run_guard("WebFetch", {"url": url, "prompt": "test"})
+
+
+class TestURLFetchGuard:
+    """Bash curl/wget commands against authenticated service URLs."""
+
+    @pytest.mark.parametrize(
+        "command, expected_exit, expected_msg",
+        [
+            # BLOCKED: GitHub API
+            ("curl https://api.github.com/repos/org/repo", 2, "gh"),
+            ("curl -s https://api.github.com/repos/org/repo/pulls", 2, "gh"),
+            ("wget https://api.github.com/user", 2, "gh"),
+            # BLOCKED: GitHub auth-gated content
+            ("curl https://github.com/org/repo/settings", 2, "gh"),
+            ("curl https://github.com/org/repo/pulls", 2, "gh"),
+            ("curl https://github.com/org/repo/issues", 2, "gh"),
+            ("curl https://github.com/org/repo/actions", 2, "gh"),
+            ("curl https://github.com/org/repo/security", 2, "gh"),
+            # BLOCKED: GitLab internal (entire domain)
+            (
+                "wget https://gitlab.cee.redhat.com/service/foo/-/raw/main/file.go",
+                2,
+                "glab",
+            ),
+            ("curl https://gitlab.cee.redhat.com/some/project", 2, "glab"),
+            # BLOCKED: GitLab public API/raw
+            ("curl https://gitlab.com/api/v4/projects", 2, "glab"),
+            ("curl https://gitlab.com/org/repo/-/raw/main/f.py", 2, "glab"),
+            ("curl https://gitlab.com/org/repo/-/blob/main/f.py", 2, "glab"),
+            # BLOCKED: Google
+            ("curl https://docs.google.com/document/d/abc123/edit", 2, "Google"),
+            ("curl https://drive.google.com/file/d/abc/view", 2, "Google"),
+            ("curl https://sheets.google.com/spreadsheets/d/abc", 2, "Google"),
+            # BLOCKED: Atlassian/Jira
+            (
+                "curl https://myorg.atlassian.net/rest/api/3/issue/PROJ-123",
+                2,
+                "Atlassian",
+            ),
+            ("curl https://myorg.atlassian.net/wiki/spaces/TEAM", 2, "Atlassian"),
+            ("curl https://jira.example.com/rest/api/latest", 2, "jira"),
+            # BLOCKED: Slack
+            ("curl https://hooks.slack.com/services/T00/B00/xxx", 2, "Slack"),
+            ("curl https://api.slack.com/api/chat.postMessage", 2, "Slack"),
+            # ALLOWED: public pages / non-guarded domains
+            ("curl https://example.com/api/data", 0, None),
+            ("curl https://github.com/org/repo", 0, None),
+            ("curl https://raw.githubusercontent.com/org/repo/main/README.md", 0, None),
+            ("curl https://httpbin.org/get", 0, None),
+            ("curl -s https://jsonplaceholder.typicode.com/posts", 0, None),
+            ("curl https://gitlab.com/org/repo", 0, None),
+            ("curl https://pypi.org/simple/requests", 0, None),
+            # ALLOWED: non-curl/wget commands with URLs pass through
+            ("git clone https://github.com/org/repo.git", 0, None),
+            # BYPASS: ALLOW_FETCH=1
+            ("ALLOW_FETCH=1 curl https://api.github.com/repos/org/repo", 0, None),
+            ("ALLOW_FETCH=1 wget https://gitlab.cee.redhat.com/foo", 0, None),
+            # BLOCKED in pipe (curl is first segment)
+            (
+                "curl https://api.github.com/repos/org/repo | jq .",
+                2,
+                "gh",
+            ),
+        ],
+        ids=[
+            # Blocked
+            "github-api",
+            "github-api-pulls",
+            "github-api-wget",
+            "github-settings",
+            "github-pulls",
+            "github-issues",
+            "github-actions",
+            "github-security",
+            "gitlab-internal-raw",
+            "gitlab-internal-project",
+            "gitlab-api",
+            "gitlab-raw",
+            "gitlab-blob",
+            "google-docs",
+            "google-drive",
+            "google-sheets",
+            "atlassian-api",
+            "atlassian-wiki",
+            "jira-server",
+            "slack-hooks",
+            "slack-api",
+            # Allowed
+            "example-com",
+            "github-public-repo",
+            "github-raw-content",
+            "httpbin",
+            "jsonplaceholder",
+            "gitlab-public-page",
+            "pypi",
+            "git-clone-not-curl",
+            # Bypass
+            "bypass-github-api",
+            "bypass-gitlab-internal",
+            # Pipe
+            "curl-pipe-jq",
+        ],
+    )
+    def test_url_fetch_guard(self, command, expected_exit, expected_msg):
+        result = run_bash(command)
+        assert_guard(result, expected_exit, expected_msg)
+
+
+class TestWebFetchGuard:
+    """WebFetch tool calls against authenticated service URLs."""
+
+    @pytest.mark.parametrize(
+        "url, expected_exit, expected_msg",
+        [
+            # BLOCKED
+            ("https://api.github.com/repos/org/repo", 2, "gh"),
+            ("https://gitlab.cee.redhat.com/anything", 2, "glab"),
+            ("https://docs.google.com/document/d/abc/edit", 2, "Google"),
+            ("https://myorg.atlassian.net/rest/api/3/issue/KEY-1", 2, "Atlassian"),
+            ("https://myorg.atlassian.net/wiki/spaces/TEAM/page", 2, "Atlassian"),
+            ("https://hooks.slack.com/services/T00/B00/xxx", 2, "Slack"),
+            ("https://api.slack.com/api/test", 2, "Slack"),
+            ("https://github.com/org/repo/settings", 2, "gh"),
+            ("https://gitlab.com/api/v4/projects/123", 2, "glab"),
+            ("https://drive.google.com/file/d/abc/view", 2, "Google"),
+            # ALLOWED
+            ("https://example.com", 0, None),
+            ("https://github.com/org/repo", 0, None),
+            ("https://docs.python.org/3/library/json.html", 0, None),
+            ("https://gitlab.com/org/repo", 0, None),
+            ("https://httpbin.org/get", 0, None),
+        ],
+        ids=[
+            "github-api",
+            "gitlab-internal",
+            "google-docs",
+            "atlassian-api",
+            "atlassian-wiki",
+            "slack-hooks",
+            "slack-api",
+            "github-settings",
+            "gitlab-api",
+            "google-drive",
+            "example-com",
+            "github-public",
+            "python-docs",
+            "gitlab-public",
+            "httpbin",
+        ],
+    )
+    def test_webfetch_guard(self, url, expected_exit, expected_msg):
+        result = run_webfetch(url)
+        assert_guard(result, expected_exit, expected_msg)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Chained command splitting
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -1415,3 +1578,255 @@ class TestShellControlStructures:
     def test_control_structures(self, command, expected_exit, expected_msg):
         result = run_bash(command)
         assert_guard(result, expected_exit, expected_msg)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Audit logging: URL guard events logged to JSONL file
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestURLGuardAuditLog:
+    """Verify URL guard events are logged to JSONL file."""
+
+    def _run_with_log_dir(self, tool_name, tool_input, tmp_path):
+        """Run the guard with a custom log directory."""
+        payload = json.dumps({"tool_name": tool_name, "tool_input": tool_input})
+        env = os.environ.copy()
+        env["URL_GUARD_LOG_DIR"] = str(tmp_path)
+        return subprocess.run(
+            ["uv", "run", SCRIPT],
+            input=payload,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def _read_log(self, tmp_path):
+        """Read and parse all JSONL entries from the log file."""
+        log_file = tmp_path / "url-guard.log"
+        if not log_file.exists():
+            return []
+        lines = log_file.read_text().strip().splitlines()
+        return [json.loads(line) for line in lines]
+
+    def test_blocked_url_logged(self, tmp_path):
+        self._run_with_log_dir(
+            "Bash",
+            {"command": "curl https://api.github.com/repos/org/repo"},
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry["action"] == "blocked"
+        assert entry["rule"] == "github-api"
+        assert entry["tool"] == "Bash"
+        assert entry["phase"] == "pre"
+        assert "api.github.com" in entry["url"]
+        assert "timestamp" in entry
+
+    def test_allowed_url_logged(self, tmp_path):
+        self._run_with_log_dir(
+            "Bash",
+            {"command": "curl https://example.com/data"},
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["action"] == "allowed"
+        assert entries[0]["rule"] is None
+
+    def test_bypassed_url_logged(self, tmp_path):
+        self._run_with_log_dir(
+            "Bash",
+            {"command": "ALLOW_FETCH=1 curl https://api.github.com/repos/org/repo"},
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["action"] == "bypassed"
+
+    def test_webfetch_blocked_logged(self, tmp_path):
+        self._run_with_log_dir(
+            "WebFetch",
+            {"url": "https://api.github.com/repos/org/repo", "prompt": "test"},
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["action"] == "blocked"
+        assert entries[0]["tool"] == "WebFetch"
+
+    def test_webfetch_allowed_logged(self, tmp_path):
+        self._run_with_log_dir(
+            "WebFetch",
+            {"url": "https://example.com", "prompt": "test"},
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["action"] == "allowed"
+        assert entries[0]["tool"] == "WebFetch"
+
+    def test_non_fetch_command_not_logged(self, tmp_path):
+        """Non-curl/wget bash commands should not produce log entries."""
+        self._run_with_log_dir("Bash", {"command": "git status"}, tmp_path)
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 0
+
+    def test_jsonl_format(self, tmp_path):
+        """Each line is valid JSON."""
+        self._run_with_log_dir(
+            "Bash",
+            {"command": "curl https://api.github.com/repos/o/r"},
+            tmp_path,
+        )
+        self._run_with_log_dir(
+            "WebFetch",
+            {"url": "https://example.com", "prompt": "t"},
+            tmp_path,
+        )
+        log_file = tmp_path / "url-guard.log"
+        lines = log_file.read_text().strip().splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            entry = json.loads(line)
+            assert "timestamp" in entry
+            assert "url" in entry
+            assert "action" in entry
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# PostToolUse: response code logging
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPostToolUseResponseLogging:
+    """PostToolUse hooks log HTTP response codes for fetch commands."""
+
+    def _run_post_hook(self, tool_name, tool_input, tool_response, tmp_path):
+        """Simulate a PostToolUse hook invocation."""
+        payload = json.dumps(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": tool_name,
+                "tool_input": tool_input,
+                "tool_response": tool_response,
+            }
+        )
+        env = os.environ.copy()
+        env["URL_GUARD_LOG_DIR"] = str(tmp_path)
+        return subprocess.run(
+            ["uv", "run", SCRIPT],
+            input=payload,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def _read_log(self, tmp_path):
+        log_file = tmp_path / "url-guard.log"
+        if not log_file.exists():
+            return []
+        return [json.loads(line) for line in log_file.read_text().strip().splitlines()]
+
+    def test_bash_curl_403_logged(self, tmp_path):
+        """HTTP 403 from curl is logged as auth_failed."""
+        self._run_post_hook(
+            "Bash",
+            {"command": "curl https://example.com/api/data"},
+            {"stdout": "HTTP/1.1 403 Forbidden\n<html>Access Denied</html>", "stderr": ""},
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["phase"] == "post"
+        assert entries[0]["auth_failed"] is True
+        assert entries[0]["response_code"] == 403
+        assert entries[0]["action"] == "auth_failed"
+
+    def test_bash_curl_401_logged(self, tmp_path):
+        """HTTP 401 from curl is logged as auth_failed."""
+        self._run_post_hook(
+            "Bash",
+            {"command": "curl https://example.com/api"},
+            {"stdout": "HTTP/2 401 Unauthorized", "stderr": ""},
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["auth_failed"] is True
+        assert entries[0]["response_code"] == 401
+
+    def test_bash_curl_200_logged(self, tmp_path):
+        """HTTP 200 from curl is logged as success."""
+        self._run_post_hook(
+            "Bash",
+            {"command": "curl https://example.com/data"},
+            {"stdout": 'HTTP/1.1 200 OK\n{"data": 1}', "stderr": ""},
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["auth_failed"] is False
+        assert entries[0]["response_code"] == 200
+        assert entries[0]["action"] == "success"
+
+    def test_webfetch_auth_failed(self, tmp_path):
+        """WebFetch response with auth failure patterns is detected."""
+        self._run_post_hook(
+            "WebFetch",
+            {"url": "https://example.com/page", "prompt": "test"},
+            "Login Required - Please sign in to continue",
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["tool"] == "WebFetch"
+        assert entries[0]["auth_failed"] is True
+
+    def test_webfetch_success(self, tmp_path):
+        """WebFetch response without auth failure is logged as success."""
+        self._run_post_hook(
+            "WebFetch",
+            {"url": "https://example.com", "prompt": "test"},
+            "Welcome to Example.com! Here is the page content.",
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["auth_failed"] is False
+        assert entries[0]["action"] == "success"
+
+    def test_non_fetch_bash_not_logged(self, tmp_path):
+        """Non-curl/wget bash commands produce no PostToolUse log entries."""
+        self._run_post_hook(
+            "Bash",
+            {"command": "git status"},
+            {"stdout": "On branch main", "stderr": ""},
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 0
+
+    def test_post_hook_always_exits_0(self, tmp_path):
+        """PostToolUse hooks are observational — always exit 0."""
+        result = self._run_post_hook(
+            "Bash",
+            {"command": "curl https://api.github.com/repos/org/repo"},
+            {"stdout": "HTTP/1.1 403 Forbidden", "stderr": ""},
+            tmp_path,
+        )
+        assert result.returncode == 0
+
+    def test_sso_redirect_detected(self, tmp_path):
+        """SSO redirect pattern is detected as auth failure."""
+        self._run_post_hook(
+            "WebFetch",
+            {"url": "https://internal.example.com/page", "prompt": "test"},
+            "Redirecting to SSO... SSO redirect detected for authentication",
+            tmp_path,
+        )
+        entries = self._read_log(tmp_path)
+        assert len(entries) == 1
+        assert entries[0]["auth_failed"] is True


### PR DESCRIPTION
## Summary
- Guards curl/wget in Bash and WebFetch tool against known authenticated service URLs (GitHub API, GitLab internal/public, Google Docs/Drive/Sheets, Atlassian/Jira, Slack)
- Hard blocks (exit 2) with CLI tool suggestions; ALLOW_FETCH=1 env var bypass for intentional raw fetches
- JSONL audit logging to ~/.claude/logs/url-guard.log records all URL checks (blocked, bypassed, allowed) for data-driven rule discovery
- PostToolUse response code detection logs auth failures (401/403/SSO redirects) on allowed URLs to surface new rule candidates

## Changes
- `tool-selection-guard.py`: AUTH_URL_RULES data structure, URL extraction, fetch command checking, WebFetch handler, audit logging, PostToolUse response analysis (+258 lines)
- `hooks.json`: WebFetch PreToolUse matcher, Bash/WebFetch PostToolUse matchers
- `test_tool_selection_guard.py`: 62 new tests across TestURLFetchGuard, TestWebFetchGuard, TestURLGuardAuditLog, TestPostToolUseResponseLogging (+415 lines)
- Version bump 1.18.0 -> 1.19.0

## Test plan
- [x] `make all` passes (418 tests, lint clean)
- [ ] E2E: restart session, try `curl https://api.github.com/repos/org/repo` — should block
- [ ] E2E: try WebFetch on `https://gitlab.cee.redhat.com/foo` — should block
- [ ] E2E: try `ALLOW_FETCH=1 curl https://api.github.com/repos/org/repo` — should bypass
- [ ] Verify audit log appears at ~/.claude/logs/url-guard.log