### PR TITLE
feat(dev-guard): adds action field, config validation, and SessionStart hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -1,6 +1,17 @@
 {
   "description": "Global hooks: git safety, commit validation, pre-push review, tool selection",
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py --validate"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1518,6 +1518,8 @@ class TestHooksJsonConfiguration:
                     if script.startswith("uv run "):
                         script = script.replace("uv run ", "")
                         script = script.replace("${CLAUDE_PLUGIN_ROOT}/hooks/", "")
+                    # Strip any arguments (e.g. "--validate") from the script name
+                    script = script.split()[0] if script.strip() else script
                     script_path = os.path.join(hooks_dir, script)
                     assert os.path.exists(script_path), (
                         f"Script '{script}' referenced in {event_name} does not exist "
@@ -1927,6 +1929,18 @@ class TestExtraURLRules:
         )
         assert result.returncode == 0
 
+    def test_non_string_pattern_does_not_break(self, tmp_path):
+        """Non-string pattern (e.g. integer) is silently ignored."""
+        rules = [{"name": "bad", "pattern": 123, "message": "msg"}]
+        rules_file = tmp_path / "bad-type.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules(
+            "Bash",
+            {"command": "curl https://example.com/data"},
+            rules_file,
+        )
+        assert result.returncode == 0
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Custom command guard rules: COMMAND_GUARD_EXTRA_RULES env var
@@ -2073,6 +2087,14 @@ class TestExtraCommandRules:
         result = self._run_with_extra_rules("some command", rules_file)
         assert result.returncode == 0
 
