### PR TITLE
feat(dev-guard): explicit allow for multiline commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "personal-claude-marketplace",
   "metadata": {
     "description": "Personal Claude Code plugins: LSP servers (uvx/npx) and custom agents",
-    "version": "2.3.0"
+    "version": "2.4.0"
   },
   "owner": {
     "name": "wgordon17"
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.28.0",
+      "version": "1.29.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "author": { "name": "wgordon17" }
 }


### PR DESCRIPTION
## Summary

- Multiline commands that pass all guard checks now emit permissionDecision allow instead of silent exit 0, bypassing Claude Code's built-in newline blocker
- Backslash continuations resolved before splitting so dangerous commands split across lines are checked as a single command
- Rule matching: patterns match env-stripped commands, exceptions match raw (stricter)
- Makefile TIP moved to stderr to avoid corrupting hookSpecificOutput JSON
- Version bump to 1.29.0