### PR TITLE
feat(dev-guard): block commands that trigger Claude Code false positives

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "author": { "name": "wgordon17" }
 }


### PR DESCRIPTION
## Summary

- Adds two new checks in `_check_subcmd` that intercept command patterns known to trigger Claude Code's built-in permission heuristics (process substitution `<(...)` and multiline `python -c`), blocking them with actionable guidance before the user sees cryptic built-in messages like "Command contains empty quotes before dash (potential bypass)"
- Follows the existing `bash -c` wrapper detection pattern — structural checks that run early in the command pipeline
- 6 new tests covering both blocked and allowed cases