+    def test_non_string_pattern_does_not_break(self, tmp_path):
+        """Non-string pattern (e.g. integer) is silently ignored."""
+        rules = [{"name": "bad", "pattern": 123, "message": "msg"}]
+        rules_file = tmp_path / "bad-type.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules("some command", rules_file)
+        assert result.returncode == 0
+
     def test_multiple_extra_rules(self, tmp_path):
         """Multiple custom rules are all checked."""
         rules = [
@@ -2100,3 +2122,438 @@ class TestExtraCommandRules:
         # Neither rule matches
         result = self._run_with_extra_rules("oc get pods", rules_file)
         assert result.returncode == 0
+
+    def test_action_ask_exits_1(self, tmp_path):
+        """action: ask causes exit 1 (confirmation prompt) instead of exit 2."""
+        rules = [
+            {
+                "name": "oc-scale-zero",
+                "pattern": r"^\s*oc\s+scale\b.*--replicas=0",
+                "message": "Scaling to zero — confirm this is intentional.",
+                "action": "ask",
+            }
+        ]
+        rules_file = tmp_path / "extra-cmd-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules("oc scale deployment/app --replicas=0", rules_file)
+        assert result.returncode == 1
+        assert "confirm" in result.stderr.lower()
+
+    def test_action_block_exits_2(self, tmp_path):
+        """action: block (explicit) causes exit 2."""
+        rules = [
+            {
+                "name": "oc-delete",
+                "pattern": r"^\s*oc\s+delete\b",
+                "message": "oc delete blocked.",
+                "action": "block",
+            }
+        ]
+        rules_file = tmp_path / "extra-cmd-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules("oc delete pod my-pod", rules_file)
+        assert result.returncode == 2
+
+    def test_action_default_is_block(self, tmp_path):
+        """Omitting action defaults to block (exit 2)."""
+        rules = [
+            {
+                "name": "oc-delete",
+                "pattern": r"^\s*oc\s+delete\b",
+                "message": "oc delete blocked.",
+            }
+        ]
+        rules_file = tmp_path / "extra-cmd-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules("oc delete pod my-pod", rules_file)
+        assert result.returncode == 2
+
+    def test_action_ask_with_exception(self, tmp_path):
+        """action: ask works with exception patterns."""
+        rules = [
+            {
+                "name": "oc-scale-zero",
+                "pattern": r"^\s*oc\s+scale\b.*--replicas=0",
+                "message": "Scaling to zero — confirm.",
+                "action": "ask",
+                "exception": "--dry-run",
+            }
+        ]
+        rules_file = tmp_path / "extra-cmd-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        # Without exception → ask (exit 1)
+        result = self._run_with_extra_rules("oc scale deployment/app --replicas=0", rules_file)
+        assert result.returncode == 1
+        # With exception → allowed (exit 0)
+        result = self._run_with_extra_rules(
+            "oc scale deployment/app --replicas=0 --dry-run", rules_file
+        )
+        assert result.returncode == 0
+
+    def test_mixed_actions(self, tmp_path):
+        """Rules with different actions coexist correctly."""
+        rules = [
+            {
+                "name": "oc-delete",
+                "pattern": r"^\s*oc\s+delete\b",
+                "message": "oc delete blocked.",
+                "action": "block",
+            },
+            {
+                "name": "oc-scale-zero",
+                "pattern": r"^\s*oc\s+scale\b.*--replicas=0",
+                "message": "Scaling to zero — confirm.",
+                "action": "ask",
+            },
+        ]
+        rules_file = tmp_path / "extra-cmd-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        # Block rule → exit 2
+        result = self._run_with_extra_rules("oc delete pod my-pod", rules_file)
+        assert result.returncode == 2
+        # Ask rule → exit 1
+        result = self._run_with_extra_rules("oc scale deployment/app --replicas=0", rules_file)
+        assert result.returncode == 1
+        # Neither → exit 0
+        result = self._run_with_extra_rules("oc get pods", rules_file)
+        assert result.returncode == 0
+
+    def test_invalid_action_defaults_to_block(self, tmp_path):
+        """Unknown action value defaults to block (exit 2)."""
+        rules = [
+            {
+                "name": "oc-delete",
+                "pattern": r"^\s*oc\s+delete\b",
+                "message": "oc delete blocked.",
+                "action": "invalid-value",
+            }
+        ]
+        rules_file = tmp_path / "extra-cmd-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules("oc delete pod my-pod", rules_file)
+        assert result.returncode == 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Custom URL guard rules: action field support
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestExtraURLRulesAction:
+    """URL_GUARD_EXTRA_RULES action field: ask (exit 1) vs block (exit 2)."""
+
+    def _run_with_extra_rules(self, tool_name, tool_input, rules_file):
+        """Run the guard with a custom extra URL rules file."""
+        payload = json.dumps({"tool_name": tool_name, "tool_input": tool_input})
+        env = os.environ.copy()
+        env["URL_GUARD_EXTRA_RULES"] = str(rules_file)
+        return subprocess.run(
+            ["uv", "run", SCRIPT],
+            input=payload,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_url_action_ask_exits_1(self, tmp_path):
+        """URL rule with action: ask causes exit 1."""
+        rules = [
+            {
+                "name": "staging-api",
+                "pattern": r"staging\.api\.example\.com",
+                "message": "Staging API — confirm this is intentional.",
+                "action": "ask",
+            }
+        ]
+        rules_file = tmp_path / "extra-url-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules(
+            "WebFetch",
+            {"url": "https://staging.api.example.com/data", "prompt": "test"},
+            rules_file,
+        )
+        assert result.returncode == 1
+
+    def test_url_action_block_exits_2(self, tmp_path):
+        """URL rule with action: block (explicit) causes exit 2."""
+        rules = [
+            {
+                "name": "internal-api",
+                "pattern": r"internal\.example\.com",
+                "message": "Blocked.",
+                "action": "block",
+            }
+        ]
+        rules_file = tmp_path / "extra-url-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules(
+            "WebFetch",
+            {"url": "https://internal.example.com/api", "prompt": "test"},
+            rules_file,
+        )
+        assert result.returncode == 2
+
+    def test_url_action_default_is_block(self, tmp_path):
+        """Omitting action on URL rule defaults to block (exit 2)."""
+        rules = [
+            {
+                "name": "internal-api",
+                "pattern": r"internal\.example\.com",
+                "message": "Blocked.",
+            }
+        ]
+        rules_file = tmp_path / "extra-url-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules(
+            "WebFetch",
+            {"url": "https://internal.example.com/api", "prompt": "test"},
+            rules_file,
+        )
+        assert result.returncode == 2
+
+    def test_url_action_ask_curl(self, tmp_path):
+        """URL rule with action: ask also works for curl commands."""
+        rules = [
+            {
+                "name": "staging-api",
+                "pattern": r"staging\.api\.example\.com",
+                "message": "Staging API — confirm.",
+                "action": "ask",
+            }
+        ]
+        rules_file = tmp_path / "extra-url-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = self._run_with_extra_rules(
+            "Bash",
+            {"command": "curl https://staging.api.example.com/data"},
+            rules_file,
+        )
+        assert result.returncode == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# --validate mode: config file validation
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _run_validate(**env_overrides) -> subprocess.CompletedProcess:
+    """Run the guard with --validate flag and optional env var overrides."""
+    env = os.environ.copy()
+    # Clear any existing config env vars
+    env.pop("URL_GUARD_EXTRA_RULES", None)
+    env.pop("COMMAND_GUARD_EXTRA_RULES", None)
+    env.update(env_overrides)
+    return subprocess.run(
+        ["uv", "run", SCRIPT, "--validate"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestValidateMode:
+    """--validate flag checks config files and reports issues."""
+
+    def test_no_env_vars_exits_0_silently(self):
+        """No env vars set → exit 0, no output."""
+        result = _run_validate()
+        assert result.returncode == 0
+        assert result.stderr.strip() == ""
+
+    def test_valid_url_rules(self, tmp_path):
+        """Valid URL rules file → exit 0, success message."""
+        rules = [
+            {
+                "name": "internal",
+                "pattern": r"internal\.example\.com",
+                "message": "Blocked.",
+            }
+        ]
+        rules_file = tmp_path / "url-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(URL_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 0
+        assert "1 rule(s)" in result.stderr
+
+    def test_valid_command_rules(self, tmp_path):
+        """Valid command rules file → exit 0, success message."""
+        rules = [
+            {
+                "name": "oc-delete",
+                "pattern": r"^\s*oc\s+delete\b",
+                "message": "Blocked.",
+            },
+            {
+                "name": "gh-delete",
+                "pattern": r"^\s*gh\s+repo\s+delete\b",
+                "message": "Blocked.",
+            },
+        ]
+        rules_file = tmp_path / "cmd-rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 0
+        assert "2 rule(s)" in result.stderr
+
+    def test_missing_file(self, tmp_path):
+        """Missing file → exit 1, error message."""
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(tmp_path / "nonexistent.json"))
+        assert result.returncode == 1
+        assert "file not found" in result.stderr
+
+    def test_invalid_json(self, tmp_path):
+        """Invalid JSON → exit 1, error message."""
+        rules_file = tmp_path / "bad.json"
+        rules_file.write_text("not json {{{")
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "invalid JSON" in result.stderr
+
+    def test_not_array(self, tmp_path):
+        """JSON object instead of array → exit 1, error message."""
+        rules_file = tmp_path / "obj.json"
+        rules_file.write_text('{"name": "x"}')
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "expected JSON array" in result.stderr
+
+    def test_empty_array(self, tmp_path):
+        """Empty array → exit 1, warning."""
+        rules_file = tmp_path / "empty.json"
+        rules_file.write_text("[]")
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "empty array" in result.stderr
+
+    def test_missing_required_fields(self, tmp_path):
+        """Missing name/pattern/message → exit 1, lists missing fields."""
+        rules = [{"name": "x"}]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "missing required field 'pattern'" in result.stderr
+        assert "missing required field 'message'" in result.stderr
+
+    def test_non_string_pattern(self, tmp_path):
+        """Non-string pattern → exit 1, type error."""
+        rules = [{"name": "x", "pattern": 123, "message": "msg"}]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "must be a string" in result.stderr
+
+    def test_invalid_regex_pattern(self, tmp_path):
+        """Invalid regex → exit 1, regex error."""
+        rules = [{"name": "x", "pattern": "[invalid(", "message": "msg"}]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "invalid regex" in result.stderr
+
+    def test_empty_pattern_warning(self, tmp_path):
+        """Empty pattern string → exit 1, warns about matching everything."""
+        rules = [{"name": "x", "pattern": "", "message": "msg"}]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "match ALL" in result.stderr
+
+    def test_empty_exception_warning(self, tmp_path):
+        """Empty exception string → exit 1, warns about disabling rule."""
+        rules = [{"name": "x", "pattern": r"^\s*oc\b", "message": "msg", "exception": ""}]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "disabling this rule" in result.stderr
+
+    def test_invalid_exception_regex(self, tmp_path):
+        """Invalid exception regex → exit 1."""
+        rules = [
+            {
+                "name": "x",
+                "pattern": r"^\s*oc\b",
+                "message": "msg",
+                "exception": "[bad(",
+            }
+        ]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "invalid regex in 'exception'" in result.stderr
+
+    def test_invalid_action_value(self, tmp_path):
+        """Unknown action value → exit 1."""
+        rules = [{"name": "x", "pattern": r"oc", "message": "msg", "action": "warn"}]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "'block' or 'ask'" in result.stderr
+
+    def test_non_string_action(self, tmp_path):
+        """Non-string action → exit 1."""
+        rules = [{"name": "x", "pattern": r"oc", "message": "msg", "action": 1}]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "'action' must be a string" in result.stderr
+
+    def test_entry_not_object(self, tmp_path):
+        """Array entry that isn't an object → exit 1."""
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text('["not an object"]')
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "expected object" in result.stderr
+
+    def test_valid_with_action_ask(self, tmp_path):
+        """Valid rule with action: ask → exit 0."""
+        rules = [
+            {
+                "name": "x",
+                "pattern": r"^\s*oc\s+scale\b",
+                "message": "Confirm.",
+                "action": "ask",
+            }
+        ]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 0
+
+    def test_mixed_valid_and_invalid(self, tmp_path):
+        """One valid + one invalid file → exit 1, shows both."""
+        url_rules = [{"name": "x", "pattern": r"example\.com", "message": "Blocked."}]
+        url_file = tmp_path / "url.json"
+        url_file.write_text(json.dumps(url_rules))
+        cmd_file = tmp_path / "cmd.json"
+        cmd_file.write_text("bad json")
+        result = _run_validate(
+            URL_GUARD_EXTRA_RULES=str(url_file),
+            COMMAND_GUARD_EXTRA_RULES=str(cmd_file),
+        )
+        assert result.returncode == 1
+        # URL rules valid
+        assert "1 rule(s)" in result.stderr
+        # Command rules invalid
+        assert "invalid JSON" in result.stderr
+
+    def test_multiple_issues_in_one_file(self, tmp_path):
+        """Multiple entries with different issues → all reported."""
+        rules = [
+            {"name": "a", "pattern": "[bad(", "message": "msg"},
+            {"name": "b", "pattern": r"ok", "action": "invalid"},
+        ]
+        rules_file = tmp_path / "rules.json"
+        rules_file.write_text(json.dumps(rules))
+        result = _run_validate(COMMAND_GUARD_EXTRA_RULES=str(rules_file))
+        assert result.returncode == 1
+        assert "invalid regex" in result.stderr
+        assert "'block' or 'ask'" in result.stderr


### PR DESCRIPTION
## Summary

- Adds optional `action` field (`"block"` or `"ask"`) to both `*_EXTRA_RULES` JSON configs
- Adds `--validate` mode for config file validation (regex, types, required fields, footguns)
- Adds SessionStart hook to validate configs automatically on session start
- Fixes `TypeError` and `AttributeError` crashes from malformed JSON entries in both loaders
