### PR TITLE
feat(cmux-integration): adds CMUX integration plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "personal-claude-marketplace",
   "metadata": {
     "description": "Personal Claude Code plugins: LSP servers (uvx/npx) and custom agents",
-    "version": "2.2.0"
+    "version": "2.3.0"
   },
   "owner": {
     "name": "wgordon17"
@@ -104,6 +104,17 @@
       "description": "Git workflow tools: history manipulation, defense-in-depth hooks, commit review, and CONTRIBUTING.md generation",
       "category": "productivity",
       "tags": ["git", "hooks", "commits", "history"],
+      "author": {
+        "name": "wgordon17"
+      }
+    },
+    {
+      "name": "cmux-integration",
+      "version": "1.0.0",
+      "source": "./cmux-integration",
+      "description": "Bridges Claude Code hook events to CMUX terminal's CLI API: notifications, sidebar status, and activity logging",
+      "category": "productivity",
+      "tags": ["cmux", "hooks", "notifications", "terminal"],
       "author": {
         "name": "wgordon17"
       }

--- a/cmux-integration/.claude-plugin/plugin.json
+++ b/cmux-integration/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "cmux-integration",
+  "description": "Bridges Claude Code hook events to CMUX terminal's CLI API: notifications, sidebar status, and activity logging",
+  "version": "1.0.0",
+  "author": { "name": "wgordon17" }
+}

