### PR TITLE
feat(code-quality): adds project rules compliance to quality-gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "source": "./code-quality",
       "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -20,7 +20,10 @@ artifact gates prevent work from being lost.
 **Always after:** implementation tasks, /swarm, /spawn, subagent work, research, planning,
 significant artifact creation.
 
-**Skip when:** pure conversation with no deliverables, single-line trivial fixes, or user opts out.
+**Skip when:** pure conversation with no deliverables, or user explicitly opts out.
+
+**Never skip "because it's trivial."** Small changes cause real failures. Don't rationalize
+your way out of the process.
 
 ---
 
@@ -111,12 +114,32 @@ Execute this protocol for EVERY round:
    break the problem down to fundamental truths and rebuild
    your assessment from the ground up.
 
-3. FIX ALL FINDINGS IMMEDIATELY
+3. PROJECT RULES + CROSS-REFERENCE INTEGRITY (Round 2 only)
+   a) Re-read CLAUDE.md and CONTRIBUTING.md (if they exist).
+      Check every change against project-specific conventions:
+      - Version bump rules (e.g., "always bump plugin versions in both files")
+      - Commit message conventions
+      - Required file updates (changelogs, manifests, registries)
+      - Deployment/delivery requirements (will this change actually reach users?)
+      - Any other project-specific rules that apply to this type of change
+
+   b) Cross-reference integrity: search the ENTIRE codebase for references
+      to things you changed, renamed, or removed. Files you DIDN'T modify
+      can have stale references to things you DID modify. Grep for:
+      - Old names/values you replaced
+      - Functions/skills/tools you renamed or removed
+      - Version numbers that should match across files
+      - Import paths, file references, cross-links
+
+   This catches issues that no generic lens covers — project conventions
+   and cross-file consistency are invisible to single-file review.
+
+4. FIX ALL FINDINGS IMMEDIATELY
    Do not note issues for later. Do not say "could be improved."
    Fix them NOW. Every identified issue must result in an edit or
    a documented, specific blocker.
 
-4. ACTION AUDIT
+5. ACTION AUDIT
    Scan ALL output (yours and any subagent output) for
    identified-but-unactioned items:
    - "could be improved" / "might want to" / "consider"
@@ -136,7 +159,7 @@ Execute this protocol for EVERY round:
    - Cross-reference against actual edits made
    - The delta is "identified-but-unactioned" — fix or justify each one
 
-5. serena::think_about_whether_you_are_done
+6. serena::think_about_whether_you_are_done
    "Did I genuinely address everything this lens covers?"
    If no → fix remaining items before proceeding to next round.
 ```
@@ -157,6 +180,12 @@ tool must confirm.
 Same-context review has an anchoring ceiling. Fresh-context subagents break through it by
 reviewing with no knowledge of your implementation decisions.
 
+**Layer 2 is NEVER optional.** Do not skip it because the change "seems trivial" or subagents
+feel "disproportionate." Small changes cause real failures — the version bump miss that broke
+the Stop hook was a 1-word fix where Layer 2 was skipped as "disproportionate." The subagent
+would have caught it. If the change is truly trivial, the subagents finish quickly — that's
+cheap insurance, not wasted effort.
+
 ### Preparation
 
 ```
@@ -168,6 +197,8 @@ Collect:
 - `git diff` (for code) or artifact content (for non-code)
 - The original user request (verbatim)
 - Work type classification from Step 0
+- CLAUDE.md / CONTRIBUTING.md project rules (if they exist) — subagents need these
+  to check project convention compliance
 
 ### Subagent A: Completeness Reviewer (opus)
 
@@ -222,7 +253,7 @@ Serena memory checks. Pure question with no persistent insights → skip memory 
 
 ## Artifact Gate (BLOCKING)
 
-Ensures work products aren't lost.
+Ensures work products aren't lost AND project conventions are satisfied.
 
 | Work Type | Gate Criteria |
 |-----------|---------------|
@@ -231,6 +262,21 @@ Ensures work products aren't lost.
 | **Research** | Key findings documented persistently (claude-mem, PROJECT.md, or file). |
 | **Config** | Valid syntax. Consistent with existing patterns. Validated. |
 | **Question** | No gate (unless answer revealed something worth persisting). |
