### PR TITLE
feat(swarm): adds context health monitoring

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "source": "./code-quality",
       "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
       "category": "quality",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,15 @@ make format       # Auto-fix: uv run ruff format . && uv run ruff check --fix .
 make test         # uv run pytest (runs dev-guard/tests/)
 ```
 
-Python 3.10+. Ruff line-length 100, select `E,W,F,I,UP,B,SIM`. Tests only exist in `dev-guard/tests/`.
+Python 3.10+. Ruff line-length 100, select `E,W,F,I,UP,B,SIM`. Tests in `dev-guard/tests/` and `cmux-integration/tests/`.
 
 ## Critical Rules
 
 - **Never edit `~/.claude/plugins/` or `~/.claude/plugins/cache/`** — those directories contain installed/cached versions. Always edit this source repository. Changes in `~/.claude/plugins/` will be lost on update and are never committed.
-- **Always bump versions in both files** when modifying a plugin:
+- **Always bump plugin versions in both files** when modifying a plugin:
   - `<plugin>/.claude-plugin/plugin.json`
-  - `.claude-plugin/marketplace.json`
+  - `.claude-plugin/marketplace.json` (the plugin's entry, NOT `metadata.version`)
+- The marketplace `metadata.version` is **informational only** — it does not control update detection. Bump it only for structural marketplace changes (adding/removing plugins, schema changes), not for individual plugin version bumps.
 
 ## Change Workflow
 

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -61,10 +61,11 @@ specialist agent.
 Run the project test suite and record the baseline (pass/fail count, any pre-existing failures).
 Check git status — ensure the working tree is clean, identify the current branch, and determine
 whether a feature branch is needed. If not already on a feature branch, create one from
-`upstream/main` or `origin/main`. Create the audit trail directory at `hack/swarm/YYYY-MM-DD/`
-(append sequence number if the directory already exists). Call `TeamCreate("swarm-impl")`, then
-create all tasks upfront with `addBlockedBy` dependencies so the full task graph is visible from
-the start.
+`upstream/main` or `origin/main`. Verify that auto-compaction is enabled — the /swarm skill
+depends on it for reliable agent operation (warn the user if disabled). Create the audit trail
+directory at `hack/swarm/YYYY-MM-DD/` (append sequence number if the directory already exists).
+Call `TeamCreate("swarm-impl")`, then create all tasks upfront with `addBlockedBy` dependencies
+so the full task graph is visible from the start.
 
 ### Phase 1: Clarify & Checkpoint (EARLY — fire-and-forget after approval)
 
@@ -230,6 +231,14 @@ blocker or a pre-existing issue. Lean toward escalation for ambiguous decisions.
 Monitor the pipeline flow actively. Route handoff messages between agents using the schemas in
 `references/communication-schema.md`. Detect backpressure (see `references/pipeline-model.md`)
 and throttle the Implementer when the Reviewer queue is full.
+
+### Context Health Monitoring
+
+Track `turn_count` from every agent's structured messages. Proactively recycle agents approaching
+context limits (default: 25 turns for Implementer/Test-Writer, 30 for Reviewer) using the
+HandoffRequest → HandoffSummary → shutdown → respawn protocol (see `references/orchestration-playbook.md`
+Step 3.6). Detect silent failures: if a teammate goes idle without completing their task or sending
+a final message, initiate recovery (status check → replacement spawn → escalate if repeated).
 
 ### Feedback Loops
 

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -27,6 +27,13 @@ This repo has a tool-selection-guard hook. You MUST use native tools:
 - Bash is ONLY for: git, uv/uvx, npx, make, and system commands
 If a Bash command is blocked, switch to the equivalent native tool.
 
+IMPORTANT — Turn Counting:
+Track your turn count — the number of tool-call rounds you have completed since spawning.
+Include "turn_count": N in EVERY structured JSON message you send to the lead. The lead uses
+this to monitor context health and may request a handoff if your count gets high. If you
+receive a HandoffRequest message, respond immediately with a HandoffSummary (see
+communication-schema.md) — your context is about to be rotated to a fresh agent.
+
 === END CONTEXT ===
 ```
 
@@ -239,7 +246,8 @@ SendMessage(type="message", recipient="team-lead",
     "summary": "Implemented OAuth2 authorization code flow with PKCE. "
                "Added token storage in session. Error handling via existing OAuthError class.",
     "notes_for_reviewer": "The token refresh logic in lines 78-95 is slightly non-obvious — "
-                          "it handles concurrent refresh requests via a lock."
+                          "it handles concurrent refresh requests via a lock.",
+    "turn_count": 12
   }',
   summary="Implementer: component-1 complete")
 ```
@@ -319,7 +327,8 @@ SendMessage(type="message", recipient="team-lead",
     "component_id": "component-1",
     "verdict": "approved",
     "issues": [],
-    "notes": "Token refresh lock could be replaced with a simpler Redis TTL, but it works correctly"
+    "notes": "Token refresh lock could be replaced with a simpler Redis TTL, but it works correctly",
+    "turn_count": 8
   }',
   summary="Reviewer: component-1 approved")
 ```
