### PR TITLE
feat(dev-guard): adds cd+git blocking and trusted dirs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Python 3.10+. Ruff line-length 100, select `E,W,F,I,UP,B,SIM`. Tests in `dev-gua
    CLAUDECODE="" claude plugin marketplace update personal-claude-marketplace
    CLAUDECODE="" claude plugin update <plugin-name>@personal-claude-marketplace
    ```
-6. **Restart and E2E verify** — Tell user to restart their session. E2E verification happens in the new session.
+6. **Reload and E2E verify** — Tell user to run `/plugins reload` to pick up the updated plugin without restarting. E2E verification happens after reload.
 
 ## Repository Structure
 

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -309,8 +309,12 @@ _DB_PATH = Path(
     os.environ.get("GUARD_DB_PATH", str(Path.home() / ".claude" / "logs" / "dev-guard.db"))
 )
 _GUARD_LOG_LEVEL = os.environ.get("GUARD_LOG_LEVEL", "actions").lower()
+_UNIFIED_CONFIG_PATH = Path(
+    os.environ.get("DEV_GUARD_CONFIG", str(Path.home() / ".claude" / "dev-guard.json"))
+)
 _session_id = None
 _tool_use_id = None
+_TRUSTED_GIT_DIRS: list[Path] = []
 
 _SECRET_PATTERN = re.compile(
     r"((?:password|token|secret|key|auth|bearer|api[_-]?key|credentials)"
@@ -591,6 +595,42 @@ def _load_extra_rules(
             raw = json.load(f)
         return [entry_to_rule(entry) for entry in raw]
     except (OSError, json.JSONDecodeError, KeyError, TypeError, AttributeError, re.error):
+        return []  # Fail silently — bad config should not break the guard
+
+
+def _load_unified_config() -> dict:
+    """Load unified dev-guard config from ~/.claude/dev-guard.json (or DEV_GUARD_CONFIG).
+
+    Returns a dict with optional keys: command_rules, url_rules, git_trusted_dirs.
+    Returns empty dict if file doesn't exist or is malformed.
+    """
+    try:
+        with open(_UNIFIED_CONFIG_PATH) as f:
+            raw = json.load(f)
+        if not isinstance(raw, dict):
+            return {}
+        return raw
+    except (OSError, json.JSONDecodeError):
+        return {}  # Missing file or bad JSON — fail silently
+
+
+def _load_trusted_dirs() -> list[Path]:
+    """Load trusted git directories from GIT_TRUSTED_DIRS env var.
+
+    The env var should point to a JSON file containing an array of
+    directory paths. Paths support ~ expansion and are resolved to absolute.
+    Returns an empty list on missing env var or any parse error.
+    """
+    dirs_path = os.environ.get("GIT_TRUSTED_DIRS")
+    if not dirs_path:
+        return []
+    try:
+        with open(dirs_path) as f:
+            raw = json.load(f)
+        if not isinstance(raw, list):
+            return []
+        return [Path(d).expanduser().resolve() for d in raw if isinstance(d, str) and d.strip()]
+    except (OSError, json.JSONDecodeError, TypeError):
         return []  # Fail silently — bad config should not break the guard
 
 
@@ -1049,6 +1089,32 @@ def _parse_branch_creation(cmd: str) -> tuple[str, str | None] | None:
     return None
 
 
+def _check_cd_git_compound(subcmds: list[str], full_command: str) -> None:
+    """Block compound commands that cd into a directory then run git.
+
+    Prevents bare repository attacks where a malicious .git directory
+    could execute hooks when git commands are run from that directory.
+    Redirects to ``git -C <path>`` which is safer and avoids directory changes.
+    """
+    cd_path: str | None = None
+    for subcmd in subcmds:
+        stripped = strip_shell_keyword(subcmd).strip()
+        cd_match = re.match(r"^\s*cd\s+(.+)", stripped)
+        if cd_match:
+            cd_path = cd_match.group(1).strip().strip("\"'")
+            continue
+        if cd_path and re.match(r"^\s*git\s+", strip_env_prefix(stripped)):
+            git_match = re.match(r"^\s*(?:\S+=\S*\s+)*git\s+(.*)", stripped)
+            git_args = git_match.group(1).strip() if git_match else ""
+            _exit_with_decision(
+                f"Compound `cd && git` is blocked — bare repository attack risk.\n"
+                f"Use `git -C` instead: `git -C {cd_path} {git_args}`",
+                "block",
+                rule_name="cd-git-compound",
+                matched_segment=full_command[:200],
+            )
+
+
 _PROTECTED_BRANCHES = frozenset({"main", "master"})
 
 # Safe start points for branch creation (no stacking risk)
@@ -1234,11 +1300,73 @@ GIT_ASK_RULES: list[GitRule] = [
 ]
 
 
+_GIT_C_PATTERN = re.compile(r"\bgit\s+-C\s+(?:\"([^\"]+)\"|'([^']+)'|(\S+))")
+
+
+def _extract_git_c_path(cmd: str) -> str | None:
+    """Extract the directory path from ``git -C <path>`` if present."""
+    m = _GIT_C_PATTERN.search(cmd)
+    if m:
+        return m.group(1) or m.group(2) or m.group(3)
+    return None
+
+
+def _is_git_informational(cmd: str) -> bool:
+    """Check if a git command is informational (safe regardless of directory)."""
+    if "--help" in cmd or "--version" in cmd:
+        return True
+    stripped = strip_env_prefix(cmd)
+    return bool(
+        re.match(r"^\s*git\s+help\b", stripped)
+        or re.match(r"^\s*git\s+config\s+--global\b", stripped)
+    )
+
+
+def _check_git_trusted_dirs(cmd: str) -> None:
+    """Block git commands operating outside configured trusted directories.
+
+    Opt-in: does nothing if GIT_TRUSTED_DIRS is not configured.
+    For ``git -C <path>``, resolves the path and checks containment.
+    For plain ``git`` commands, checks the current working directory.
+    """
+    if not _TRUSTED_GIT_DIRS:
+        return
+
+    if not re.search(r"(^|\s)git\s", cmd):
+        return
+
+    if _is_git_informational(cmd):
+        return
+
+    git_c_path = _extract_git_c_path(cmd)
+    effective_dir = Path(git_c_path).expanduser().resolve() if git_c_path else Path.cwd().resolve()
+
+    for trusted in _TRUSTED_GIT_DIRS:
+        try:
+            effective_dir.relative_to(trusted)
+            return  # Within a trusted dir — allow
+        except ValueError:
+            continue
+
+    trusted_display = ", ".join(str(d) for d in _TRUSTED_GIT_DIRS)
+    _exit_with_decision(
+        f"Git operation targets an untrusted directory: {effective_dir}\n"
+        f"Trusted directories: {trusted_display}\n"
+        f"Add this path to git_trusted_dirs in {_UNIFIED_CONFIG_PATH}.",
+        "block",
+        rule_name="git-untrusted-dir",
+        matched_segment=cmd[:200],
+    )
+
+
 def check_git_safety(cmd: str, fetch_seen: bool = False) -> None:
     """Check a command against git safety rules. Exits on block or ask match."""
     # Early exit: not a git command
     if not re.search(r"(^|\s)git\s", cmd):
         return
+
+    # Trusted directory check (before other rules — fundamental access control)
+    _check_git_trusted_dirs(cmd)
 
     # DENY rules (block)
     for name, check_fn, message in GIT_DENY_RULES:
@@ -2602,8 +2730,160 @@ def _validate_rules_file(path: str, env_var: str, is_url: bool = False) -> tuple
     return issues, len(raw)
 
 
+def _validate_trusted_dirs_file(path: str) -> tuple[list[str], int]:
+    """Validate a GIT_TRUSTED_DIRS JSON file. Returns (issues, count) tuple."""
+    issues = []
+    env_var = "GIT_TRUSTED_DIRS"
+    if not os.path.exists(path):
+        issues.append(f"{env_var}: file not found: {path}")
+        return issues, 0
+    try:
+        with open(path) as f:
+            raw = json.load(f)
+    except json.JSONDecodeError as e:
+        issues.append(f"{env_var}: invalid JSON: {e}")
+        return issues, 0
+    except OSError as e:
+        issues.append(f"{env_var}: cannot read file: {e}")
+        return issues, 0
+    if not isinstance(raw, list):
+        issues.append(f"{env_var}: expected JSON array, got {type(raw).__name__}")
+        return issues, 0
+    if not raw:
+        issues.append(f"{env_var}: file contains empty array (no directories)")
+        return issues, 0
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, str):
+            issues.append(f"{env_var}[{i}]: expected string path, got {type(entry).__name__}")
+            continue
+        if not entry.strip():
+            issues.append(f"{env_var}[{i}]: empty path")
+            continue
+        resolved = Path(entry).expanduser()
+        if not resolved.is_dir():
+            issues.append(f"{env_var}[{i}]: directory does not exist: {entry}")
+    return issues, len(raw)
+
+
+def _validate_unified_config(path: Path) -> tuple[list[str], list[str]]:
+    """Validate unified dev-guard config file. Returns (issues, loaded_msgs)."""
+    issues: list[str] = []
+    loaded: list[str] = []
+    label = f"dev-guard.json ({path})"
+    try:
+        with open(path) as f:
+            raw = json.load(f)
+    except json.JSONDecodeError as e:
+        issues.append(f"{label}: invalid JSON: {e}")
+        return issues, loaded
+    except OSError:
+        return issues, loaded  # File not found is fine — it's optional
+    if not isinstance(raw, dict):
+        issues.append(f"{label}: expected JSON object, got {type(raw).__name__}")
+        return issues, loaded
+
+    valid_keys = {"command_rules", "url_rules", "git_trusted_dirs"}
+    unknown = set(raw.keys()) - valid_keys
+    if unknown:
+        issues.append(f"{label}: unknown keys: {', '.join(sorted(unknown))}")
+
+    # Validate command_rules section
+    cmd_rules = raw.get("command_rules")
+    if cmd_rules is not None:
+        if not isinstance(cmd_rules, list):
+            issues.append(f"{label}.command_rules: expected array")
+        else:
+            # Reuse existing validator by writing to a temp structure
+            section_issues, count = _validate_rules_entries(cmd_rules, f"{label}.command_rules")
+            issues.extend(section_issues)
+            if not section_issues:
+                loaded.append(f"Command rules: {count} rule(s) from {path}")
+
+    # Validate url_rules section
+    url_rules = raw.get("url_rules")
+    if url_rules is not None:
+        if not isinstance(url_rules, list):
+            issues.append(f"{label}.url_rules: expected array")
+        else:
+            section_issues, count = _validate_rules_entries(
+                url_rules, f"{label}.url_rules", is_url=True
+            )
+            issues.extend(section_issues)
+            if not section_issues:
+                loaded.append(f"URL rules: {count} rule(s) from {path}")
+
+    # Validate git_trusted_dirs section
+    dirs = raw.get("git_trusted_dirs")
+    if dirs is not None:
+        if not isinstance(dirs, list):
+            issues.append(f"{label}.git_trusted_dirs: expected array")
+        elif not dirs:
+            issues.append(f"{label}.git_trusted_dirs: empty array (no directories)")
+        else:
+            for i, entry in enumerate(dirs):
+                pfx = f"{label}.git_trusted_dirs[{i}]"
+                if not isinstance(entry, str):
+                    issues.append(f"{pfx}: expected string, got {type(entry).__name__}")
+                elif not entry.strip():
+                    issues.append(f"{pfx}: empty path")
+                else:
+                    resolved = Path(entry).expanduser()
+                    if not resolved.is_dir():
+                        issues.append(f"{pfx}: directory does not exist: {entry}")
+            if not issues:
+                loaded.append(f"Git trusted dirs: {len(dirs)} path(s) from {path}")
+
+    return issues, loaded
+
+
+def _validate_rules_entries(
+    entries: list, prefix: str, is_url: bool = False
+) -> tuple[list[str], int]:
+    """Validate a list of rule entries (shared logic for file and unified config)."""
+    issues: list[str] = []
+    required = {"name", "pattern", "message"}
+    valid_actions = {"block", "ask", "allow"}
+    for i, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            issues.append(f"{prefix}[{i}]: expected object, got {type(entry).__name__}")
+            continue
+        name = entry.get("name", f"entry {i}")
+        pfx = f"{prefix}[{i}] ({name!r})"
+        for field in required:
+            if field not in entry:
+                issues.append(f"{pfx}: missing required field '{field}'")
+            elif not isinstance(entry[field], str):
+                issues.append(
+                    f"{pfx}: '{field}' must be a string, got {type(entry[field]).__name__}"
+                )
+        if "pattern" in entry and isinstance(entry["pattern"], str):
+            if not entry["pattern"]:
+                issues.append(f"{pfx}: 'pattern' is empty")
+            else:
+                try:
+                    re.compile(entry["pattern"])
+                except re.error as e:
+                    issues.append(f"{pfx}: invalid regex in 'pattern': {e}")
+        if not is_url and "exception" in entry:
+            exc = entry["exception"]
+            if exc is not None and not isinstance(exc, str):
+                issues.append(f"{pfx}: 'exception' must be a string or null")
+            elif isinstance(exc, str) and exc:
+                try:
+                    re.compile(exc)
+                except re.error as e:
+                    issues.append(f"{pfx}: invalid regex in 'exception': {e}")
+        if "action" in entry:
+            action = entry["action"]
+            if not isinstance(action, str):
+                issues.append(f"{pfx}: 'action' must be a string")
+            elif action not in valid_actions:
+                issues.append(f"{pfx}: 'action' must be 'block', 'ask', or 'allow'")
+    return issues, len(entries)
+
+
 def _validate_config() -> int:
-    """Validate extra rules config files.
+    """Validate all config sources: unified config and env var overrides.
 
     Output channels follow hook conventions:
       - Success (exit 0): stdout (shown in transcript)
@@ -2611,11 +2891,21 @@ def _validate_config() -> int:
     """
     url_path = os.environ.get("URL_GUARD_EXTRA_RULES")
     cmd_path = os.environ.get("COMMAND_GUARD_EXTRA_RULES")
-    if not url_path and not cmd_path:
+    dirs_path = os.environ.get("GIT_TRUSTED_DIRS")
+    has_unified = _UNIFIED_CONFIG_PATH.exists()
+    if not url_path and not cmd_path and not dirs_path and not has_unified:
         return 0  # Nothing configured, nothing to validate
 
-    all_issues = []
-    loaded = []
+    all_issues: list[str] = []
+    loaded: list[str] = []
+
+    # Validate unified config first
+    if has_unified:
+        issues, msgs = _validate_unified_config(_UNIFIED_CONFIG_PATH)
+        all_issues.extend(issues)
+        loaded.extend(msgs)
+
+    # Validate env var overrides
     if url_path:
         issues, count = _validate_rules_file(url_path, "URL_GUARD_EXTRA_RULES", is_url=True)
         if issues:
@@ -2628,6 +2918,12 @@ def _validate_config() -> int:
             all_issues.extend(issues)
         else:
             loaded.append(f"Command rules: {count} rule(s) from {cmd_path}")
+    if dirs_path:
+        issues, count = _validate_trusted_dirs_file(dirs_path)
+        if issues:
+            all_issues.extend(issues)
+        else:
+            loaded.append(f"Git trusted dirs: {count} path(s) from {dirs_path}")
 
     if all_issues:
         # stderr + exit 2: fed back to Claude for explanation
@@ -2706,6 +3002,10 @@ def _handle_bash_command(command: str) -> None:
     _check_fetch_command(command)
 
     subcmds = split_commands(command)
+
+    # Block cd && git compounds before processing individual subcommands
+    _check_cd_git_compound(subcmds, command)
+
     fetch_seen = False
     for subcmd in subcmds:
         fetch_seen = _check_subcmd(subcmd, fetch_seen)
@@ -2743,9 +3043,28 @@ def main() -> None:
     global _session_id, _tool_use_id
 
     # Load user-defined extra rules (deferred from module level to avoid
-    # side effects during import and to keep rule loading in one place)
+    # side effects during import and to keep rule loading in one place).
+    # Unified config (~/.claude/dev-guard.json) loads first, then env vars add on top.
+    config = _load_unified_config()
+    for section, target, converter in [
+        ("command_rules", RULES, _cmd_rule_from_entry),
+        ("url_rules", AUTH_URL_RULES, _url_rule_from_entry),
+    ]:
+        entries = config.get(section)
+        if isinstance(entries, list):
+            for entry in entries:
+                with contextlib.suppress(KeyError, TypeError, AttributeError, re.error):
+                    target.append(converter(entry))  # type: ignore[arg-type]
+    dirs = config.get("git_trusted_dirs")
+    if isinstance(dirs, list):
+        _TRUSTED_GIT_DIRS.extend(
+            Path(d).expanduser().resolve() for d in dirs if isinstance(d, str) and d.strip()
+        )
+
+    # Env var overrides (additive — stacks on top of unified config)
     AUTH_URL_RULES.extend(_load_extra_rules("URL_GUARD_EXTRA_RULES", _url_rule_from_entry))
     RULES.extend(_load_extra_rules("COMMAND_GUARD_EXTRA_RULES", _cmd_rule_from_entry))
+    _TRUSTED_GIT_DIRS.extend(_load_trusted_dirs())
 
     if "--trust" in sys.argv:
         sys.exit(_handle_trust_command(sys.argv))

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -3895,3 +3895,418 @@ class TestHookOutputHelper:
         output = _mod._hook_output("allow", reason)
         parsed = json.loads(output)
         assert parsed["hookSpecificOutput"]["permissionDecisionReason"] == reason
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Feature: cd && git compound command blocking
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCdGitCompound:
+    """Block compound commands that cd into a directory then run git."""
+
+    def test_cd_and_git_push_blocked(self):
+        """cd /path && git push is blocked."""
+        result = run_bash("cd /some/repo && git push origin HEAD:main")
+        assert_guard(result, 2, "cd-git-compound", "cd-and-push")
+
+    def test_cd_and_git_commit_blocked(self):
+        """cd /path && git commit is blocked."""
+        result = run_bash("cd /some/repo && git commit -m 'test'")
+        assert_guard(result, 2, "cd-git-compound", "cd-and-commit")
+
+    def test_cd_semicolon_git_blocked(self):
+        """cd /path ; git push is blocked (semicolon separator)."""
+        result = run_bash("cd /some/repo ; git push origin main")
+        assert_guard(result, 2, "cd-git-compound", "cd-semicolon-git")
+
+    def test_cd_and_non_git_allowed(self):
+        """cd /path && make all is allowed (no git involved)."""
+        result = run_bash("cd /some/repo && make all")
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_git_without_cd_allowed(self):
+        """Plain git push is allowed (no cd prefix)."""
+        result = run_bash("git -C /some/repo push origin HEAD:main")
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_cd_and_intervening_cmd_then_git_blocked(self):
+        """cd /path && ls && git push is blocked (cd still in effect)."""
+        result = run_bash("cd /some/repo && ls && git push origin main")
+        assert_guard(result, 2, "cd-git-compound", "cd-ls-git")
+
+    def test_guidance_includes_git_c_suggestion(self):
+        """Guidance message includes git -C alternative."""
+        result = run_bash("cd /my/project && git push origin main")
+        output = result.stderr + result.stdout
+        assert "git -C" in output, f"Expected 'git -C' in output: {output}"
+        assert "/my/project" in output, f"Expected path in output: {output}"
+
+    def test_cd_quoted_path_and_git_blocked(self):
+        """cd with quoted path followed by git is blocked."""
+        result = run_bash('cd "/path with spaces" && git status')
+        assert_guard(result, 2, "cd-git-compound", "cd-quoted-git")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Feature: git trusted directories
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _run_with_trusted_dirs(command, dirs_file):
+    """Run the guard with a custom trusted dirs file (GIT_TRUSTED_DIRS)."""
+    env = os.environ.copy()
+    env["GIT_TRUSTED_DIRS"] = str(dirs_file)
+    return run_guard("Bash", {"command": command}, env=env)
+
+
+class TestGitTrustedDirs:
+    """Block git commands operating outside configured trusted directories."""
+
+    def test_git_c_trusted_dir_allowed(self, tmp_path):
+        """git -C pointing to a trusted directory is allowed."""
+        # Use CWD to avoid /tmp/ triggering the tmp-path rule on Linux CI
+        cwd = os.getcwd()
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps([cwd]))
+        result = _run_with_trusted_dirs(f"git -C {cwd}/subdir push origin main", dirs_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_git_c_untrusted_dir_blocked(self, tmp_path):
+        """git -C pointing outside trusted directories is blocked."""
+        cwd = os.getcwd()
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps([cwd]))
+        result = _run_with_trusted_dirs("git -C /nonexistent/untrusted push origin main", dirs_file)
+        assert_guard(result, 2, "git-untrusted-dir", "untrusted-git-c")
+
+    def test_no_trusted_dirs_allows_all(self):
+        """Without GIT_TRUSTED_DIRS, all git commands are allowed."""
+        result = run_bash("git -C /any/path status")
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_git_version_always_allowed(self, tmp_path):
+        """git --version is informational and always allowed."""
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps(["/nonexistent"]))
+        result = _run_with_trusted_dirs("git --version", dirs_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_git_help_always_allowed(self, tmp_path):
+        """git help is informational and always allowed."""
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps(["/nonexistent"]))
+        result = _run_with_trusted_dirs("git help push", dirs_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_git_config_global_always_allowed(self, tmp_path):
+        """git config --global is allowed (operates on global config, not repo)."""
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps(["/nonexistent"]))
+        result = _run_with_trusted_dirs("git config --global user.name", dirs_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_git_cmd_with_help_flag_allowed(self, tmp_path):
+        """git push --help is informational and always allowed."""
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps(["/nonexistent"]))
+        result = _run_with_trusted_dirs("git push --help", dirs_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_multiple_trusted_dirs(self, tmp_path):
+        """Multiple trusted directories — command in any one is allowed."""
+        # Use CWD to avoid /tmp/ triggering the tmp-path rule on Linux CI
+        cwd = os.getcwd()
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps(["/nonexistent/dir1", cwd]))
+        # In second trusted dir — allowed
+        result = _run_with_trusted_dirs(f"git -C {cwd}/repo status", dirs_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_blocked_message_shows_trusted_dirs(self, tmp_path):
+        """Block message shows the configured trusted directories."""
+        cwd = os.getcwd()
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps([cwd]))
+        result = _run_with_trusted_dirs("git -C /nonexistent/evil push origin main", dirs_file)
+        output = result.stderr + result.stdout
+        assert cwd in output, f"Expected trusted dir in output: {output}"
+
+    def test_tilde_expansion(self, tmp_path):
+        """Paths with ~ are expanded correctly."""
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps(["~"]))
+        # CWD is under home dir — should be allowed
+        result = _run_with_trusted_dirs("git status", dirs_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_git_c_quoted_path(self, tmp_path):
+        """git -C with a quoted path is handled correctly."""
+        # Use CWD to avoid /tmp/ triggering the tmp-path rule on Linux CI
+        cwd = os.getcwd()
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps([cwd]))
+        result = _run_with_trusted_dirs(f'git -C "{cwd}/my repo" status', dirs_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_malformed_json_fails_open(self, tmp_path):
+        """Malformed JSON trusted dirs file fails open (no blocking)."""
+        dirs_file = tmp_path / "bad.json"
+        dirs_file.write_text("not json")
+        result = _run_with_trusted_dirs("git -C /any/path status", dirs_file)
+        assert result.returncode == 0, f"Expected pass (fail-open), stderr: {result.stderr}"
+
+    def test_empty_array_fails_open(self, tmp_path):
+        """Empty array in trusted dirs file fails open (no blocking)."""
+        dirs_file = tmp_path / "empty.json"
+        dirs_file.write_text("[]")
+        result = _run_with_trusted_dirs("git -C /any/path status", dirs_file)
+        assert result.returncode == 0, f"Expected pass (fail-open), stderr: {result.stderr}"
+
+
+class TestGitTrustedDirsValidation:
+    """Validation of GIT_TRUSTED_DIRS config file."""
+
+    def test_validate_valid_dirs(self, tmp_path):
+        """Valid trusted dirs file passes validation."""
+        trusted = tmp_path / "projects"
+        trusted.mkdir()
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps([str(trusted)]))
+        env = os.environ.copy()
+        env["GIT_TRUSTED_DIRS"] = str(dirs_file)
+        result = subprocess.run(
+            ["uv", "run", SCRIPT, "--validate"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "Git trusted dirs" in result.stdout
+
+    def test_validate_missing_file(self, tmp_path):
+        """Missing trusted dirs file fails validation."""
+        env = os.environ.copy()
+        env["GIT_TRUSTED_DIRS"] = str(tmp_path / "nonexistent.json")
+        result = subprocess.run(
+            ["uv", "run", SCRIPT, "--validate"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 2
+        assert "file not found" in result.stderr
+
+    def test_validate_nonexistent_dir(self, tmp_path):
+        """Trusted dirs file with nonexistent directory fails validation."""
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps(["/this/dir/does/not/exist"]))
+        env = os.environ.copy()
+        env["GIT_TRUSTED_DIRS"] = str(dirs_file)
+        result = subprocess.run(
+            ["uv", "run", SCRIPT, "--validate"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 2
+        assert "does not exist" in result.stderr
+
+    def test_validate_non_string_entry(self, tmp_path):
+        """Trusted dirs file with non-string entry fails validation."""
+        dirs_file = tmp_path / "trusted.json"
+        dirs_file.write_text(json.dumps([123, "/tmp"]))
+        env = os.environ.copy()
+        env["GIT_TRUSTED_DIRS"] = str(dirs_file)
+        result = subprocess.run(
+            ["uv", "run", SCRIPT, "--validate"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 2
+        assert "expected string" in result.stderr
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Feature: unified dev-guard.json config
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _run_with_unified_config(command, config_file, *, extra_env=None):
+    """Run the guard with a unified config file (DEV_GUARD_CONFIG)."""
+    env = os.environ.copy()
+    env["DEV_GUARD_CONFIG"] = str(config_file)
+    # Clear individual env vars to isolate unified config testing
+    env.pop("COMMAND_GUARD_EXTRA_RULES", None)
+    env.pop("URL_GUARD_EXTRA_RULES", None)
+    env.pop("GIT_TRUSTED_DIRS", None)
+    if extra_env:
+        env.update(extra_env)
+    return run_guard("Bash", {"command": command}, env=env)
+
+
+class TestUnifiedConfig:
+    """Unified ~/.claude/dev-guard.json config file."""
+
+    def test_command_rules_from_unified_config(self, tmp_path):
+        """command_rules section loads and blocks matching commands."""
+        config = {
+            "command_rules": [
+                {
+                    "name": "test-block",
+                    "pattern": r"^\s*dangerous-cmd\b",
+                    "message": "Use safe-cmd instead.",
+                }
+            ]
+        }
+        config_file = tmp_path / "dev-guard.json"
+        config_file.write_text(json.dumps(config))
+        result = _run_with_unified_config("dangerous-cmd --flag", config_file)
+        assert result.returncode == 2
+        assert "safe-cmd" in result.stderr
+
+    def test_url_rules_from_unified_config(self, tmp_path):
+        """url_rules section loads and blocks matching URLs."""
+        config = {
+            "url_rules": [
+                {
+                    "name": "test-url",
+                    "pattern": r"internal\.corp\.com",
+                    "message": "Use VPN tool instead.",
+                }
+            ]
+        }
+        config_file = tmp_path / "dev-guard.json"
+        config_file.write_text(json.dumps(config))
+        result = _run_with_unified_config("curl https://internal.corp.com/api", config_file)
+        assert result.returncode == 2
+        assert "VPN tool" in result.stderr
+
+    def test_git_trusted_dirs_from_unified_config(self, tmp_path):
+        """git_trusted_dirs section loads and blocks untrusted git paths."""
+        cwd = os.getcwd()
+        config = {"git_trusted_dirs": [cwd]}
+        config_file = tmp_path / "dev-guard.json"
+        config_file.write_text(json.dumps(config))
+        # Trusted path — allowed
+        result = _run_with_unified_config(f"git -C {cwd}/sub status", config_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+        # Untrusted path — blocked
+        result = _run_with_unified_config("git -C /nonexistent/evil status", config_file)
+        assert result.returncode == 2
+        assert "git-untrusted-dir" in (result.stderr + result.stdout)
+
+    def test_env_var_overrides_stacks(self, tmp_path):
+        """Env var rules stack on top of unified config (additive)."""
+        # Unified config blocks dangerous-cmd
+        config = {
+            "command_rules": [
+                {
+                    "name": "unified-block",
+                    "pattern": r"^\s*unified-cmd\b",
+                    "message": "Blocked by unified config.",
+                }
+            ]
+        }
+        config_file = tmp_path / "dev-guard.json"
+        config_file.write_text(json.dumps(config))
+        # Env var adds another rule blocking extra-cmd
+        extra_rules = [
+            {
+                "name": "env-block",
+                "pattern": r"^\s*env-cmd\b",
+                "message": "Blocked by env var.",
+            }
+        ]
+        extra_file = tmp_path / "extra-rules.json"
+        extra_file.write_text(json.dumps(extra_rules))
+        # Both should be blocked
+        result = _run_with_unified_config(
+            "unified-cmd", config_file, extra_env={"COMMAND_GUARD_EXTRA_RULES": str(extra_file)}
+        )
+        assert result.returncode == 2
+        assert "unified config" in result.stderr
+        result = _run_with_unified_config(
+            "env-cmd", config_file, extra_env={"COMMAND_GUARD_EXTRA_RULES": str(extra_file)}
+        )
+        assert result.returncode == 2
+        assert "env var" in result.stderr
+
+    def test_missing_unified_config_is_fine(self, tmp_path):
+        """Missing unified config file is silently ignored."""
+        config_file = tmp_path / "nonexistent.json"
+        result = _run_with_unified_config("git status", config_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+    def test_malformed_unified_config_fails_open(self, tmp_path):
+        """Malformed unified config file is silently ignored."""
+        config_file = tmp_path / "bad.json"
+        config_file.write_text("not json {{{")
+        result = _run_with_unified_config("git status", config_file)
+        assert result.returncode == 0, f"Expected pass (fail-open), stderr: {result.stderr}"
+
+    def test_unknown_keys_ignored_at_runtime(self, tmp_path):
+        """Unknown keys in unified config don't break loading."""
+        config = {"future_feature": True, "git_trusted_dirs": ["~"]}
+        config_file = tmp_path / "dev-guard.json"
+        config_file.write_text(json.dumps(config))
+        result = _run_with_unified_config("git status", config_file)
+        assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
+
+
+class TestUnifiedConfigValidation:
+    """Validation of unified dev-guard.json config."""
+
+    def test_validate_valid_unified_config(self, tmp_path):
+        """Valid unified config passes validation."""
+        cwd = os.getcwd()
+        config = {
+            "command_rules": [{"name": "test", "pattern": r"^\s*test\b", "message": "Test rule."}],
+            "git_trusted_dirs": [cwd],
+        }
+        config_file = tmp_path / "dev-guard.json"
+        config_file.write_text(json.dumps(config))
+        env = os.environ.copy()
+        env["DEV_GUARD_CONFIG"] = str(config_file)
+        result = subprocess.run(
+            ["uv", "run", SCRIPT, "--validate"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "Command rules" in result.stdout
+        assert "Git trusted dirs" in result.stdout
+
+    def test_validate_unknown_keys_warns(self, tmp_path):
+        """Unknown keys in unified config are flagged during validation."""
+        config = {"bogus_key": []}
+        config_file = tmp_path / "dev-guard.json"
+        config_file.write_text(json.dumps(config))
+        env = os.environ.copy()
+        env["DEV_GUARD_CONFIG"] = str(config_file)
+        result = subprocess.run(
+            ["uv", "run", SCRIPT, "--validate"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 2
+        assert "unknown keys" in result.stderr
+
+    def test_validate_bad_rule_in_unified(self, tmp_path):
+        """Invalid rule entry in unified config is caught by validation."""
+        config = {"command_rules": [{"name": "test"}]}  # missing pattern, message
+        config_file = tmp_path / "dev-guard.json"
+        config_file.write_text(json.dumps(config))
+        env = os.environ.copy()
+        env["DEV_GUARD_CONFIG"] = str(config_file)
+        result = subprocess.run(
+            ["uv", "run", SCRIPT, "--validate"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 2
+        assert "missing required field" in result.stderr


### PR DESCRIPTION
## Summary

- Blocks compound `cd <path> && git <cmd>` commands with guidance to use `git -C <path>` instead (prevents bare repository attacks)
- Adds unified `~/.claude/dev-guard.json` config file (auto-discovered, overridable via `DEV_GUARD_CONFIG` env var) with sections for `command_rules`, `url_rules`, and `git_trusted_dirs`
- Opt-in trusted directory enforcement blocks git commands outside configured paths; informational git commands (`--version`, `help`, `config --global`) are exempt
- Individual env vars (`COMMAND_GUARD_EXTRA_RULES`, `URL_GUARD_EXTRA_RULES`, `GIT_TRUSTED_DIRS`) still work as additive overrides
- Updates CLAUDE.md workflow to use `/plugins reload` instead of session restart
- 35 new tests covering all features