+
+**Project-specific checks (all work types) — final re-verification:**
+Round 2 checked project rules during review. This gate re-verifies AFTER all fixes are applied
+(Layer 1 fixes + Layer 2 subagent fixes may have changed the state). Re-read CLAUDE.md:
+- Version bumps in plugin/package manifests (if project requires them)
+- Registry/marketplace entries updated to match
+- Will the change actually reach users after merge? (cache invalidation, version detection)
+- Any required companion files (changelogs, migration guides, etc.)
+
+**Upstream state verification (if a PR exists):**
+Do not assume prior pushes landed or that the PR is still open. Verify:
+- `gh pr view` — is the PR still open, or was it already merged/closed?
+- `git log origin/main..HEAD` — does the branch contain ALL intended commits?
+- If force-pushing to an already-merged branch, commits are silently orphaned
+- After merge: `git log origin/main` — confirm the merge includes your changes
 
 ---
 
@@ -264,6 +310,7 @@ Layer 1 — Self-Review:
   Issues found: [count]
   Issues fixed: [count]
   Identified-but-unactioned caught: [count]
+  Project rules violations caught: [count]
 
 Layer 2 — Subagent Reviews:
   Subagent A (Completeness): [count] findings across 2 passes

--- a/code-quality/skills/quality-gate/references/lens-rubrics.md
+++ b/code-quality/skills/quality-gate/references/lens-rubrics.md
@@ -27,6 +27,8 @@ structure. This file provides the specific questions and techniques for each len
 - What was identified by you or a subagent but not actioned?
 - What was deferred without the user explicitly requesting deferral?
 - Are all code paths covered? All branches implemented?
+- **Project rules:** Re-read CLAUDE.md/CONTRIBUTING.md. Check version bumps, manifest
+  updates, deployment readiness. Will this change actually reach users after merge?
 - **Reasoning:** Use `sequential-thinking` MCP to check each atomic requirement.
 - **First-principles:** "Return to the original request. What are its fundamental parts?
   Is each one fully satisfied?"
@@ -162,6 +164,9 @@ structure. This file provides the specific questions and techniques for each len
 - All required fields present?
 - No placeholder values left?
 - Documentation/comments for non-obvious settings?
+- **Project rules:** Re-read CLAUDE.md/CONTRIBUTING.md. Version bumped in ALL required
+  files? Registry/marketplace entries updated? Will this change reach users after merge,
+  or will caching/versioning prevent delivery?
 
 ### Round 3: Security
 

--- a/code-quality/skills/quality-gate/references/subagent-prompts.md
+++ b/code-quality/skills/quality-gate/references/subagent-prompts.md
@@ -19,6 +19,9 @@ WORK TYPE: {work_type}
 CHANGES TO REVIEW:
 {git_diff_or_artifact_content}
 
+PROJECT RULES (if CLAUDE.md or CONTRIBUTING.md exists, read it):
+{claude_md_rules_if_any}
+
 REVIEW CHECKLIST:
 1. Read the original request word-by-word. Break it into atomic requirements.
 2. For EACH requirement: is it fully addressed? Not partially — FULLY.
@@ -26,6 +29,7 @@ REVIEW CHECKLIST:
 4. Search for identified-but-unactioned items: "could be improved", "consider", "might want to"
 5. Check for partial implementations: stubs, empty functions, placeholder values
 6. If this is subagent output: check for "I implemented X but not Y" patterns
+7. Check project rules compliance: version bumps, required manifest updates, deployment readiness
 
 For each issue found, report:
 - What requirement or item is affected
@@ -69,6 +73,9 @@ WORK TYPE: {work_type}
 CHANGES TO REVIEW:
 {git_diff_or_artifact_content}
 
+PROJECT RULES (if CLAUDE.md or CONTRIBUTING.md exists, read it):
+{claude_md_rules_if_any}
+
 This work claims to be production-ready. Prove it wrong.
 
 FOCUS AREAS FOR CODE:
@@ -83,6 +90,10 @@ FOCUS AREAS FOR NON-CODE:
 2. LOGIC: Where does the reasoning break down?
 3. GAPS: What failure modes aren't addressed?
 4. ASSUMPTIONS: What implicit assumptions will surprise someone?
+
+FOCUS AREA FOR ALL WORK TYPES:
+- PROJECT RULES: Were version bumps done? Manifests updated? Will this change
+  actually reach users after merge? Any required companion updates missing?
 
 For each issue found, report:
 - The specific problem


### PR DESCRIPTION
## Summary

- Adds project rules + cross-reference integrity check to Round Execution Protocol
- Makes Layer 2 subagent reviews mandatory (removes "skip for trivial" escape hatch)
- Adds project-specific checks to Artifact Gate with Round 2 vs Gate distinction
- Includes CLAUDE.md context in both subagent prompts and lens rubrics
- Bumps code-quality to 2.1.0

Note: This commit was orphaned when PR #56 merged before the force-push landed.