@@ -340,7 +349,8 @@ SendMessage(type="message", recipient="team-lead",
         "description": "Token expiry not handled — if the access token is expired, refresh() silently returns None",
         "suggested_fix": "Check if token.expires_at < now() before returning, raise TokenExpiredError if so"
       }
-    ]
+    ],
+    "turn_count": 10
   }',
   summary="Reviewer: component-1 rejected — 1 critical")
 ```
@@ -434,7 +444,8 @@ SendMessage(type="message", recipient="team-lead",
     "test_files": ["tests/unit/test_oauth.py"],
     "test_count": 8,
     "summary": "8 tests covering: auth code exchange, PKCE validation, token refresh, "
-               "expired token handling, invalid client error, concurrent refresh lock"
+               "expired token handling, invalid client error, concurrent refresh lock",
+    "turn_count": 15
   }',
   summary="Test-Writer: component-1 — 8 tests written")
 ```
@@ -503,7 +514,8 @@ SendMessage(type="message", recipient="team-lead",
     "passed": 8,
     "failed": 0,
     "errors": 0,
-    "failures": []
+    "failures": [],
+    "turn_count": 4
   }',
   summary="Test-Runner: component-1 — 8/8 passed")
 ```
@@ -524,7 +536,8 @@ SendMessage(type="message", recipient="team-lead",
         "test": "tests/unit/test_oauth.py::test_token_refresh",
         "error": "KeyError: 'refresh_token'\n  File src/auth/oauth.py:95 in refresh()\n    return token[\"refresh_token\"]"
       }
-    ]
+    ],
+    "turn_count": 5
   }',
   summary="Test-Runner: component-1 — 2 failures")
 ```
@@ -1502,7 +1515,9 @@ Review all `skills/*/SKILL.md` files modified during this swarm:
 ### Content Quality
 - All phases are documented with clear actions
 - Agent spawn calls include all required parameters (name, subagent_type, model, team_name, prompt)
+- All agent prompts include the turn counting instruction in the context bundle
 - JSON schemas referenced in the skill exist in `references/communication-schema.md`
+- All structured message examples include `turn_count` field
 - File paths and references are consistent (e.g., `architect-plan.json` not `plan.json`)
 - No placeholder text left unfilled (e.g., `<TODO>`, `[fill this in]`)
 

--- a/code-quality/skills/swarm/references/pipeline-model.md
+++ b/code-quality/skills/swarm/references/pipeline-model.md
@@ -252,6 +252,25 @@ The Architect persists through Phase 3 to answer clarification questions from th
 and Reviewer. Implementers and Reviewers may message the Architect directly for clarifications
 without routing through the Lead.
 
+### Context Health & Agent Recycling
+
+Pipeline agents are persistent and accumulate context across all components. The Lead monitors
+`turn_count` from each agent's structured messages and proactively recycles agents approaching
+context limits. See `orchestration-playbook.md` Step 3.6 for the full protocol.
+
+Key points for the pipeline:
+- Recycling only happens **between components**, never mid-implementation or mid-review
+- The replacement agent receives the original prompt plus a `HandoffSummary` from the outgoing
+  agent, ensuring continuity of design decisions and file state awareness
+- The pipeline flow is paused during recycling — no new `ComponentAssignment` is sent until the
+  replacement agent is ready
+- Recycling is transparent to other pipeline agents: the Reviewer doesn't know (or care) if it's
+  reviewing work from the original or replacement Implementer
+
+If an agent goes silent (idle without completion message), the Lead follows the silent failure
+detection protocol: status check → recovery spawn → escalate if repeated. See
+`communication-schema.md` for the detection heuristic and recovery schemas.
+
 ### Phase 3 Completion
 
 The pipeline team is done when all components have passed the Test-Runner and all `TestResult`


### PR DESCRIPTION
## Summary

- Agents self-report `turn_count` in every structured JSON message (ComponentHandoff, ReviewResult, TestHandoff, TestResult)
- Orchestrator tracks turn counts and proactively recycles long-running Phase 3 agents (Implementer at 25 turns, Reviewer at 30) via HandoffRequest/HandoffSummary protocol
- Silent failure detection: if a teammate goes idle without completion message, Lead runs status check then spawns recovery agent
- Pre-flight check in Phase 0 warns if auto-compaction is disabled since /swarm depends on it
- New schemas: HandoffRequest, HandoffSummary, silent failure detection heuristic
- Version bump: code-quality 1.3.0 to 1.4.0