### PR TITLE
fix(dev-guard): fixes Stop hook and quality-gate gaps

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "source": "./code-quality",
       "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
       "category": "quality",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.32.0",
+      "version": "1.33.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -145,7 +145,21 @@ Execute this protocol for EVERY round:
    - "could be improved" / "might want to" / "consider"
    - "potential issue" / "noted for future" / "TODO"
    - "follow-up" / "out of scope" / "later"
+   - "pre-existing" / "preexisting" / "known issue" / "existing failure"
    - Any issue described without a corresponding fix
+
+   THE "PREEXISTING" TRAP:
+   Labeling something "preexisting" is NOT permission to ignore it.
+   For every issue labeled preexisting or known:
+   - WHY does it exist? Investigate the root cause, don't just note it.
+   - Is it within scope of the current work? If your changes touch the
+     same area, fix it.
+   - Is it ACTUALLY preexisting? Verify by checking the baseline, not
+     by assuming.
+   - Even if truly preexisting and out of scope: document it as a
+     concrete follow-up task, not a hand-wave.
+   "4 pre-existing test failures" repeated without investigation is
+   the same as ignoring 4 bugs.
 
    For EACH identified-but-unactioned item:
    - Can fix now? → Fix it.
@@ -200,32 +214,61 @@ Collect:
 - CLAUDE.md / CONTRIBUTING.md project rules (if they exist) — subagents need these
   to check project convention compliance
 
-### Subagent A: Completeness Reviewer (opus)
+### Subagent Execution (2 passes each — BOTH mandatory)
 
-**Pass 1:** Spawn with diff/artifact + original request.
-Focus: requirements coverage, deferred work, action verification.
-See `references/subagent-prompts.md` for the full prompt template.
+Each subagent runs TWO passes. Pass 2 is NOT optional — it catches issues the subagent
+missed on Pass 1 and verifies your fixes didn't introduce new problems. You MUST save
+the agent ID from Pass 1 to resume for Pass 2.
 
-Fix all findings from Subagent A.
+**Subagent A: Completeness Reviewer (opus)**
 
-**Pass 2:** Resume Subagent A (preserves its context).
-Prompt: "Here are the fixes I made. Review them. Also: what did YOU miss on your
-first pass? You had fresh eyes but still have blind spots. Look again."
+```
+PASS 1:
+  agent_result = Agent(
+    description="Completeness review",
+    model="opus",
+    prompt=<see references/subagent-prompts.md, Subagent A Pass 1>
+  )
+  → Save agent_result.agentId
+  → Fix ALL findings
 
-Fix all findings from Pass 2.
+PASS 2 (MANDATORY — do not skip):
+  Agent(
+    description="Completeness re-review",
+    resume=<saved agentId from Pass 1>,
+    prompt="Here are the fixes I made: {summary_of_fixes}.
+            Review them. Also: what did YOU miss on your first pass?
+            You had fresh eyes but still have blind spots. Look again."
+  )
+  → Fix ALL findings from Pass 2
+```
 
-### Subagent B: Adversarial Reviewer (opus)
+**Subagent B: Adversarial Reviewer (opus)**
 
-**Pass 1:** Spawn with diff/artifact + original request.
-Focus: bugs, security, edge cases, production failures.
-See `references/subagent-prompts.md` for the full prompt template.
+```
+PASS 1:
+  agent_result = Agent(
+    description="Adversarial review",
+    model="opus",
+    prompt=<see references/subagent-prompts.md, Subagent B Pass 1>
+  )
+  → Save agent_result.agentId
+  → Fix ALL findings
 
-Fix all findings from Subagent B.
+PASS 2 (MANDATORY — do not skip):
+  Agent(
+    description="Adversarial re-review",
+    resume=<saved agentId from Pass 1>,
+    prompt="Here are the fixes: {summary_of_fixes}.
+            Verify they're correct. What else breaks in production?"
+  )
+  → Fix ALL findings from Pass 2
+```
 
-**Pass 2:** Resume Subagent B.
-Prompt: "Here are the fixes. Verify they're correct. What else breaks in production?"
-
-Fix all findings from Pass 2.
+**Why Pass 2 matters:** Pass 1 finds issues. You fix them. But fixes can introduce NEW
+issues, and the subagent's first pass always misses something (fresh eyes still have blind
+spots). Pass 2 catches both. Skipping it is like running tests once, making changes, and
+not re-running them.
 
 ---
 

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.32.0",
+  "version": "1.33.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -83,7 +83,7 @@
         "hooks": [
           {
             "type": "prompt",
-            "prompt": "Before stopping, verify ALL of the following. Return {\"decision\": \"block\", \"reason\": \"...\"} if ANY check fails:\n\n1. If code was written: were tests run and passing?\n2. Search the diff or conversation for TODO, FIXME, HACK, 'later', 'follow-up' — any unresolved?\n3. Were any issues identified but not fixed? (look for 'could be improved', 'consider', 'potential issue')\n4. Does the work fully address the original request? Check each requirement.\n5. If implementation work: are changes on a feature branch or ready to commit?\n6. Were project memories (hack/ files, plans) updated if applicable?\n\nReturn {\"decision\": \"approve\"} ONLY if ALL checks pass."
+            "prompt": "You are a stop hook validator. Check these conditions against the conversation: (1) if code was written, were tests run and passing? (2) no unresolved TODO/FIXME/HACK in diff or conversation (3) no issues identified but left unfixed (4) work fully addresses original request (5) implementation changes are on a branch or ready to commit (6) project memories updated if applicable. Respond with ONLY valid JSON, nothing else — no analysis, no explanation, just the JSON object: {\"decision\": \"approve\"} if all checks pass, or {\"decision\": \"block\", \"reason\": \"brief explanation of what failed\"} if any check fails."
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Rewrites Stop hook prompt to require JSON-only output (fixes "JSON validation failed")
- Adds "preexisting" to Action Audit scan list with mandatory root cause investigation
- Restructures subagent execution with explicit Agent() syntax and mandatory Pass 2
- Bumps dev-guard to 1.33.0, code-quality to 2.2.0