### PR TITLE
feat(cmux-integration): slim notifications, re-enable sidebar

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -110,7 +110,7 @@
     },
     {
       "name": "cmux-integration",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "source": "./cmux-integration",
       "description": "Bridges Claude Code hook events to CMUX terminal's CLI API: notifications, sidebar status, and activity logging",
       "category": "productivity",

--- a/cmux-integration/.claude-plugin/plugin.json
+++ b/cmux-integration/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cmux-integration",
   "description": "Bridges Claude Code hook events to CMUX terminal's CLI API: notifications, sidebar status, and activity logging",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "author": { "name": "wgordon17" }
 }

--- a/cmux-integration/hooks/hooks.json
+++ b/cmux-integration/hooks/hooks.json
@@ -1,7 +1,18 @@
 {
-  "description": "CMUX integration: route Claude Code hook events to cmux notify for desktop notifications",
+  "description": "CMUX integration: sidebar status, desktop notifications (blocked/done only), and activity logging",
   "hooks": {
     "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
       {
         "matcher": "",
         "hooks": [
@@ -23,7 +34,7 @@
         ]
       }
     ],
-    "SubagentStop": [
+    "Notification": [
       {
         "matcher": "",
         "hooks": [
@@ -34,7 +45,18 @@
         ]
       }
     ],
-    "Notification": [
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/cmux-hook.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
       {
         "matcher": "",
         "hooks": [


### PR DESCRIPTION
## Summary
- Notifications reduced to only blocked (permission_prompt, elicitation_dialog) and done (Stop) events — eliminates subagent noise
- SubagentStop, idle_prompt, and auth_success notifications removed
- Sidebar commands re-enabled now that cmux CLI supports them (set-status, log, PreToolUse/PostToolUse activity tracking)
- Bumps to 2.0.0