--- a/cmux-integration/README.md
+++ b/cmux-integration/README.md
@@ -1,0 +1,61 @@
+# CMUX Integration Plugin
+
+Bridges Claude Code hook events to CMUX terminal's CLI API for rich notifications, sidebar status pills, and activity logging. Replaces the basic cmux-notify.sh script from CMUX docs with comprehensive coverage of all relevant hook events.
+
+## Event → CMUX Mapping
+
+| Hook Event | Matcher | CMUX Action | Content |
+|---|---|---|---|
+| Notification | (all types) | `cmux notify` | title from notification_type, body from message field |
+| SubagentStop | (all) | `cmux notify` + `cmux log` | "Agent [type] finished: [first sentence]" |
+| Stop | (all) | `cmux set-status` + `cmux notify` | status pill "complete", notify with summary |
+| SessionStart | (all) | `cmux set-status` + `cmux log` | status pill "session active", log entry |
+| SessionEnd | (all) | `cmux clear-status` + `cmux log` | clear all status, log "session ended" |
+| PreToolUse | Bash, Task | `cmux set-status` | activity pill "Running: [cmd]" or "Spawning: [agent]" |
+| PostToolUse | Task | `cmux log` + `cmux clear-status` | log task result, clear activity |
+
+## Prerequisites
+
+- CMUX installed (see [CMUX Getting Started](https://www.cmux.dev/docs))
+- `cmux` CLI symlink in PATH (per CMUX documentation)
+
+The plugin degrades gracefully — if CMUX is not running or the CLI is not available, all hooks exit silently without impacting Claude Code operation.
+
+## Installation
+
+```bash
+claude plugin marketplace add cmux-integration@personal-claude-marketplace
+```
+
+## Migration from Manual cmux-notify.sh
+
+If you previously followed CMUX's notification docs and created `~/.claude/hooks/cmux-notify.sh` with corresponding `settings.json` entries, remove the script and delete the `Stop`/`PostToolUse` hook entries from `~/.claude/settings.json` to avoid duplicate notifications:
+
+```bash
+rm ~/.claude/hooks/cmux-notify.sh
+# Then edit ~/.claude/settings.json to remove the cmux-notify.sh hook entries
+```
+
+The plugin auto-detects the legacy script at session start and warns if it's still present.
+
+## Graceful Degradation
+
+The plugin checks `cmux ping` on each hook invocation. If CMUX is not running or the CLI is not in PATH:
+
+- All hooks exit with code 0 (success)
+- No errors are printed
+- Claude Code operation is unaffected
+- No external communication occurs — all interaction is local via the `cmux` CLI
+
+## Privacy Note
+
+Notifications may include the first sentence of Claude's last response (from `SubagentStop` and `Stop` events). This content is already visible in your terminal but may appear in:
+
+- Desktop notification history
+- CMUX's sidebar log
+
+No data is sent to external services — all communication is local via the cmux CLI.
+
+## Author
+
+wgordon17 - February 2026

--- a/cmux-integration/hooks/cmux-hook.py
+++ b/cmux-integration/hooks/cmux-hook.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""CMUX Integration Hook -- bridges Claude Code events to cmux CLI.
+
+Routes hook events (session lifecycle, tool use, notifications, agent completion)
+to the cmux terminal multiplexer for sidebar status, desktop notifications,
+and activity logging.
+"""
+
+import contextlib
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+_CMUX_AVAILABLE: bool | None = None
+
+_MAX_INPUT = 10 * 1024 * 1024  # 10 MB
+
+
+def _cmux_available() -> bool:
+    """Check if cmux CLI is reachable. Caches result for the process lifetime."""
+    global _CMUX_AVAILABLE
+    if _CMUX_AVAILABLE is not None:
+        return _CMUX_AVAILABLE
+    try:
+        result = subprocess.run(
+            ["cmux", "ping"],
+            capture_output=True,
+            timeout=2,  # noqa: S603, S607
+        )
+        _CMUX_AVAILABLE = result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        _CMUX_AVAILABLE = False
+    return _CMUX_AVAILABLE
+
+
+def _cmux(*args: str) -> None:
+    """Fire-and-forget cmux CLI call. Never raises."""
+    with contextlib.suppress(Exception):
+        subprocess.run(  # noqa: S603, S607
+            ["cmux", *args], capture_output=True, timeout=5
+        )
+
+
+# Sentence-boundary pattern: period/exclamation/question followed by whitespace.
+_SENTENCE_END = re.compile(r"[.!?]\s")
+
+
+def _first_sentence(text: str | None) -> str:
+    """Extract the first sentence from *text*, truncated to 120 chars."""
+    if not text:
+        return ""
+    m = _SENTENCE_END.search(text)
+    sentence = text[: m.start() + 1] if m else text
+    sentence = sentence.strip()
+    if len(sentence) > 120:
+        sentence = sentence[:117] + "..."
+    return sentence
+
+
+def _parse_hook_input() -> dict:
+    """Read and parse JSON hook payload from stdin."""
+    raw = sys.stdin.buffer.read(_MAX_INPUT + 1)
+    if len(raw) > _MAX_INPUT:
+        sys.exit(0)
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        print("cmux-hook: failed to parse hook input", file=sys.stderr)
+        sys.exit(0)
+
+
+# ── Event Handlers ──────────────────────────────────────────────────────────
+
+
+def _handle_notification(data: dict) -> None:
+    notification_type = data.get("notification_type", "")
+    message = data.get("message", "")
+    title_map = {
+        "permission_prompt": "Permission Needed",
+        "idle_prompt": "Claude Idle",
+        "auth_success": "Auth Success",
+        "elicitation_dialog": "Claude Code",
+    }
+    title = title_map.get(notification_type) or data.get("title") or "Claude Code"
+    _cmux("notify", "--title", title, "--body", message)
+
+
+def _handle_subagent_stop(data: dict) -> None:
+    agent_type = data.get("agent_type") or "unknown"
+    msg = _first_sentence(data.get("last_assistant_message"))
+    body = f"Agent {agent_type} finished: {msg}" if msg else f"Agent {agent_type} finished"
+    _cmux("notify", "--title", "Agent Complete", "--body", body)
+    _cmux("log", body, "--level", "success", "--source", "claude")
+
+
+def _handle_stop(data: dict) -> None:
+    if data.get("stop_hook_active") is True:
+        return
+    msg = _first_sentence(data.get("last_assistant_message"))
+    _cmux("set-status", "claude-session", "complete", "--icon", "✓", "--color", "green")
+    _cmux("clear-status", "claude-activity")
+    body = f"Work complete: {msg}" if msg else "Work complete"
+    _cmux("notify", "--title", "Claude Code", "--body", body)
+    _cmux("log", "Claude stopped", "--level", "info", "--source", "claude")
+
+
+def _handle_session_start(data: dict) -> None:
+    legacy_hook = Path.home() / ".claude" / "hooks" / "cmux-notify.sh"
+    if legacy_hook.exists():
+        print(
+            "Warning: ~/.claude/hooks/cmux-notify.sh detected. "
+            "This may cause duplicate CMUX notifications. "
+            "Consider removing it — the cmux-integration plugin handles all CMUX notifications.",
+            file=sys.stderr,
+        )
+    _cmux("set-status", "claude-session", "active", "--icon", "●", "--color", "green")
+    _cmux("log", "Session started", "--level", "info", "--source", "claude")
+
+
+def _handle_session_end(data: dict) -> None:
+    _cmux("clear-status", "claude-session")
+    _cmux("clear-status", "claude-activity")
+    _cmux("log", "Session ended", "--level", "info", "--source", "claude")
+
+
+def _handle_pre_tool_use(data: dict) -> None:
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+    if tool_name == "Bash":
+        cmd = tool_input.get("command", "")[:60]
+        _cmux("set-status", "claude-activity", f"Running: {cmd}", "--icon", "⏳")
+    elif tool_name == "Task":
+        desc = tool_input.get("description", "agent")[:60]
+        _cmux("set-status", "claude-activity", f"Spawning: {desc}", "--icon", "🚀")
+
+
+def _handle_post_tool_use(data: dict) -> None:
+    _cmux("clear-status", "claude-activity")
+    response = data.get("tool_response", "")
+    if isinstance(response, str):
+        summary = _first_sentence(response)
+    elif isinstance(response, dict):
+        summary = _first_sentence(str(response.get("stdout", ""))[:500])
+    else:
+        summary = ""
+    msg = f"Task completed: {summary}" if summary else "Task completed"
+    _cmux("log", msg, "--level", "success", "--source", "claude")
+
+
+# ── Dispatcher ──────────────────────────────────────────────────────────────
+
+_DISPATCH: dict[str, Callable[[dict], None]] = {
+    "Notification": _handle_notification,
+    "SubagentStop": _handle_subagent_stop,
+    "Stop": _handle_stop,
+    "SessionStart": _handle_session_start,
+    "SessionEnd": _handle_session_end,
+    "PreToolUse": _handle_pre_tool_use,
+    "PostToolUse": _handle_post_tool_use,
+}
+
+
+def main() -> None:
+    data = _parse_hook_input()
+    if not _cmux_available():
+        sys.exit(0)
+    event = data.get("hook_event_name", "")
+    handler = _DISPATCH.get(event)
+    if handler:
+        handler(data)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmux-integration/hooks/hooks.json
+++ b/cmux-integration/hooks/hooks.json
@@ -1,0 +1,91 @@
+{
+  "description": "CMUX integration: route Claude Code hook events to cmux CLI for notifications, status, and activity logging",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cmux-integration/tests/test_cmux_hook.py
+++ b/cmux-integration/tests/test_cmux_hook.py
@@ -1,0 +1,784 @@
+"""Tests for cmux-hook.py
+
+Comprehensive tests for CMUX Integration Hook event handlers and utilities.
+Uses mocking for subprocess calls and stdin parsing.
+"""
+
+import importlib.util
+import io
+import json
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+SCRIPT = Path(__file__).parent.parent / "hooks" / "cmux-hook.py"
+spec = importlib.util.spec_from_file_location("cmux_hook", SCRIPT)
+cmux_hook = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cmux_hook)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _first_sentence() tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFirstSentence:
+    """Tests for _first_sentence() extraction and truncation."""
+
+    def test_normal_sentence_with_period(self):
+        """Extract sentence ending with period."""
+        result = cmux_hook._first_sentence("Hello world. More text.")
+        assert result == "Hello world."
+
+    def test_sentence_ending_with_exclamation(self):
+        """Extract sentence ending with exclamation mark."""
+        result = cmux_hook._first_sentence("Done! Next.")
+        assert result == "Done!"
+
+    def test_sentence_ending_with_question(self):
+        """Extract sentence ending with question mark."""
+        result = cmux_hook._first_sentence("Really? Yes.")
+        assert result == "Really?"
+
+    def test_multiline_with_newline(self):
+        """Extract first sentence from multi-line text with newline."""
+        result = cmux_hook._first_sentence("First line.\nSecond line.")
+        assert result == "First line."
+
+    def test_empty_string(self):
+        """Empty string returns empty string."""
+        result = cmux_hook._first_sentence("")
+        assert result == ""
+
+    def test_none_input(self):
+        """None input returns empty string."""
+        result = cmux_hook._first_sentence(None)
+        assert result == ""
+
+    def test_no_sentence_boundary(self):
+        """Text without sentence boundary returns full text."""
+        result = cmux_hook._first_sentence("No punctuation here")
+        assert result == "No punctuation here"
+
+    def test_very_long_text_truncated(self):
+        """Text longer than 120 chars is truncated with '...'."""
+        long_text = "A" * 130 + ". More text."
+        result = cmux_hook._first_sentence(long_text)
+        assert result == "A" * 117 + "..."
+        assert len(result) == 120
+
+    def test_very_long_first_sentence_truncated(self):
+        """Very long first sentence is truncated with '...'."""
+        long_sentence = "A" * 150 + ". Next."
+        result = cmux_hook._first_sentence(long_sentence)
+        assert result == "A" * 117 + "..."
+        assert len(result) == 120
+
+    def test_sentence_with_trailing_whitespace(self):
+        """Whitespace is stripped from result."""
+        result = cmux_hook._first_sentence("  Hello world.  More text.")
+        assert result == "Hello world."
+
+    def test_sentence_with_multiple_spaces_after_period(self):
+        """Period followed by multiple spaces still marks sentence boundary."""
+        result = cmux_hook._first_sentence("First.   Second.")
+        assert result == "First."
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _parse_hook_input() tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestParseHookInput:
+    """Tests for _parse_hook_input() JSON parsing."""
+
+    def test_valid_json_on_stdin(self):
+        """Valid JSON payload is parsed and returned."""
+        payload = json.dumps({"hook_event_name": "Stop", "data": "test"})
+        with mock.patch("sys.stdin.buffer.read", return_value=payload.encode()):
+            result = cmux_hook._parse_hook_input()
+            assert result == {"hook_event_name": "Stop", "data": "test"}
+
+    def test_invalid_json_exits_zero(self):
+        """Invalid JSON causes SystemExit with code 0 (fail-open)."""
+        with (
+            mock.patch("sys.stdin.buffer.read", return_value=b"not json"),
+            mock.patch("sys.stderr"),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook._parse_hook_input()
+            assert exc_info.value.code == 0
+
+    def test_empty_stdin_exits_zero(self):
+        """Empty stdin causes SystemExit with code 0."""
+        with mock.patch("sys.stdin.buffer.read", return_value=b""):
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook._parse_hook_input()
+            assert exc_info.value.code == 0
+
+    def test_oversized_input_exits_zero(self):
+        """Input larger than _MAX_INPUT causes SystemExit with code 0."""
+        large_input = b"x" * (10 * 1024 * 1024 + 1)
+        with mock.patch("sys.stdin.buffer.read", return_value=large_input):
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook._parse_hook_input()
+            assert exc_info.value.code == 0
+
+    def test_error_printed_to_stderr(self):
+        """Parse errors are printed to stderr."""
+        with (
+            mock.patch("sys.stdin.buffer.read", return_value=b"invalid"),
+            mock.patch("sys.stderr"),
+            pytest.raises(SystemExit),
+        ):
+            cmux_hook._parse_hook_input()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _cmux_available() tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCmuxAvailable:
+    """Tests for _cmux_available() subprocess check and caching."""
+
+    def setup_method(self):
+        """Reset global cache before each test."""
+        cmux_hook._CMUX_AVAILABLE = None
+
+    def test_cmux_ping_success(self):
+        """Successful cmux ping returns True."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(returncode=0)
+            result = cmux_hook._cmux_available()
+            assert result is True
+            mock_run.assert_called_once_with(["cmux", "ping"], capture_output=True, timeout=2)
+
+    def test_cmux_ping_failure(self):
+        """Failed cmux ping (returncode 1) returns False."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(returncode=1)
+            result = cmux_hook._cmux_available()
+            assert result is False
+
+    def test_cmux_not_in_path(self):
+        """FileNotFoundError when cmux not in PATH returns False."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError()
+            result = cmux_hook._cmux_available()
+            assert result is False
+
+    def test_cmux_timeout(self):
+        """TimeoutExpired exception returns False."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired("cmux", 2)
+            result = cmux_hook._cmux_available()
+            assert result is False
+
+    def test_cmux_os_error(self):
+        """OSError exception returns False."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.side_effect = OSError()
+            result = cmux_hook._cmux_available()
+            assert result is False
+
+    def test_result_cached(self):
+        """Result is cached; second call doesn't run subprocess."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.return_value = mock.Mock(returncode=0)
+            result1 = cmux_hook._cmux_available()
+            result2 = cmux_hook._cmux_available()
+            assert result1 is True
+            assert result2 is True
+            # Should only be called once
+            assert mock_run.call_count == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# _cmux() tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCmuxCall:
+    """Tests for _cmux() fire-and-forget subprocess calls."""
+
+    def test_successful_call(self):
+        """Successful subprocess call completes without error."""
+        with mock.patch("subprocess.run") as mock_run:
+            cmux_hook._cmux("notify", "--title", "Test", "--body", "Message")
+            mock_run.assert_called_once_with(
+                ["cmux", "notify", "--title", "Test", "--body", "Message"],
+                capture_output=True,
+                timeout=5,
+            )
+
+    def test_exception_suppressed(self):
+        """Exceptions during call are swallowed."""
+        with mock.patch("subprocess.run") as mock_run:
+            mock_run.side_effect = RuntimeError("Test error")
+            # Should not raise
+            cmux_hook._cmux("notify", "--title", "Test", "--body", "Message")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Handler tests (with _cmux mocked)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestHandleNotification:
+    """Tests for _handle_notification() event handler."""
+
+    def test_permission_prompt_type(self):
+        """permission_prompt notification gets 'Permission Needed' title."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "notification_type": "permission_prompt",
+                "message": "Need permission",
+            }
+            cmux_hook._handle_notification(data)
+            mock_cmux.assert_called_once_with(
+                "notify",
+                "--title",
+                "Permission Needed",
+                "--body",
+                "Need permission",
+            )
+
+    def test_idle_prompt_type(self):
+        """idle_prompt notification gets 'Claude Idle' title."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"notification_type": "idle_prompt", "message": "Claude is idle"}
+            cmux_hook._handle_notification(data)
+            mock_cmux.assert_called_once_with(
+                "notify", "--title", "Claude Idle", "--body", "Claude is idle"
+            )
+
+    def test_auth_success_type(self):
+        """auth_success notification gets 'Auth Success' title."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "notification_type": "auth_success",
+                "message": "Authenticated",
+            }
+            cmux_hook._handle_notification(data)
+            mock_cmux.assert_called_once_with(
+                "notify", "--title", "Auth Success", "--body", "Authenticated"
+            )
+
+    def test_elicitation_dialog_type(self):
+        """elicitation_dialog notification gets 'Claude Code' title."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "notification_type": "elicitation_dialog",
+                "message": "Respond please",
+            }
+            cmux_hook._handle_notification(data)
+            mock_cmux.assert_called_once_with(
+                "notify",
+                "--title",
+                "Claude Code",
+                "--body",
+                "Respond please",
+            )
+
+    def test_unknown_type_uses_title_field(self):
+        """Unknown type uses custom title field."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "notification_type": "unknown_type",
+                "message": "Message body",
+                "title": "Custom Title",
+            }
+            cmux_hook._handle_notification(data)
+            mock_cmux.assert_called_once_with(
+                "notify", "--title", "Custom Title", "--body", "Message body"
+            )
+
+    def test_unknown_type_fallback_to_default(self):
+        """Unknown type without title field falls back to 'Claude Code'."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"notification_type": "unknown_type", "message": "Message"}
+            cmux_hook._handle_notification(data)
+            mock_cmux.assert_called_once_with(
+                "notify", "--title", "Claude Code", "--body", "Message"
+            )
+
+    def test_empty_message_uses_empty_body(self):
+        """Missing message field results in empty body."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"notification_type": "permission_prompt"}
+            cmux_hook._handle_notification(data)
+            mock_cmux.assert_called_once_with(
+                "notify", "--title", "Permission Needed", "--body", ""
+            )
+
+
+class TestHandleSubagentStop:
+    """Tests for _handle_subagent_stop() event handler."""
+
+    def test_with_last_message(self):
+        """Subagent stop with last_assistant_message includes message in notification."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "agent_type": "architect",
+                "last_assistant_message": "Analysis complete. Summary here.",
+            }
+            cmux_hook._handle_subagent_stop(data)
+            # Should call notify and log
+            calls = mock_cmux.call_args_list
+            assert len(calls) == 2
+            notify_call = calls[0]
+            log_call = calls[1]
+            # Check notify call
+            assert notify_call[0][0] == "notify"
+            assert "Agent Complete" in notify_call[0]
+            # Check log call
+            assert log_call[0][0] == "log"
+            assert "Agent architect finished: Analysis complete." in " ".join(
+                str(x) for x in log_call[0]
+            )
+
+    def test_without_last_message(self):
+        """Subagent stop without last_assistant_message uses simple text."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"agent_type": "security"}
+            cmux_hook._handle_subagent_stop(data)
+            calls = mock_cmux.call_args_list
+            assert len(calls) == 2
+            # Check log call
+            log_call = calls[1]
+            assert "Agent security finished" in log_call[0]
+
+    def test_unknown_agent_type(self):
+        """Unknown agent type shows 'unknown' in message."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {}
+            cmux_hook._handle_subagent_stop(data)
+            calls = mock_cmux.call_args_list
+            assert len(calls) == 2
+            log_call = calls[1]
+            assert "Agent unknown finished" in log_call[0]
+
+
+class TestHandleStop:
+    """Tests for _handle_stop() event handler."""
+
+    def test_stop_hook_active_returns_early(self):
+        """When stop_hook_active=True, handler returns early without cmux calls."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"stop_hook_active": True}
+            cmux_hook._handle_stop(data)
+            # Should not call _cmux
+            mock_cmux.assert_not_called()
+
+    def test_stop_hook_inactive_sets_status(self):
+        """When stop_hook_active=False, sets complete status."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"stop_hook_active": False}
+            cmux_hook._handle_stop(data)
+            calls = mock_cmux.call_args_list
+            # Should have set-status call
+            set_status_call = calls[0]
+            assert set_status_call[0][0] == "set-status"
+            assert "claude-session" in set_status_call[0]
+            assert "complete" in set_status_call[0]
+
+    def test_stop_with_last_message(self):
+        """Stop with last_assistant_message includes it in notification."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "stop_hook_active": False,
+                "last_assistant_message": "Task finished. Done.",
+            }
+            cmux_hook._handle_stop(data)
+            calls = mock_cmux.call_args_list
+            # Check notify call (should be 3rd call after set-status and clear-status)
+            notify_call = calls[2]
+            assert notify_call[0][0] == "notify"
+            assert "Task finished." in " ".join(str(x) for x in notify_call[0])
+
+    def test_stop_without_last_message(self):
+        """Stop without last_assistant_message uses simple text."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"stop_hook_active": False}
+            cmux_hook._handle_stop(data)
+            calls = mock_cmux.call_args_list
+            notify_call = calls[2]
+            assert "Work complete" in notify_call[0]
+
+
+class TestHandleSessionStart:
+    """Tests for _handle_session_start() event handler."""
+
+    def test_no_legacy_hook(self):
+        """Session start without legacy cmux-notify.sh skips warning."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+            mock.patch("pathlib.Path.exists", return_value=False),
+            mock.patch("sys.stderr"),
+        ):
+            data = {}
+            cmux_hook._handle_session_start(data)
+            # Should call _cmux but not print warning
+            calls = mock_cmux.call_args_list
+            assert len(calls) == 2
+            assert calls[0][0][0] == "set-status"
+
+    def test_legacy_hook_exists_prints_warning(self):
+        """Session start with legacy cmux-notify.sh prints warning to stderr."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux"),
+            mock.patch("pathlib.Path.exists", return_value=True),
+            mock.patch("sys.stderr", new_callable=io.StringIO) as mock_stderr,
+        ):
+            data = {}
+            cmux_hook._handle_session_start(data)
+            # Should print warning
+            stderr_value = mock_stderr.getvalue()
+            assert "cmux-notify.sh" in stderr_value
+            assert "duplicate" in stderr_value
+
+    def test_sets_session_active_status(self):
+        """Session start sets active status."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+            mock.patch("pathlib.Path.exists", return_value=False),
+            mock.patch("sys.stderr"),
+        ):
+            data = {}
+            cmux_hook._handle_session_start(data)
+            set_status_call = mock_cmux.call_args_list[0]
+            assert "claude-session" in set_status_call[0]
+            assert "active" in set_status_call[0]
+
+    def test_logs_session_started(self):
+        """Session start logs 'Session started' message."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+            mock.patch("pathlib.Path.exists", return_value=False),
+            mock.patch("sys.stderr"),
+        ):
+            data = {}
+            cmux_hook._handle_session_start(data)
+            log_call = mock_cmux.call_args_list[1]
+            assert log_call[0][0] == "log"
+            assert "Session started" in log_call[0]
+
+
+class TestHandleSessionEnd:
+    """Tests for _handle_session_end() event handler."""
+
+    def test_clears_session_status(self):
+        """Session end clears claude-session status."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {}
+            cmux_hook._handle_session_end(data)
+            calls = mock_cmux.call_args_list
+            clear_session_call = calls[0]
+            assert clear_session_call[0][0] == "clear-status"
+            assert "claude-session" in clear_session_call[0]
+
+    def test_clears_activity_status(self):
+        """Session end clears claude-activity status."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {}
+            cmux_hook._handle_session_end(data)
+            calls = mock_cmux.call_args_list
+            clear_activity_call = calls[1]
+            assert clear_activity_call[0][0] == "clear-status"
+            assert "claude-activity" in clear_activity_call[0]
+
+    def test_logs_session_ended(self):
+        """Session end logs 'Session ended' message."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {}
+            cmux_hook._handle_session_end(data)
+            calls = mock_cmux.call_args_list
+            log_call = calls[2]
+            assert log_call[0][0] == "log"
+            assert "Session ended" in log_call[0]
+
+
+class TestHandlePreToolUse:
+    """Tests for _handle_pre_tool_use() event handler."""
+
+    def test_bash_tool_sets_running_status(self):
+        """Bash tool sets 'Running' status with command."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "tool_name": "Bash",
+                "tool_input": {"command": "git status"},
+            }
+            cmux_hook._handle_pre_tool_use(data)
+            mock_cmux.assert_called_once()
+            call_args = mock_cmux.call_args[0]
+            assert call_args[0] == "set-status"
+            assert "Running: git status" in call_args
+            assert "⏳" in call_args
+
+    def test_bash_tool_truncates_long_command(self):
+        """Bash tool truncates command to 60 chars."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            long_cmd = "x" * 100
+            data = {
+                "tool_name": "Bash",
+                "tool_input": {"command": long_cmd},
+            }
+            cmux_hook._handle_pre_tool_use(data)
+            call_args = mock_cmux.call_args[0]
+            assert len(call_args[2]) <= 60 + len("Running: ")
+
+    def test_task_tool_sets_spawning_status(self):
+        """Task tool sets 'Spawning' status with description."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "tool_name": "Task",
+                "tool_input": {"description": "Running tests"},
+            }
+            cmux_hook._handle_pre_tool_use(data)
+            mock_cmux.assert_called_once()
+            call_args = mock_cmux.call_args[0]
+            assert call_args[0] == "set-status"
+            assert "Spawning: Running tests" in call_args
+            assert "🚀" in call_args
+
+    def test_task_tool_truncates_long_description(self):
+        """Task tool truncates description to 60 chars."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            long_desc = "x" * 100
+            data = {
+                "tool_name": "Task",
+                "tool_input": {"description": long_desc},
+            }
+            cmux_hook._handle_pre_tool_use(data)
+            call_args = mock_cmux.call_args[0]
+            assert len(call_args[2]) <= 60 + len("Spawning: ")
+
+    def test_unknown_tool_no_call(self):
+        """Unknown tool name results in no cmux call."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"tool_name": "UnknownTool", "tool_input": {}}
+            cmux_hook._handle_pre_tool_use(data)
+            mock_cmux.assert_not_called()
+
+
+class TestHandlePostToolUse:
+    """Tests for _handle_post_tool_use() event handler."""
+
+    def test_clears_activity_status(self):
+        """Post tool use clears activity status."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"tool_response": "Success"}
+            cmux_hook._handle_post_tool_use(data)
+            calls = mock_cmux.call_args_list
+            clear_call = calls[0]
+            assert clear_call[0][0] == "clear-status"
+            assert "claude-activity" in clear_call[0]
+
+    def test_string_response_extracts_first_sentence(self):
+        """String response extracts first sentence for logging."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "tool_response": "First sentence. Second sentence.",
+            }
+            cmux_hook._handle_post_tool_use(data)
+            calls = mock_cmux.call_args_list
+            log_call = calls[1]
+            assert "First sentence." in " ".join(str(x) for x in log_call[0])
+
+    def test_dict_response_extracts_stdout(self):
+        """Dict response extracts first sentence from stdout."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {
+                "tool_response": {
+                    "stdout": "Output here. More output.",
+                    "returncode": 0,
+                }
+            }
+            cmux_hook._handle_post_tool_use(data)
+            calls = mock_cmux.call_args_list
+            log_call = calls[1]
+            assert "Output here." in " ".join(str(x) for x in log_call[0])
+
+    def test_no_response_uses_simple_message(self):
+        """Empty response uses 'Task completed' without summary."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"tool_response": ""}
+            cmux_hook._handle_post_tool_use(data)
+            calls = mock_cmux.call_args_list
+            log_call = calls[1]
+            assert "Task completed" in log_call[0]
+
+    def test_dict_without_stdout_no_summary(self):
+        """Dict without stdout uses simple message."""
+        with mock.patch.object(cmux_hook, "_cmux") as mock_cmux:
+            data = {"tool_response": {"returncode": 0}}
+            cmux_hook._handle_post_tool_use(data)
+            calls = mock_cmux.call_args_list
+            log_call = calls[1]
+            assert "Task completed" in log_call[0]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# main() integration tests
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMain:
+    """Integration tests for main() dispatcher."""
+
+    def setup_method(self):
+        """Reset global cache before each test."""
+        cmux_hook._CMUX_AVAILABLE = None
+
+    def test_unknown_event_name_no_handler(self):
+        """Unknown event name doesn't call any handler."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux_available", return_value=True),
+            mock.patch.object(cmux_hook, "_parse_hook_input") as mock_parse,
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+        ):
+            mock_parse.return_value = {"hook_event_name": "UnknownEvent"}
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook.main()
+            assert exc_info.value.code == 0
+            # Should not call _cmux
+            mock_cmux.assert_not_called()
+
+    def test_cmux_unavailable_exits_early(self):
+        """If cmux unavailable, exits 0 without calling handlers."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux_available", return_value=False),
+            mock.patch.object(cmux_hook, "_parse_hook_input") as mock_parse,
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+        ):
+            mock_parse.return_value = {"hook_event_name": "Stop"}
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook.main()
+            assert exc_info.value.code == 0
+            # Should not call _cmux
+            mock_cmux.assert_not_called()
+
+    def test_notification_event_dispatches_handler(self):
+        """Notification event dispatches to _handle_notification."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux_available", return_value=True),
+            mock.patch.object(cmux_hook, "_parse_hook_input") as mock_parse,
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+        ):
+            mock_parse.return_value = {
+                "hook_event_name": "Notification",
+                "notification_type": "permission_prompt",
+                "message": "Test",
+            }
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook.main()
+            assert exc_info.value.code == 0
+            # Should call _cmux
+            assert mock_cmux.called
+
+    def test_stop_event_dispatches_handler(self):
+        """Stop event dispatches to _handle_stop."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux_available", return_value=True),
+            mock.patch.object(cmux_hook, "_parse_hook_input") as mock_parse,
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+        ):
+            mock_parse.return_value = {
+                "hook_event_name": "Stop",
+                "stop_hook_active": False,
+            }
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook.main()
+            assert exc_info.value.code == 0
+            # Should call _cmux
+            assert mock_cmux.called
+
+    def test_subagent_stop_event_dispatches_handler(self):
+        """SubagentStop event dispatches to _handle_subagent_stop."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux_available", return_value=True),
+            mock.patch.object(cmux_hook, "_parse_hook_input") as mock_parse,
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+        ):
+            mock_parse.return_value = {
+                "hook_event_name": "SubagentStop",
+                "agent_type": "architect",
+            }
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook.main()
+            assert exc_info.value.code == 0
+            # Should call _cmux
+            assert mock_cmux.called
+
+    def test_session_start_event_dispatches_handler(self):
+        """SessionStart event dispatches to _handle_session_start."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux_available", return_value=True),
+            mock.patch.object(cmux_hook, "_parse_hook_input") as mock_parse,
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+            mock.patch("pathlib.Path.exists", return_value=False),
+            mock.patch("sys.stderr"),
+        ):
+            mock_parse.return_value = {
+                "hook_event_name": "SessionStart",
+            }
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook.main()
+            assert exc_info.value.code == 0
+            # Should call _cmux
+            assert mock_cmux.called
+
+    def test_session_end_event_dispatches_handler(self):
+        """SessionEnd event dispatches to _handle_session_end."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux_available", return_value=True),
+            mock.patch.object(cmux_hook, "_parse_hook_input") as mock_parse,
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+        ):
+            mock_parse.return_value = {
+                "hook_event_name": "SessionEnd",
+            }
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook.main()
+            assert exc_info.value.code == 0
+            # Should call _cmux
+            assert mock_cmux.called
+
+    def test_pre_tool_use_event_dispatches_handler(self):
+        """PreToolUse event dispatches to _handle_pre_tool_use."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux_available", return_value=True),
+            mock.patch.object(cmux_hook, "_parse_hook_input") as mock_parse,
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+        ):
+            mock_parse.return_value = {
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls"},
+            }
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook.main()
+            assert exc_info.value.code == 0
+            # Should call _cmux
+            assert mock_cmux.called
+
+    def test_post_tool_use_event_dispatches_handler(self):
+        """PostToolUse event dispatches to _handle_post_tool_use."""
+        with (
+            mock.patch.object(cmux_hook, "_cmux_available", return_value=True),
+            mock.patch.object(cmux_hook, "_parse_hook_input") as mock_parse,
+            mock.patch.object(cmux_hook, "_cmux") as mock_cmux,
+        ):
+            mock_parse.return_value = {
+                "hook_event_name": "PostToolUse",
+                "tool_response": "Success",
+            }
+            with pytest.raises(SystemExit) as exc_info:
+                cmux_hook.main()
+            assert exc_info.value.code == 0
+            # Should call _cmux
+            assert mock_cmux.called

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dev = ["ruff>=0.9", "pytest>=8"]
 
 [tool.pytest.ini_options]
-testpaths = ["dev-guard/tests"]
+testpaths = ["dev-guard/tests", "cmux-integration/tests"]
 addopts = "-v --tb=short"
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- New cmux-integration plugin bridging Claude Code hook events to CMUX terminal CLI API
- Handles 7 events: Notification, SubagentStop, Stop, SessionStart, SessionEnd, PreToolUse (Bash/Task), PostToolUse (Task)
- Rich notifications with first-sentence extraction from agent responses
- Sidebar status pills for session state and current activity
- Graceful degradation via cmux ping — no-op when CMUX not running
- Auto-detects legacy cmux-notify.sh and warns at session start
- 64 tests, all passing