### PR TITLE
feat(dev-guard): rewrite Stop hook as two-script command type

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.34.0",
+      "version": "1.35.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "source": "./code-quality",
       "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/skills/deep-research/SKILL.md
+++ b/code-quality/skills/deep-research/SKILL.md
@@ -105,6 +105,16 @@ Include viewpoints from:
 
 ## Output Format
 
+### Output Location
+
+If a `hack/` directory exists in the current working directory, write the research report to a file:
+
+1. Create `hack/research/` if it does not exist
+2. Write the report to `hack/research/YYYY-MM-DD-<topic>.md` (use today's date and a short kebab-case topic slug, e.g. `2026-03-16-vertex-ai-pricing.md`)
+3. After writing, tell the user the file path
+
+If no `hack/` directory exists, deliver the report in the conversation only.
+
 ### Research Report Structure
 
 ```markdown

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -147,7 +147,22 @@ Execute this protocol for EVERY round:
    - "potential issue" / "noted for future" / "TODO"
    - "follow-up" / "out of scope" / "later"
    - "pre-existing" / "preexisting" / "known issue" / "existing failure"
+   - "should be verified" / "needs to be confirmed" / "you should check"
+   - "verify against your" / "please verify" / "you may want to update"
    - Any issue described without a corresponding fix
+
+   THE "DEFERRAL-TO-USER" TRAP:
+   Saying "should be verified" or "you should check" is an admission that
+   work needs doing — and a confession that you didn't do it. If it should
+   be verified, verify it. If it needs checking, check it. If it needs
+   confirming, confirm it. The user asked you to do the work, not to
+   generate a checklist of work for them to do.
+   - "The field ID should be verified against your instance" → Look it up.
+   - "You may want to update the config" → Update it.
+   - "This should be tested with..." → Test it.
+   - "Needs to be confirmed" → Confirm it.
+   Every "should be" is either done or documented as a specific blocker
+   with why you couldn't do it yourself.
 
    THE "PREEXISTING" TRAP:
    Labeling something "preexisting" is NOT permission to ignore it.

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -38,8 +38,9 @@ digraph quality_gate {
   layer2 [label="Layer 2: Fresh-Context Subagents\n2 subagents x 2 passes"];
   memory [label="Memory Gate (BLOCKING)"];
   artifact [label="Artifact Gate (BLOCKING)"];
+  nodataloss [label="No Data Loss Gate (BLOCKING)"];
   final [label="Final Verification"];
-  detect -> layer1 -> layer2 -> memory -> artifact -> final;
+  detect -> layer1 -> layer2 -> memory -> artifact -> nodataloss -> final;
 }
 ```
 
@@ -194,11 +195,22 @@ tool must confirm.
 Same-context review has an anchoring ceiling. Fresh-context subagents break through it by
 reviewing with no knowledge of your implementation decisions.
 
-**Layer 2 is NEVER optional.** Do not skip it because the change "seems trivial" or subagents
-feel "disproportionate." Small changes cause real failures — the version bump miss that broke
-the Stop hook was a 1-word fix where Layer 2 was skipped as "disproportionate." The subagent
-would have caught it. If the change is truly trivial, the subagents finish quickly — that's
-cheap insurance, not wasted effort.
+**Layer 2 is NEVER optional and NEVER substitutable.** Do not skip it because the change "seems
+trivial" or subagents feel "disproportionate." Do not substitute it with prior review work —
+swarm Phase 4 reviewers, sc:analyze output, or any other earlier review does NOT replace Layer 2.
+
+**Why Layer 2 is distinct from all prior reviews:**
+- **Timing:** Layer 2 reviews the FINAL state — after Layer 1 fixes, after any swarm Phase 5
+  fixes, after everything. Prior reviews examined earlier, now-stale versions of the work.
+- **Lens:** Layer 2 uses holistic lenses (completeness-vs-original-request, adversarial).
+  Domain-specific reviewers (security, performance, QA) cover different ground.
+- **Context:** Layer 2 subagents have zero knowledge of your implementation decisions,
+  rationalizations, or "good enough" compromises. Prior reviewers in the same session share
+  your context ceiling.
+
+If you find yourself writing "SUBSTITUTED by" or "already covered by" for Layer 2, you are
+rationalizing. Stop. Spawn the subagents. If the change is truly trivial, the subagents
+finish quickly — that's cheap insurance, not wasted effort.
 
 ### Preparation
 
@@ -323,6 +335,23 @@ Do not assume prior pushes landed or that the PR is still open. Verify:
 
 ---
 
+## No Data Loss Gate (BLOCKING)
+
+Ensures work artifacts are persisted to a durable, findable location — not just in the
+conversation context. Cannot proceed past this gate without confirming each applicable item.
+
+| Work Type | Persistence Check |
+|-----------|-------------------|
+| **Code** | Changes are committed to a feature branch OR explicitly staged and user is informed. No committed-but-not-pushed-and-forgotten work. |
+| **Planning** | Plan written to `hack/plans/YYYY-MM-DD-<topic>.md`. New tasks added to `hack/TODO.md`. |
+| **Research** | Findings written to `hack/research/YYYY-MM-DD-<topic>.md` (if hack/ exists), otherwise to PROJECT.md or saved to claude-mem. Key claims are not conversation-only. |
+| **All types** | Every significant artifact has a clear, durable home. Nothing important exists only in the conversation. |
+
+**Skip conditions:** Pure question with no artifacts → skip. Work explicitly scoped as
+"conversation only" by the user → skip.
+
+---
+
 ## Final Verification
 
 | Work Type | Verification |
@@ -356,8 +385,9 @@ Layer 1 — Self-Review:
   Project rules violations caught: [count]
 
 Layer 2 — Subagent Reviews:
-  Subagent A (Completeness): [count] findings across 2 passes
-  Subagent B (Adversarial): [count] findings across 2 passes
+  Subagent A (Completeness): [count] findings across 2 passes — agent ID: [id]
+  Subagent B (Adversarial): [count] findings across 2 passes — agent ID: [id]
+  (Layer 2 MUST show agent IDs. "SUBSTITUTED" or "N/A" is NEVER valid here.)
 
 Memory Gate: [PASS / UPDATED]
   hack/ files: [updated / N/A]
@@ -367,6 +397,9 @@ Memory Gate: [PASS / UPDATED]
 
 Artifact Gate: [PASS / N/A]
   [work-type-specific status]
+
+No Data Loss Gate: [PASS / N/A]
+  [artifact persistence status]
 
 Final Verification: [PASS / FAIL]
 
@@ -392,8 +425,11 @@ Overall: [PASS / NEEDS WORK]
 
 ## Stop Hook Safety Net
 
-A global Stop hook in `dev-guard` (`type: agent`) catches premature completion claims that bypass
-this skill. Unlike prompt-type hooks, the agent has tool access — it reads the transcript, greps
-modified files for TODOs, checks git status, and verifies test execution actually happened. It
-adapts checks by work type (code, research, questions, planning) and verifies that factual claims
-were backed by research tool calls. Uses `stop_hook_active` guard to prevent infinite loops.
+A global Stop hook in `dev-guard` (`type: command`) catches premature completion claims that bypass
+this skill. It uses a two-script architecture for speed: `stop-hook.py` (stdlib-only, <200ms)
+performs deterministic triage — loop guard, transcript delta, signal detection (write tools, MCP
+writes, completion claim regex, git diff hash change) — and fast-exits for low-signal cases.
+When signals warrant deeper evaluation, it delegates to `stop-hook-llm.py` which calls
+claude-sonnet-4-6 via Vertex AI with an adaptive prompt based on work type (code, research,
+questions, planning) and trigger reasons. Fails open on any infrastructure error.
+Uses `stop_hook_active` guard to prevent infinite loops.

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -81,9 +81,9 @@
       {
         "hooks": [
           {
-            "type": "agent",
-            "prompt": "You are a quality stop gate. If stop_hook_active is true in $ARGUMENTS, return {\"ok\": true} immediately.\n\nOtherwise, read the JSONL transcript at the transcript_path from $ARGUMENTS. Each line is a JSON object. Extract: (a) the first user message (the original request), (b) all assistant messages, (c) tool call names and results. Also run git diff to check for code changes.\n\nDetermine work type: code/config (git diff has results), question/research (no git diff, conversation only), planning (plan files written), or mixed.\n\nFOR ALL WORK TYPES:\n1. COMPLETENESS: Compare the original user request against what was delivered. Was every part of the request addressed? Not partially, not deferred.\n2. IDENTIFIED-BUT-UNFIXED: Search ALL assistant messages for 'could be improved', 'consider', 'potential issue', 'preexisting', 'known issue', 'follow-up', 'out of scope'. If an issue was identified but no subsequent fix/edit followed, block.\n3. VERIFICATION: Search the transcript for WebSearch, WebFetch, or doc-reading tool calls. Were factual claims, technical assumptions, API schemas, or recommendations backed by primary source research? Block if significant claims were made with no evidence of verification.\n4. MEMORIES: If a hack/ directory exists in cwd, were PROJECT.md or TODO.md updated for non-trivial work?\n\nFOR CODE/CONFIG WORK:\n5. TESTS: Search transcript for test execution tool calls (pytest, make test, etc). Block if code was modified but no test execution found.\n6. TODOs: Grep modified files (from git diff) for TODO, FIXME, HACK. Block if found.\n7. BRANCH: Run git status — changes should be on a feature branch or staged.\n\nFOR QUESTIONS/RESEARCH:\n5. Search transcript for WebSearch/WebFetch tool calls. Were answers backed by research, or stated from memory? Block if no research evidence for specific technical claims.\n6. Were uncertainties flagged with 'I don't know' rather than confident guesses?\n\nReturn {\"ok\": true} only if ALL applicable checks pass. Return {\"ok\": false, \"reason\": \"what failed\"} if any check fails.",
-            "timeout": 120
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.py",
+            "timeout": 60
           }
         ]
       }

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -130,7 +130,12 @@ def _build_prompt(ctx: dict) -> str:
     criteria.append(
         "IDENTIFIED-BUT-UNFIXED: Did the assistant mention issues ('could be improved', "
         "'consider', 'potential issue', 'follow-up', 'out of scope') without fixing them? "
-        "If yes, that is incomplete work."
+        "If yes, that is incomplete work. "
+        "DEFERRAL-TO-USER is the same failure: phrases like 'should be verified', "
+        "'needs to be confirmed', 'you should check', 'verify against your', "
+        "'please verify', 'you may want to update' mean the assistant identified "
+        "work that needs doing and punted it. If it should be verified, verify it. "
+        "If it needs checking, check it. Do not defer work to the user."
     )
 
     if work_type in ("code_config", "mixed"):

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["anthropic[vertex]>=0.40.0"]
+# ///
+"""Stop Hook LLM Evaluator -- Sonnet quality gate via Vertex AI.
+
+Receives context JSON on stdin from stop-hook.py, calls claude-sonnet-4-6
+via Vertex AI with an adaptive prompt based on trigger reasons, and returns
+a pass/fail decision JSON on stdout.
+
+Stdin schema (from stop-hook.py):
+  {
+    "first_user_message": str | null,
+    "new_tool_calls": list[str],
+    "recent_assistant_messages": list[str],
+    "git_diff_stat": str | null,
+    "trigger_reasons": list[str],
+    "work_type": "code_config | planning | research | question | conversation | mixed"
+  }
+
+Stdout schema:
+  {
+    "decision": "pass" | "fail",
+    "reasoning": str,
+    "findings": list[str] | null   -- null on pass, specific issues on fail
+  }
+
+Exit codes:
+  0 -- pass (allow stop)
+  2 -- fail (block stop, Claude should continue)
+
+Fails open (exits 0) on any infrastructure error (import, auth, timeout, parse).
+
+Environment variables:
+  ANTHROPIC_VERTEX_PROJECT_ID      -- GCP project ID (required)
+  CLOUD_ML_REGION                  -- Vertex AI region (default: us-east5)
+  ANTHROPIC_DEFAULT_SONNET_MODEL   -- model override (default: claude-sonnet-4-6)
+"""
+
+import json
+import os
+import re
+import sys
+from typing import NoReturn
+
+_MAX_INPUT = 1 * 1024 * 1024  # 1 MB — context is small
+# Strip Claude Code context-window suffixes like [1m] — Vertex AI doesn't accept them
+_RAW_MODEL = os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", "claude-sonnet-4-6")
+_MODEL = re.sub(r"\[.*\]$", "", _RAW_MODEL)
+_MAX_TOKENS = 1024
+_TIMEOUT = 50  # seconds — stop-hook.py allows 60, leave buffer
+
+
+def _fail_open(reason: str) -> NoReturn:
+    """Emit a pass decision and exit 0 (fail-open on infrastructure errors)."""
+    output = {
+        "decision": "pass",
+        "reasoning": f"LLM evaluator failed open: {reason}",
+        "findings": None,
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+def _parse_stdin() -> dict:
+    """Read and parse context JSON from stdin."""
+    try:
+        raw = sys.stdin.buffer.read(_MAX_INPUT + 1)
+    except OSError as e:
+        _fail_open(f"stdin read error: {e}")
+    if len(raw) > _MAX_INPUT:
+        _fail_open("stdin too large")
+    try:
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            _fail_open("stdin is not a JSON object")
+        return data
+    except (json.JSONDecodeError, ValueError) as e:
+        _fail_open(f"stdin JSON parse error: {e}")
+
+
+def _build_prompt(ctx: dict) -> str:
+    """Build an adaptive evaluation prompt based on trigger reasons and work type."""
+    first_user_msg = ctx.get("first_user_message") or "(not available)"
+    tool_calls = ctx.get("new_tool_calls") or []
+    recent_msgs = ctx.get("recent_assistant_messages") or []
+    diff_stat = ctx.get("git_diff_stat")
+    trigger_reasons = ctx.get("trigger_reasons") or []
+    work_type = ctx.get("work_type", "conversation")
+
+    # Build context section
+    lines = [
+        "You are a quality gate for a Claude Code session. "
+        "Evaluate whether the work is complete and correct.",
+        "",
+        "## Session Context",
+        f"**Original user request:** {first_user_msg}",
+        f"**Work type:** {work_type}",
+        f"**Trigger reasons:** {', '.join(trigger_reasons) if trigger_reasons else 'none'}",
+        f"**Tools used this turn:** {', '.join(tool_calls) if tool_calls else 'none'}",
+    ]
+
+    if diff_stat:
+        lines += [
+            "",
+            "## Git Changes",
+            "```",
+            diff_stat,
+            "```",
+        ]
+
+    if recent_msgs:
+        lines += ["", "## Recent Assistant Messages"]
+        for i, msg in enumerate(recent_msgs[-3:], 1):
+            # Truncate very long messages for prompt efficiency
+            preview = msg[:800] + "..." if len(msg) > 800 else msg
+            lines += [f"**Message {i}:**", preview, ""]
+
+    # Add work-type-specific evaluation criteria
+    lines += ["", "## Evaluation Criteria"]
+
+    criteria: list[str] = []
+
+    # Universal criteria
+    criteria.append(
+        "COMPLETENESS: Was every part of the original user request addressed? "
+        "Not partially, not deferred without explicit user agreement."
+    )
+    criteria.append(
+        "IDENTIFIED-BUT-UNFIXED: Did the assistant mention issues ('could be improved', "
+        "'consider', 'potential issue', 'follow-up', 'out of scope') without fixing them? "
+        "If yes, that is incomplete work."
+    )
+
+    if work_type in ("code_config", "mixed"):
+        criteria.append(
+            "CODE QUALITY: Were tests run after code changes? "
+            "Are there any TODOs or FIXMEs left in modified code?"
+        )
+        criteria.append(
+            "BRANCH SAFETY: Are changes on a feature branch (not main/master) "
+            "or appropriately staged?"
+        )
+
+    if work_type in ("research", "mixed") or "research" in trigger_reasons:
+        criteria.append(
+            "VERIFICATION: Were factual claims, API schemas, or technical recommendations "
+            "backed by primary source research (WebSearch/WebFetch), or stated from memory? "
+            "Flag unverified specific claims."
+        )
+
+    if work_type in ("question",) or "completion_claim" in trigger_reasons:
+        criteria.append(
+            "UNCERTAINTY: Were uncertainties flagged with 'I don't know' rather than "
+            "confident guesses? Were limitations acknowledged?"
+        )
+
+    if "planning" in trigger_reasons:
+        criteria.append(
+            "PLANNING ARTIFACTS: Were plan files written to hack/plans/? "
+            "Was TODO.md updated with new tasks?"
+        )
+
+    if "subagent" in trigger_reasons:
+        criteria.append(
+            "SUBAGENT RESULTS: Were subagent results verified? "
+            "Did the orchestrating turn confirm the work was complete?"
+        )
+
+    for i, criterion in enumerate(criteria, 1):
+        lines.append(f"{i}. {criterion}")
+
+    lines += [
+        "",
+        "## Decision",
+        "Respond with ONLY a JSON object — no prose, no markdown fences:",
+        (
+            '{"decision": "pass" | "fail", "reasoning": "brief explanation", '
+            '"findings": ["issue1", "issue2"] | null}'
+        ),
+        "",
+        "- Set decision=pass if ALL applicable criteria are satisfied.",
+        "- Set decision=fail if ANY criterion is clearly violated. "
+        "findings must list specific, actionable issues.",
+        "- findings must be null when decision=pass.",
+        "- Be precise. Do not fail for cosmetic issues or minor style choices.",
+        "- When in doubt, pass. The goal is catching genuinely incomplete or incorrect work.",
+    ]
+
+    return "\n".join(lines)
+
+
+def _call_vertex(prompt: str) -> dict:
+    """Call claude-sonnet-4-6 via Vertex AI. Returns parsed response dict."""
+    try:
+        from anthropic import AnthropicVertex
+    except ImportError as e:
+        _fail_open(f"anthropic[vertex] not available: {e}")
+
+    project_id = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
+    region = os.environ.get("CLOUD_ML_REGION", "us-east5")
+
+    if not project_id:
+        _fail_open("ANTHROPIC_VERTEX_PROJECT_ID env var not set")
+
+    try:
+        client = AnthropicVertex(project_id=project_id, region=region)
+        message = client.messages.create(
+            model=_MODEL,
+            max_tokens=_MAX_TOKENS,
+            timeout=_TIMEOUT,
+            messages=[{"role": "user", "content": prompt}],
+        )
+    except Exception as e:
+        _fail_open(f"Vertex AI call failed: {type(e).__name__}: {e}")
+
+    # Extract text content
+    text = ""
+    for block in message.content:
+        if hasattr(block, "text"):
+            text = block.text.strip()
+            break
+
+    if not text:
+        _fail_open("empty response from Vertex AI")
+
+    # Parse JSON — model may occasionally wrap in fences, strip them
+    if text.startswith("```"):
+        lines = text.splitlines()
+        text = "\n".join(line for line in lines if not line.startswith("```")).strip()
+
+    try:
+        result = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        _fail_open(f"model returned non-JSON: {text[:200]}")
+
+    if not isinstance(result, dict):
+        _fail_open("model response is not a JSON object")
+
+    return result
+
+
+def _validate_response(result: dict) -> tuple[str, str, list[str] | None]:
+    """Validate and extract fields from the model response.
+
+    Returns (decision, reasoning, findings).
+    Falls back to pass on malformed responses.
+    """
+    decision = result.get("decision", "")
+    if decision not in ("pass", "fail"):
+        # Malformed — fail-open
+        _fail_open(f"unexpected decision value: {decision!r}")
+
+    reasoning = result.get("reasoning", "")
+    if not isinstance(reasoning, str):
+        reasoning = ""
+
+    findings = result.get("findings")
+    if decision == "pass":
+        findings = None
+    elif not isinstance(findings, list):
+        findings = [reasoning] if reasoning else ["Quality check failed."]
+    else:
+        # Filter to non-empty strings
+        findings = [str(f) for f in findings if str(f).strip()]
+        if not findings:
+            findings = [reasoning] if reasoning else ["Quality check failed."]
+
+    return decision, reasoning, findings
+
+
+def main() -> None:
+    ctx = _parse_stdin()
+    prompt = _build_prompt(ctx)
+    raw_result = _call_vertex(prompt)
+    decision, reasoning, findings = _validate_response(raw_result)
+
+    output = {
+        "decision": decision,
+        "reasoning": reasoning,
+        "findings": findings,
+    }
+    print(json.dumps(output))
+
+    if decision == "fail":
+        sys.exit(2)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -4,7 +4,7 @@
 # ///
 """Stop Hook Main -- zero-dependency fast triage for Claude Code Stop events.
 
-Reads Stop hook stdin JSON, manages per-session state in /tmp, performs
+Reads Stop hook stdin JSON, manages per-session state in ~/.claude, performs
 deterministic triage (loop guard, transcript delta, git diff, signal detection,
 question classification, work-type determination), and either exits 0 (allow
 stop) or delegates to stop-hook-llm.py for LLM evaluation.
@@ -13,7 +13,7 @@ Exit codes:
   0 -- allow stop (fast-exit or LLM pass)
   2 -- block stop, Claude should continue (LLM fail)
 
-State file: /tmp/claude-stop-hook-state.json (overridable via STOP_HOOK_STATE_PATH)
+State file: ~/.claude/stop-hook-state.json (overridable via STOP_HOOK_STATE_PATH)
 """
 
 import contextlib
@@ -30,12 +30,15 @@ from typing import NoReturn
 # ── Constants ────────────────────────────────────────────────────────────────
 
 _MAX_INPUT = 10 * 1024 * 1024  # 10 MB
-_STATE_PATH = Path(os.environ.get("STOP_HOOK_STATE_PATH", "/tmp/claude-stop-hook-state.json"))
+_STATE_PATH = Path(
+    os.environ.get("STOP_HOOK_STATE_PATH", str(Path.home() / ".claude" / "stop-hook-state.json"))
+)
 _STATE_TTL_SECONDS = 24 * 3600  # 24 hours
 _GIT_TIMEOUT = 5  # seconds
 _LLM_TIMEOUT = 60  # seconds
 _SHORT_RESPONSE_CHARS = 200
 _RECENT_MESSAGES_LIMIT = 5
+_HACK_RECENT_SECONDS = 300  # 5 minutes
 
 # MCP tool names that are read-only (do NOT trigger write-signal detection)
 _MCP_READ_ONLY = frozenset(
@@ -142,9 +145,12 @@ def _load_state() -> dict:
 
 
 def _save_state(state: dict) -> None:
-    """Save state file. Silently ignores errors."""
+    """Save state file atomically. Silently ignores errors."""
     with contextlib.suppress(OSError):
-        _STATE_PATH.write_text(json.dumps(state))
+        _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _STATE_PATH.with_suffix(".tmp")
+        tmp.write_text(json.dumps(state))
+        os.replace(tmp, _STATE_PATH)
 
 
 def _clean_stale_sessions(state: dict) -> dict:
@@ -170,13 +176,15 @@ def _update_session_state(
     state: dict,
     session_id: str,
     diff_hash: str,
-    transcript_line_count: int,
+    transcript_byte_offset: int,
+    first_user_message: str | None = None,
 ) -> dict:
     """Write updated session state and return the full state dict."""
     state[session_id] = {
         "last_diff_hash": diff_hash,
         "last_fire_timestamp": time.time(),
-        "last_transcript_line_count": transcript_line_count,
+        "last_transcript_byte_offset": transcript_byte_offset,
+        "first_user_message": first_user_message,
     }
     return state
 
@@ -205,104 +213,113 @@ def _parse_hook_input() -> dict:
 
 
 def _parse_transcript(
-    transcript_path: str, start_line: int
+    transcript_path: str,
+    start_byte_offset: int,
+    cached_first_user_message: str | None,
 ) -> tuple[list[str], list[str], str | None, str | None, int]:
-    """Parse JSONL transcript from start_line onward.
+    """Parse JSONL transcript, reading only new bytes from start_byte_offset.
+
+    Uses byte offsets instead of line counts for efficient seeking.
+    Caches first_user_message in caller's state to avoid re-scanning.
 
     Returns:
         (new_tool_calls, recent_assistant_messages, latest_user_message,
-         first_user_message, total_line_count)
+         first_user_message, end_byte_offset)
     """
     new_tool_calls: list[str] = []
     assistant_messages: list[str] = []
     latest_user_message: str | None = None
-    first_user_message: str | None = None
-    total_lines = start_line
+    first_user_message = cached_first_user_message
 
     try:
         path = Path(transcript_path)
         if not path.exists():
-            return [], [], None, None, 0
+            return [], [], None, first_user_message, 0
 
-        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-        total_lines = len(lines)
+        file_size = path.stat().st_size
 
-        # Scan all lines for first_user_message (from the beginning)
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
-                continue
-            if not isinstance(entry, dict):
-                continue
-            role = entry.get("role", "")
-            if role == "user" and first_user_message is None:
-                content = entry.get("content", "")
-                if isinstance(content, str) and content.strip():
-                    first_user_message = content.strip()
-                elif isinstance(content, list):
-                    for block in content:
-                        if isinstance(block, dict) and block.get("type") == "text":
-                            text = block.get("text", "")
-                            if text.strip():
-                                first_user_message = text.strip()
-                                break
+        # No new content since last check
+        if file_size <= start_byte_offset:
+            return [], [], None, first_user_message, start_byte_offset
 
-        # Parse new lines (from start_line onward)
-        for line in lines[start_line:]:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except (json.JSONDecodeError, ValueError):
-                continue
-            if not isinstance(entry, dict):
-                continue
+        # If first_user_message is not cached, read from beginning to find it;
+        # otherwise seek directly to new content
+        need_first_user = first_user_message is None
+        read_from = 0 if need_first_user else start_byte_offset
 
-            role = entry.get("role", "")
-            msg_type = entry.get("type", "")
+        with open(path, encoding="utf-8", errors="replace") as f:
+            if read_from > 0:
+                f.seek(read_from)
 
-            # Tool use entries (flat format: top-level type == "tool_use")
-            if msg_type == "tool_use":
-                tool_name = entry.get("name", "")
-                if tool_name:
-                    new_tool_calls.append(tool_name)
+            while True:
+                line = f.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(entry, dict):
+                    continue
 
-            # Assistant messages (inline tool_use blocks live here, not in flat tool_use entries)
-            if role == "assistant":
-                content = entry.get("content", "")
-                if isinstance(content, str) and content.strip():
-                    assistant_messages.append(content.strip())
-                elif isinstance(content, list):
-                    for block in content:
-                        if isinstance(block, dict) and block.get("type") == "text":
-                            text = block.get("text", "")
-                            if text.strip():
-                                assistant_messages.append(text.strip())
-                        elif isinstance(block, dict) and block.get("type") == "tool_use":
-                            name = block.get("name", "")
-                            if name:
-                                new_tool_calls.append(name)
+                role = entry.get("role", "")
+                msg_type = entry.get("type", "")
 
-            # User messages (track latest)
-            if role == "user":
-                content = entry.get("content", "")
-                if isinstance(content, str) and content.strip():
-                    latest_user_message = content.strip()
-                elif isinstance(content, list):
-                    for block in content:
-                        if isinstance(block, dict) and block.get("type") == "text":
-                            text = block.get("text", "")
-                            if text.strip():
-                                latest_user_message = text.strip()
-                                break
+                # First user message (only when not cached)
+                if need_first_user and role == "user" and first_user_message is None:
+                    content = entry.get("content", "")
+                    if isinstance(content, str) and content.strip():
+                        first_user_message = content.strip()
+                    elif isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, dict) and block.get("type") == "text":
+                                text = block.get("text", "")
+                                if text.strip():
+                                    first_user_message = text.strip()
+                                    break
+
+                # Tool use entries (flat format: top-level type == "tool_use")
+                if msg_type == "tool_use":
+                    tool_name = entry.get("name", "")
+                    if tool_name:
+                        new_tool_calls.append(tool_name)
+
+                # Assistant messages
+                if role == "assistant":
+                    content = entry.get("content", "")
+                    if isinstance(content, str) and content.strip():
+                        assistant_messages.append(content.strip())
+                    elif isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, dict) and block.get("type") == "text":
+                                text = block.get("text", "")
+                                if text.strip():
+                                    assistant_messages.append(text.strip())
+                            elif isinstance(block, dict) and block.get("type") == "tool_use":
+                                name = block.get("name", "")
+                                if name:
+                                    new_tool_calls.append(name)
+
+                # User messages (track latest)
+                if role == "user":
+                    content = entry.get("content", "")
+                    if isinstance(content, str) and content.strip():
+                        latest_user_message = content.strip()
+                    elif isinstance(content, list):
+                        for block in content:
+                            if isinstance(block, dict) and block.get("type") == "text":
+                                text = block.get("text", "")
+                                if text.strip():
+                                    latest_user_message = text.strip()
+                                    break
+
+            end_offset = f.tell()
 
     except (OSError, UnicodeDecodeError):
-        pass
+        return [], [], None, first_user_message, start_byte_offset
 
     # Deduplicate tool calls while preserving order
     seen: set[str] = set()
@@ -313,7 +330,7 @@ def _parse_transcript(
             deduped_tool_calls.append(tc)
 
     recent = assistant_messages[-_RECENT_MESSAGES_LIMIT:]
-    return deduped_tool_calls, recent, latest_user_message, first_user_message, total_lines
+    return deduped_tool_calls, recent, latest_user_message, first_user_message, end_offset
 
 
 # ── Git Checks ───────────────────────────────────────────────────────────────
@@ -409,7 +426,7 @@ def _check_hack_dir_modified(cwd: str) -> dict[str, bool]:
     """Check if hack/plans/ or hack/research/ files were recently modified."""
     result = {"plans": False, "research": False}
     now = time.time()
-    recent_threshold = 300  # 5 minutes
+    recent_threshold = _HACK_RECENT_SECONDS
     try:
         hack_path = Path(cwd) / "hack"
         if not hack_path.is_dir():
@@ -579,13 +596,14 @@ def main() -> None:
     # ── Fast-exit 2: First fire — initialize state ───────────────────────────
     if session_state is None:
         diff_hash = _git_diff_hash(cwd)
-        # Set line_count to 0 — next invocation will parse from line 0, catching everything
-        state = _update_session_state(state, session_id, diff_hash, 0)
+        # Set byte_offset to 0 — next invocation will parse from byte 0, catching everything
+        state = _update_session_state(state, session_id, diff_hash, 0, None)
         _save_state(state)
         _exit_pass()
 
-    last_transcript_line_count = session_state.get("last_transcript_line_count", 0)
+    last_byte_offset = session_state.get("last_transcript_byte_offset", 0)
     last_diff_hash = session_state.get("last_diff_hash", "")
+    cached_first_user_message = session_state.get("first_user_message")
 
     # ── Parse transcript delta ───────────────────────────────────────────────
     (
@@ -593,13 +611,15 @@ def main() -> None:
         recent_assistant_messages,
         latest_user_message,
         first_user_message,
-        total_lines,
-    ) = _parse_transcript(transcript_path, last_transcript_line_count)
+        end_byte_offset,
+    ) = _parse_transcript(transcript_path, last_byte_offset, cached_first_user_message)
 
-    # ── Fast-exit 3: Zero new transcript lines ───────────────────────────────
-    if total_lines <= last_transcript_line_count:
-        # No new lines — nothing changed, reuse last_diff_hash to avoid git subprocess
-        state = _update_session_state(state, session_id, last_diff_hash, total_lines)
+    # ── Fast-exit 3: No new transcript content ───────────────────────────────
+    if end_byte_offset <= last_byte_offset:
+        # No new content — nothing changed, reuse last_diff_hash to avoid git subprocess
+        state = _update_session_state(
+            state, session_id, last_diff_hash, end_byte_offset, first_user_message
+        )
         _save_state(state)
         _exit_pass()
 
@@ -618,13 +638,17 @@ def main() -> None:
 
     # ── Fast-exit 4: META question ───────────────────────────────────────────
     if question_type == "meta" and not write_signals and not diff_changed:
-        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        state = _update_session_state(
+            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+        )
         _save_state(state)
         _exit_pass()
 
     # ── Fast-exit 5: OPINION question ────────────────────────────────────────
     if question_type == "opinion" and not write_signals and not diff_changed:
-        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        state = _update_session_state(
+            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+        )
         _save_state(state)
         _exit_pass()
 
@@ -640,13 +664,17 @@ def main() -> None:
         and not has_question_in_message
         and not user_requested_action
     ):
-        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        state = _update_session_state(
+            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+        )
         _save_state(state)
         _exit_pass()
 
     # ── Exit-with-guidance: Research + short response ────────────────────────
     if research_used and response_is_short and not write_signals and not diff_changed:
-        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        state = _update_session_state(
+            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+        )
         _save_state(state)
         _exit_pass("Research done, verify external claims if any.")
 
@@ -659,7 +687,9 @@ def main() -> None:
         and not new_tool_calls
         and has_question_in_message
     ):
-        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        state = _update_session_state(
+            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+        )
         _save_state(state)
         _exit_pass("Answer based on code exploration.")
 
@@ -682,7 +712,9 @@ def main() -> None:
 
     # ── Fast-exit 7: No triggers at all ─────────────────────────────────────
     if not trigger_reasons:
-        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        state = _update_session_state(
+            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+        )
         _save_state(state)
         _exit_pass()
 
@@ -708,7 +740,9 @@ def main() -> None:
     decision, findings = _invoke_llm(llm_context, plugin_root)
 
     # ── Update state regardless of decision ─────────────────────────────────
-    state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+    state = _update_session_state(
+        state, session_id, current_diff_hash, end_byte_offset, first_user_message
+    )
     _save_state(state)
 
     # ── Exit based on LLM decision ───────────────────────────────────────────

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -318,6 +318,11 @@ def _parse_transcript(
 
             end_offset = f.tell()
 
+        # After a full scan, if first_user_message was never found (e.g. image-only
+        # first message), use "" sentinel so we don't re-scan the entire file next time
+        if need_first_user and first_user_message is None:
+            first_user_message = ""
+
     except (OSError, UnicodeDecodeError):
         return [], [], None, first_user_message, start_byte_offset
 

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -1,0 +1,722 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""Stop Hook Main -- zero-dependency fast triage for Claude Code Stop events.
+
+Reads Stop hook stdin JSON, manages per-session state in /tmp, performs
+deterministic triage (loop guard, transcript delta, git diff, signal detection,
+question classification, work-type determination), and either exits 0 (allow
+stop) or delegates to stop-hook-llm.py for LLM evaluation.
+
+Exit codes:
+  0 -- allow stop (fast-exit or LLM pass)
+  2 -- block stop, Claude should continue (LLM fail)
+
+State file: /tmp/claude-stop-hook-state.json (overridable via STOP_HOOK_STATE_PATH)
+"""
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import NoReturn
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+_MAX_INPUT = 10 * 1024 * 1024  # 10 MB
+_STATE_PATH = Path(os.environ.get("STOP_HOOK_STATE_PATH", "/tmp/claude-stop-hook-state.json"))
+_STATE_TTL_SECONDS = 24 * 3600  # 24 hours
+_GIT_TIMEOUT = 5  # seconds
+_LLM_TIMEOUT = 60  # seconds
+_SHORT_RESPONSE_CHARS = 200
+_RECENT_MESSAGES_LIMIT = 5
+
+# MCP tool names that are read-only (do NOT trigger write-signal detection)
+_MCP_READ_ONLY = frozenset(
+    {
+        "find_symbol",
+        "get_symbols_overview",
+        "search_for_pattern",
+        "list_dir",
+        "list_memories",
+        "read_memory",
+        "check_onboarding_performed",
+        "resolve-library-id",
+        "query-docs",
+        "sequentialthinking",
+        "browser_snapshot",
+        "browser_console_messages",
+        "browser_network_requests",
+        "browser_tabs",
+    }
+)
+
+# think_about_* prefix — checked separately
+_MCP_THINK_PREFIX = "think_about_"
+
+# Write tool names (native Claude tools)
+_WRITE_TOOLS = frozenset({"Edit", "Write", "NotebookEdit"})
+
+# Agent/task tool names
+_AGENT_TOOLS = frozenset({"Agent", "Task", "TeamCreate"})
+
+# Factual question patterns (no ML)
+_FACTUAL_PATTERNS = re.compile(
+    r"\b(version|api|schema|support|require|format|compatible|"
+    r"how\s+to|what\s+is|does\s+\S+\s+work|syntax|documentation|"
+    r"library|protocol)\b",
+    re.IGNORECASE,
+)
+
+# Opinion question patterns
+_OPINION_PATTERNS = re.compile(
+    r"\b(should|better|prefer|recommend|which\s+\S+\s+choose|advice)\b",
+    re.IGNORECASE,
+)
+
+# Meta question patterns (conversation management — exit 0)
+_META_PATTERNS = re.compile(
+    r"\b(ready|done|good|continue|merge|commit|next|proceed|lgtm)\b",
+    re.IGNORECASE,
+)
+
+# Action words in user messages that indicate a work request
+_ACTION_WORDS = re.compile(
+    r"\b(create|add|fix|implement|update|change|delete|remove|build|"
+    r"deploy|run|test|write)\b",
+    re.IGNORECASE,
+)
+
+# Completion claim patterns — must appear at END of message
+# ($ = end-of-string, no MULTILINE).
+# This prevents false positives on mid-paragraph claims like
+# "I've completed X.\nHowever, these remain:".
+_COMPLETION_CLAIM_PATTERNS = [
+    re.compile(
+        r"(?:^|[.!?]\s+)(?:I(?:'ve| have)\s+"
+        r"(?:completed|finished|done|implemented|added|fixed|updated|created|"
+        r"removed|deleted|written|built))[^.!?]*[.!?]?\s*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?:^|[.!?]\s+)(?:all\s+done|that\s+should\s+do\s+it|"
+        r"everything\s+is\s+ready|that(?:'s| is)\s+(?:it|done|complete|all))"
+        r"[^.!?]*[.!?]?\s*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?:^|[.!?]\s+)(?:the\s+(?:changes|implementation|fix|update|task)\s+"
+        r"(?:is|are)\s+(?:complete|done|finished|ready))[^.!?]*[.!?]?\s*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?:^|[.!?]\s+)(?:you\s+(?:can|should|may)\s+now)[^.!?]*[.!?]?\s*$",
+        re.IGNORECASE,
+    ),
+]
+
+# Research tool names
+_RESEARCH_TOOLS = frozenset({"WebSearch", "WebFetch"})
+
+
+# ── State Management ─────────────────────────────────────────────────────────
+
+
+def _load_state() -> dict:
+    """Load state file. Returns empty dict on missing or corrupted file."""
+    try:
+        if _STATE_PATH.exists():
+            text = _STATE_PATH.read_text()
+            data = json.loads(text)
+            if isinstance(data, dict):
+                return data
+    except (OSError, json.JSONDecodeError, ValueError):
+        pass
+    return {}
+
+
+def _save_state(state: dict) -> None:
+    """Save state file. Silently ignores errors."""
+    with contextlib.suppress(OSError):
+        _STATE_PATH.write_text(json.dumps(state))
+
+
+def _clean_stale_sessions(state: dict) -> dict:
+    """Remove sessions older than 24 hours."""
+    now = time.time()
+    cutoff = now - _STATE_TTL_SECONDS
+    return {
+        sid: sdata
+        for sid, sdata in state.items()
+        if isinstance(sdata, dict) and sdata.get("last_fire_timestamp", 0) >= cutoff
+    }
+
+
+def _get_session_state(state: dict, session_id: str) -> dict | None:
+    """Return state for a session or None if not present."""
+    entry = state.get(session_id)
+    if isinstance(entry, dict):
+        return entry
+    return None
+
+
+def _update_session_state(
+    state: dict,
+    session_id: str,
+    diff_hash: str,
+    transcript_line_count: int,
+) -> dict:
+    """Write updated session state and return the full state dict."""
+    state[session_id] = {
+        "last_diff_hash": diff_hash,
+        "last_fire_timestamp": time.time(),
+        "last_transcript_line_count": transcript_line_count,
+    }
+    return state
+
+
+# ── Stdin Parsing ────────────────────────────────────────────────────────────
+
+
+def _parse_hook_input() -> dict:
+    """Read and parse JSON hook payload from stdin. Exits 0 on failure."""
+    try:
+        raw = sys.stdin.buffer.read(_MAX_INPUT + 1)
+    except OSError:
+        sys.exit(0)
+    if len(raw) > _MAX_INPUT:
+        sys.exit(0)
+    try:
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            sys.exit(0)
+        return data
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+
+# ── Transcript Parsing ───────────────────────────────────────────────────────
+
+
+def _parse_transcript(
+    transcript_path: str, start_line: int
+) -> tuple[list[str], list[str], str | None, str | None, int]:
+    """Parse JSONL transcript from start_line onward.
+
+    Returns:
+        (new_tool_calls, recent_assistant_messages, latest_user_message,
+         first_user_message, total_line_count)
+    """
+    new_tool_calls: list[str] = []
+    assistant_messages: list[str] = []
+    latest_user_message: str | None = None
+    first_user_message: str | None = None
+    total_lines = start_line
+
+    try:
+        path = Path(transcript_path)
+        if not path.exists():
+            return [], [], None, None, 0
+
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        total_lines = len(lines)
+
+        # Scan all lines for first_user_message (from the beginning)
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(entry, dict):
+                continue
+            role = entry.get("role", "")
+            if role == "user" and first_user_message is None:
+                content = entry.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    first_user_message = content.strip()
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "")
+                            if text.strip():
+                                first_user_message = text.strip()
+                                break
+
+        # Parse new lines (from start_line onward)
+        for line in lines[start_line:]:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(entry, dict):
+                continue
+
+            role = entry.get("role", "")
+            msg_type = entry.get("type", "")
+
+            # Tool use entries (flat format: top-level type == "tool_use")
+            if msg_type == "tool_use":
+                tool_name = entry.get("name", "")
+                if tool_name:
+                    new_tool_calls.append(tool_name)
+
+            # Assistant messages (inline tool_use blocks live here, not in flat tool_use entries)
+            if role == "assistant":
+                content = entry.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    assistant_messages.append(content.strip())
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "")
+                            if text.strip():
+                                assistant_messages.append(text.strip())
+                        elif isinstance(block, dict) and block.get("type") == "tool_use":
+                            name = block.get("name", "")
+                            if name:
+                                new_tool_calls.append(name)
+
+            # User messages (track latest)
+            if role == "user":
+                content = entry.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    latest_user_message = content.strip()
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "")
+                            if text.strip():
+                                latest_user_message = text.strip()
+                                break
+
+    except (OSError, UnicodeDecodeError):
+        pass
+
+    # Deduplicate tool calls while preserving order
+    seen: set[str] = set()
+    deduped_tool_calls: list[str] = []
+    for tc in new_tool_calls:
+        if tc not in seen:
+            seen.add(tc)
+            deduped_tool_calls.append(tc)
+
+    recent = assistant_messages[-_RECENT_MESSAGES_LIMIT:]
+    return deduped_tool_calls, recent, latest_user_message, first_user_message, total_lines
+
+
+# ── Git Checks ───────────────────────────────────────────────────────────────
+
+
+def _git_diff_hash(cwd: str) -> str:
+    """Return a hash of 'git diff' output. Empty string on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "diff"],
+            capture_output=True,
+            timeout=_GIT_TIMEOUT,
+            cwd=cwd,
+        )
+        if result.returncode == 0:
+            return hashlib.sha256(result.stdout).hexdigest()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return ""
+
+
+def _git_diff_stat(cwd: str) -> str | None:
+    """Return 'git diff --stat' output or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--stat"],
+            capture_output=True,
+            timeout=_GIT_TIMEOUT,
+            cwd=cwd,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+# ── Signal Detection ─────────────────────────────────────────────────────────
+
+
+def _is_mcp_write_tool(tool_name: str) -> bool:
+    """Return True if this MCP tool call represents a write operation."""
+    if not tool_name.startswith("mcp__"):
+        return False
+    # Strip mcp__<server>__ prefix to get the function name
+    parts = tool_name.split("__", 2)
+    func_name = parts[2] if len(parts) >= 3 else ""
+    if func_name in _MCP_READ_ONLY:
+        return False
+    return not func_name.startswith(_MCP_THINK_PREFIX)
+
+
+def _detect_write_signals(tool_calls: list[str]) -> list[str]:
+    """Return list of signal names detected from tool calls.
+
+    Note: Bash tool calls not classified as writes — we only have tool names, not inputs.
+    Git diff change detection handles the Bash-wrote-files case.
+    """
+    signals: list[str] = []
+
+    for tc in tool_calls:
+        if tc in _WRITE_TOOLS:
+            signals.append("write_tool")
+            break
+
+    for tc in tool_calls:
+        if tc in _AGENT_TOOLS:
+            signals.append("subagent")
+            break
+
+    for tc in tool_calls:
+        if _is_mcp_write_tool(tc):
+            signals.append("mcp_write")
+            break
+
+    return signals
+
+
+def _detect_completion_claim(message: str | None) -> bool:
+    """Return True if message contains a completion claim at end/standalone."""
+    if not message:
+        return False
+    return any(pattern.search(message) for pattern in _COMPLETION_CLAIM_PATTERNS)
+
+
+def _detect_research_tools(tool_calls: list[str]) -> bool:
+    """Return True if any research tool was used."""
+    return any(tc in _RESEARCH_TOOLS for tc in tool_calls)
+
+
+def _check_hack_dir_modified(cwd: str) -> dict[str, bool]:
+    """Check if hack/plans/ or hack/research/ files were recently modified."""
+    result = {"plans": False, "research": False}
+    now = time.time()
+    recent_threshold = 300  # 5 minutes
+    try:
+        hack_path = Path(cwd) / "hack"
+        if not hack_path.is_dir():
+            return result
+        for subdir, key in [("plans", "plans"), ("research", "research")]:
+            sub_path = hack_path / subdir
+            if sub_path.is_dir():
+                for fpath in sub_path.iterdir():
+                    if fpath.is_file():
+                        mtime = fpath.stat().st_mtime
+                        if now - mtime <= recent_threshold:
+                            result[key] = True
+                            break
+    except OSError:
+        pass
+    return result
+
+
+# ── Question Classification ──────────────────────────────────────────────────
+
+
+def _classify_question(user_message: str | None) -> str | None:
+    """Classify the user's question type.
+
+    Returns: 'meta', 'opinion', 'factual', or None (not a question / unknown)
+    Priority: META > OPINION > FACTUAL
+    """
+    if not user_message:
+        return None
+    if _META_PATTERNS.search(user_message):
+        return "meta"
+    if _OPINION_PATTERNS.search(user_message):
+        return "opinion"
+    if _FACTUAL_PATTERNS.search(user_message):
+        return "factual"
+    if "?" in user_message:
+        return "factual"  # Default: unknown question type → treat as factual
+    return None
+
+
+# ── Work Type Determination ──────────────────────────────────────────────────
+
+
+def _determine_work_type(
+    tool_calls: list[str],
+    diff_changed: bool,
+    hack_modified: dict[str, bool],
+    user_message: str | None,
+    write_signals: list[str],
+) -> str:
+    """Determine the type of work performed."""
+    types: list[str] = []
+
+    if diff_changed or write_signals:
+        types.append("code_config")
+
+    if hack_modified.get("plans"):
+        types.append("planning")
+
+    if hack_modified.get("research") or _detect_research_tools(tool_calls):
+        types.append("research")
+
+    has_question = bool(user_message and "?" in user_message)
+    if has_question and not write_signals:
+        types.append("question")
+
+    if not types:
+        return "conversation"
+    if len(types) == 1:
+        return types[0]
+    return "mixed"
+
+
+# ── LLM Delegation ───────────────────────────────────────────────────────────
+
+
+def _invoke_llm(
+    context: dict,
+    plugin_root: str,
+) -> tuple[str, list[str] | None]:
+    """Invoke stop-hook-llm.py subprocess.
+
+    Returns (decision, findings) where decision is 'pass' or 'fail'.
+    Falls back to 'pass' (fail-open) on any error.
+    """
+    llm_script = Path(plugin_root) / "hooks" / "stop-hook-llm.py"
+
+    try:
+        result = subprocess.run(
+            ["uv", "run", str(llm_script)],
+            input=json.dumps(context).encode(),
+            capture_output=True,
+            timeout=_LLM_TIMEOUT,
+        )
+        if result.returncode not in (0, 2):
+            # Unexpected exit code — fail-open
+            return "pass", None
+
+        stdout = result.stdout.strip()
+        if not stdout:
+            return "pass", None
+
+        try:
+            response = json.loads(stdout)
+        except (json.JSONDecodeError, ValueError):
+            return "pass", None
+
+        if not isinstance(response, dict):
+            return "pass", None
+
+        decision = response.get("decision", "pass")
+        if decision not in ("pass", "fail"):
+            decision = "pass"
+
+        findings = response.get("findings")
+        if not isinstance(findings, list):
+            findings = None
+
+        return decision, findings
+
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        # Fail-open: any infrastructure error → allow stop
+        return "pass", None
+
+
+# ── Exit Helpers ─────────────────────────────────────────────────────────────
+
+
+def _exit_pass(message: str | None = None) -> NoReturn:
+    """Exit 0, optionally printing a guidance message to stdout."""
+    if message:
+        print(message)
+    sys.exit(0)
+
+
+def _exit_block(findings: list[str] | None) -> NoReturn:
+    """Exit 2 with findings printed to stderr."""
+    if findings:
+        print("Stop hook findings:", file=sys.stderr)
+        for finding in findings:
+            print(f"  - {finding}", file=sys.stderr)
+    else:
+        print("Stop hook: quality check failed. Please review your work.", file=sys.stderr)
+    sys.exit(2)
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    data = _parse_hook_input()
+
+    # ── Fast-exit 1: Loop guard ──────────────────────────────────────────────
+    if data.get("stop_hook_active") is True:
+        _exit_pass()
+
+    session_id = data.get("session_id", "")
+    transcript_path = data.get("transcript_path", "")
+    cwd = data.get("cwd", ".")
+    last_assistant_message = (data.get("last_assistant_message") or "").strip()
+
+    # ── Load + clean state ───────────────────────────────────────────────────
+    state = _load_state()
+    state = _clean_stale_sessions(state)
+    session_state = _get_session_state(state, session_id)
+
+    # ── Fast-exit 2: First fire — initialize state ───────────────────────────
+    if session_state is None:
+        diff_hash = _git_diff_hash(cwd)
+        # Set line_count to 0 — next invocation will parse from line 0, catching everything
+        state = _update_session_state(state, session_id, diff_hash, 0)
+        _save_state(state)
+        _exit_pass()
+
+    last_transcript_line_count = session_state.get("last_transcript_line_count", 0)
+    last_diff_hash = session_state.get("last_diff_hash", "")
+
+    # ── Parse transcript delta ───────────────────────────────────────────────
+    (
+        new_tool_calls,
+        recent_assistant_messages,
+        latest_user_message,
+        first_user_message,
+        total_lines,
+    ) = _parse_transcript(transcript_path, last_transcript_line_count)
+
+    # ── Fast-exit 3: Zero new transcript lines ───────────────────────────────
+    if total_lines <= last_transcript_line_count:
+        # No new lines — nothing changed, reuse last_diff_hash to avoid git subprocess
+        state = _update_session_state(state, session_id, last_diff_hash, total_lines)
+        _save_state(state)
+        _exit_pass()
+
+    # ── Git diff check ───────────────────────────────────────────────────────
+    current_diff_hash = _git_diff_hash(cwd)
+    diff_changed = bool(current_diff_hash and current_diff_hash != last_diff_hash)
+
+    # ── Detect signals ───────────────────────────────────────────────────────
+    write_signals = _detect_write_signals(new_tool_calls)
+    completion_claim = _detect_completion_claim(last_assistant_message)
+    research_used = _detect_research_tools(new_tool_calls)
+    hack_modified = _check_hack_dir_modified(cwd)
+
+    # ── Question classification ──────────────────────────────────────────────
+    question_type = _classify_question(latest_user_message)
+
+    # ── Fast-exit 4: META question ───────────────────────────────────────────
+    if question_type == "meta" and not write_signals and not diff_changed:
+        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        _save_state(state)
+        _exit_pass()
+
+    # ── Fast-exit 5: OPINION question ────────────────────────────────────────
+    if question_type == "opinion" and not write_signals and not diff_changed:
+        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        _save_state(state)
+        _exit_pass()
+
+    # ── Fast-exit 6: Short response with no signals ──────────────────────────
+    response_is_short = len(last_assistant_message) < _SHORT_RESPONSE_CHARS
+    has_question_in_message = bool(latest_user_message and "?" in latest_user_message)
+    user_requested_action = bool(latest_user_message and _ACTION_WORDS.search(latest_user_message))
+
+    if (
+        response_is_short
+        and not new_tool_calls
+        and not diff_changed
+        and not has_question_in_message
+        and not user_requested_action
+    ):
+        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        _save_state(state)
+        _exit_pass()
+
+    # ── Exit-with-guidance: Research + short response ────────────────────────
+    if research_used and response_is_short and not write_signals and not diff_changed:
+        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        _save_state(state)
+        _exit_pass("Research done, verify external claims if any.")
+
+    # ── Exit-with-guidance: Read-only + question ─────────────────────────────
+    if (
+        not write_signals
+        and not diff_changed
+        and not completion_claim
+        and question_type in ("factual",)
+        and not new_tool_calls
+        and has_question_in_message
+    ):
+        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        _save_state(state)
+        _exit_pass("Answer based on code exploration.")
+
+    # ── Build trigger reasons ────────────────────────────────────────────────
+    trigger_reasons: list[str] = []
+    if completion_claim:
+        trigger_reasons.append("completion_claim")
+    if diff_changed or "write_tool" in write_signals:
+        trigger_reasons.append("code_change")
+    if research_used:
+        trigger_reasons.append("research")
+    if "subagent" in write_signals:
+        trigger_reasons.append("subagent")
+    if hack_modified.get("plans"):
+        trigger_reasons.append("planning")
+    if "mcp_write" in write_signals:
+        trigger_reasons.append("mcp_write")
+    if user_requested_action and not write_signals:
+        trigger_reasons.append("action_requested_no_tools")
+
+    # ── Fast-exit 7: No triggers at all ─────────────────────────────────────
+    if not trigger_reasons:
+        state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+        _save_state(state)
+        _exit_pass()
+
+    # ── Determine work type ──────────────────────────────────────────────────
+    work_type = _determine_work_type(
+        new_tool_calls, diff_changed, hack_modified, latest_user_message, write_signals
+    )
+
+    # ── Build LLM context ────────────────────────────────────────────────────
+    diff_stat = _git_diff_stat(cwd) if diff_changed else None
+
+    llm_context = {
+        "first_user_message": first_user_message,
+        "new_tool_calls": new_tool_calls,
+        "recent_assistant_messages": recent_assistant_messages,
+        "git_diff_stat": diff_stat,
+        "trigger_reasons": trigger_reasons,
+        "work_type": work_type,
+    }
+
+    # ── Invoke LLM ───────────────────────────────────────────────────────────
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
+    decision, findings = _invoke_llm(llm_context, plugin_root)
+
+    # ── Update state regardless of decision ─────────────────────────────────
+    state = _update_session_state(state, session_id, current_diff_hash, total_lines)
+    _save_state(state)
+
+    # ── Exit based on LLM decision ───────────────────────────────────────────
+    if decision == "fail":
+        _exit_block(findings)
+    else:
+        _exit_pass()
+
+
+if __name__ == "__main__":
+    main()

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -1,0 +1,780 @@
+"""Tests for stop-hook.py
+
+Black-box subprocess tests. Each test feeds JSON on stdin and asserts exit codes
+and stdout/stderr content. State file isolation via STOP_HOOK_STATE_PATH env var.
+LLM subprocess invocation tested via a mock stop-hook-llm.py stub.
+"""
+
+import json
+import os
+import subprocess
+import textwrap
+import uuid
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent / "hooks" / "stop-hook.py"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def make_payload(
+    *,
+    session_id: str | None = None,
+    transcript_path: str = "",
+    cwd: str = ".",
+    stop_hook_active: bool = False,
+    last_assistant_message: str = "",
+) -> dict:
+    return {
+        "hook_event_name": "Stop",
+        "session_id": session_id or str(uuid.uuid4()),
+        "transcript_path": transcript_path,
+        "cwd": cwd,
+        "permission_mode": "acceptEdits",
+        "stop_hook_active": stop_hook_active,
+        "last_assistant_message": last_assistant_message,
+    }
+
+
+def run_hook(
+    payload: dict,
+    *,
+    state_path: Path | None = None,
+    plugin_root: str = "",
+    extra_env: dict | None = None,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if state_path is not None:
+        env["STOP_HOOK_STATE_PATH"] = str(state_path)
+    if plugin_root:
+        env["CLAUDE_PLUGIN_ROOT"] = plugin_root
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["uv", "run", str(SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def write_transcript(path: Path, entries: list[dict]) -> None:
+    """Write a list of dicts as JSONL to a transcript file."""
+    lines = [json.dumps(e) for e in entries]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def seed_state(
+    state_path: Path,
+    session_id: str,
+    *,
+    line_count: int = 5,
+    diff_hash: str = "",
+) -> None:
+    """Write initial state so the hook treats this as a second fire."""
+    state = {
+        session_id: {
+            "last_diff_hash": diff_hash,
+            "last_fire_timestamp": __import__("time").time(),
+            "last_transcript_line_count": line_count,
+        }
+    }
+    state_path.write_text(json.dumps(state))
+
+
+def write_mock_llm(
+    plugin_root: Path,
+    *,
+    decision: str = "pass",
+    findings: list[str] | None = None,
+) -> None:
+    """Write a mock stop-hook-llm.py stub to plugin_root/hooks/.
+
+    Serializes findings as a JSON string embedded in Python source so there are
+    no Python syntax issues with None vs JSON null.
+    """
+    hooks_dir = plugin_root / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    # Embed as a JSON string constant parsed at runtime — avoids null/None mismatch
+    result_json = json.dumps({"decision": decision, "reasoning": "mock", "findings": findings})
+    stub = textwrap.dedent(f"""\
+        #!/usr/bin/env -S uv run
+        # /// script
+        # requires-python = ">=3.10"
+        # ///
+        import json, sys
+        result = json.loads({result_json!r})
+        print(json.dumps(result))
+        sys.exit(2 if result["decision"] == "fail" else 0)
+    """)
+    llm_script = hooks_dir / "stop-hook-llm.py"
+    llm_script.write_text(stub)
+    llm_script.chmod(0o755)
+
+
+# ── Fast-exit: loop guard ─────────────────────────────────────────────────────
+
+
+class TestLoopGuard:
+    def test_stop_hook_active_exits_0(self, tmp_path):
+        payload = make_payload(stop_hook_active=True)
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+
+    def test_stop_hook_active_does_not_write_state(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        payload = make_payload(stop_hook_active=True)
+        run_hook(payload, state_path=state_path)
+        assert not state_path.exists()
+
+
+# ── Fast-exit: first fire ─────────────────────────────────────────────────────
+
+
+class TestFirstFire:
+    def test_first_fire_exits_0(self, tmp_path):
+        payload = make_payload(session_id="sess-abc")
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+
+    def test_first_fire_creates_state_file(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        session_id = "sess-first-fire"
+        payload = make_payload(session_id=session_id)
+        run_hook(payload, state_path=state_path)
+        assert state_path.exists()
+        state = json.loads(state_path.read_text())
+        assert session_id in state
+        entry = state[session_id]
+        assert "last_diff_hash" in entry
+        assert "last_fire_timestamp" in entry
+        assert "last_transcript_line_count" in entry
+
+    def test_first_fire_with_corrupt_state_exits_0(self, tmp_path):
+        state_path = tmp_path / "state.json"
+        state_path.write_text("NOT JSON {{{{")
+        payload = make_payload(session_id="sess-corrupt")
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0
+
+
+# ── Fast-exit: zero new transcript lines ──────────────────────────────────────
+
+
+class TestZeroNewLines:
+    def test_zero_new_lines_exits_0(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = "sess-zero-lines"
+        entries = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        write_transcript(transcript, entries)
+        # Seed state at current line count — no new lines since last fire
+        seed_state(tmp_path / "state.json", session_id, line_count=len(entries))
+
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0
+
+
+# ── Fast-exit: short response with no signals ─────────────────────────────────
+
+
+class TestShortResponseFastExit:
+    def test_short_response_no_tools_no_diff_exits_0(self, tmp_path):
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = "sess-short"
+        entries = [
+            {"role": "user", "content": "What time is it?"},
+            {"role": "assistant", "content": "It is 3pm."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id, line_count=1)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="It is 3pm.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0
+
+    def test_long_response_does_not_fast_exit_short_path(self, tmp_path):
+        """A long assistant message bypasses the short-response fast exit."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = "sess-long"
+        long_msg = "x" * 300  # > 200 chars
+        entries = [
+            {"role": "user", "content": "Do something."},
+            {"role": "assistant", "content": long_msg},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id, line_count=1)
+
+        # No plugin root → LLM fails open → still exits 0, but didn't short-circuit
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message=long_msg,
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        # Fails open because no LLM configured
+        assert result.returncode == 0
+
+
+# ── Question classification ───────────────────────────────────────────────────
+
+
+class TestQuestionClassification:
+    def _run_with_user_message(
+        self,
+        tmp_path,
+        user_msg: str,
+        assistant_msg: str = "Sure.",
+    ) -> subprocess.CompletedProcess:
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": user_msg},
+            {"role": "assistant", "content": assistant_msg},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message=assistant_msg,
+        )
+        return run_hook(payload, state_path=tmp_path / "state.json")
+
+    def test_meta_question_exits_0(self, tmp_path):
+        result = self._run_with_user_message(tmp_path, "Looks good, proceed.")
+        assert result.returncode == 0
+
+    def test_meta_lgtm_exits_0(self, tmp_path):
+        result = self._run_with_user_message(tmp_path, "LGTM, go ahead and merge.")
+        assert result.returncode == 0
+
+    def test_opinion_question_exits_0(self, tmp_path):
+        result = self._run_with_user_message(tmp_path, "Should I use PostgreSQL or SQLite?")
+        assert result.returncode == 0
+
+    def test_opinion_recommend_exits_0(self, tmp_path):
+        result = self._run_with_user_message(tmp_path, "What would you recommend for caching?")
+        assert result.returncode == 0
+
+    def test_factual_question_does_not_exit_via_meta_opinion(self, tmp_path):
+        """Factual question with no tools → exit-with-guidance path, still exits 0."""
+        result = self._run_with_user_message(
+            tmp_path,
+            "What is the Python version requirement?",
+            "Python 3.10+.",
+        )
+        # Read-only + factual question → exit-with-guidance (exit 0)
+        assert result.returncode == 0
+
+
+# ── Exit-with-guidance ────────────────────────────────────────────────────────
+
+
+class TestExitWithGuidance:
+    def test_research_short_response_guidance_message(self, tmp_path):
+        """WebSearch used + short response → prints guidance to stdout."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Research Python packaging."},
+            {"type": "tool_use", "name": "WebSearch", "id": "t1"},
+            {"role": "assistant", "content": "Here is a summary."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id, line_count=1)
+
+        # Pass cwd=tmp_path (non-git dir) so git diff returns empty string,
+        # matching the seeded empty diff_hash — otherwise diff_changed=True blocks this path.
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            cwd=str(tmp_path),
+            last_assistant_message="Here is a summary.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0
+        assert (
+            "verify external claims" in result.stdout.lower()
+            or "research done" in result.stdout.lower()
+        )
+
+    def test_read_only_factual_question_guidance_message(self, tmp_path):
+        """Read tool + factual question → prints guidance to stdout."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "What does the Read tool do?"},
+            {"role": "assistant", "content": "It reads files."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id, line_count=1)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="It reads files.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0
+        # Either guidance message or plain exit 0 — both acceptable for factual + no tools
+        assert result.returncode == 0
+
+
+# ── Signal detection: write tools ─────────────────────────────────────────────
+
+
+class TestWriteToolSignals:
+    def _make_transcript_with_tool(self, tmp_path: Path, tool_name: str) -> tuple[str, Path, str]:
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            {"type": "tool_use", "name": tool_name, "id": "t1"},
+            {"role": "assistant", "content": "I've completed the fix. The changes are ready."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        return session_id, transcript, "I've completed the fix. The changes are ready."
+
+    def test_edit_tool_triggers_llm_path(self, tmp_path):
+        """Edit tool in transcript → LLM path. Mock LLM returns pass → exit 0."""
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        session_id, transcript, msg = self._make_transcript_with_tool(tmp_path, "Edit")
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message=msg,
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        assert result.returncode == 0
+
+    def test_edit_tool_llm_fail_exits_2(self, tmp_path):
+        """Edit tool + completion claim + mock LLM fail → exit 2."""
+        write_mock_llm(tmp_path / "plugin", decision="fail", findings=["Tests were not run."])
+        session_id, transcript, msg = self._make_transcript_with_tool(tmp_path, "Edit")
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message=msg,
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        assert result.returncode == 2
+        assert "Tests were not run" in result.stderr
+
+    def test_write_tool_triggers_llm_path(self, tmp_path):
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        session_id, transcript, msg = self._make_transcript_with_tool(tmp_path, "Write")
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message=msg,
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        assert result.returncode == 0
+
+    def test_notebook_edit_triggers_llm_path(self, tmp_path):
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        session_id, transcript, msg = self._make_transcript_with_tool(tmp_path, "NotebookEdit")
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message=msg,
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        assert result.returncode == 0
+
+
+# ── Signal detection: MCP write tools ────────────────────────────────────────
+
+
+class TestMCPWriteToolSignals:
+    def _make_transcript_with_mcp(
+        self,
+        tmp_path: Path,
+        tool_name: str,
+        assistant_msg: str,
+    ) -> tuple[str, Path]:
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Do the work."},
+            {"type": "tool_use", "name": tool_name, "id": "t1"},
+            {"role": "assistant", "content": assistant_msg},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        return session_id, transcript
+
+    def test_mcp_read_only_tool_does_not_trigger(self, tmp_path):
+        """find_symbol is read-only MCP — should not trigger write signal."""
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        session_id, transcript = self._make_transcript_with_mcp(
+            tmp_path, "mcp__serena__find_symbol", "Here are the results."
+        )
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="Here are the results.",
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        # Read-only MCP + short read-only response → fast exit 0 (no LLM needed)
+        assert result.returncode == 0
+
+    def test_mcp_write_tool_triggers_llm(self, tmp_path):
+        """An MCP tool that is NOT in the read-only list → write signal → LLM."""
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        # addCommentToJiraIssue is clearly a write
+        session_id, transcript = self._make_transcript_with_mcp(
+            tmp_path,
+            "mcp__jira__addCommentToJiraIssue",
+            "I've completed and added the comment.",
+        )
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="I've completed and added the comment.",
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        assert result.returncode == 0  # mock LLM passes
+
+    def test_mcp_think_prefix_does_not_trigger(self, tmp_path):
+        """think_about_* tools are read-only."""
+        session_id, transcript = self._make_transcript_with_mcp(
+            tmp_path, "mcp__serena__think_about_problem", "Thinking done."
+        )
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="Thinking done.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0
+
+
+# ── Signal detection: completion claims ───────────────────────────────────────
+
+
+class TestCompletionClaims:
+    def _run_with_message(self, tmp_path: Path, assistant_msg: str) -> subprocess.CompletedProcess:
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Implement the feature."},
+            {"role": "assistant", "content": assistant_msg},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message=assistant_msg,
+        )
+        return run_hook(payload, state_path=tmp_path / "state.json")
+
+    def test_completion_claim_at_end_triggers_llm_fail_open(self, tmp_path):
+        """Completion claim at end of message → triggers LLM path → fails open."""
+        result = self._run_with_message(
+            tmp_path, "The implementation is ready. I've completed all the work."
+        )
+        # No plugin_root → LLM fails open → exit 0
+        assert result.returncode == 0
+
+    def test_completion_claim_mid_sentence_does_not_trigger(self, tmp_path):
+        """Mid-sentence claim should NOT trigger (no MULTILINE, $ end-of-string)."""
+        # The claim is mid-message, followed by more content
+        msg = (
+            "I've completed the first part.\n"
+            "However, there are still issues to fix:\n"
+            "- Item 1\n"
+            "- Item 2"
+        )
+        result = self._run_with_message(tmp_path, msg)
+        # No completion claim at end-of-string, no write tools → fast exit
+        assert result.returncode == 0
+
+    def test_all_done_at_end_triggers(self, tmp_path):
+        result = self._run_with_message(tmp_path, "That should do it. All done.")
+        # fails open → exit 0
+        assert result.returncode == 0
+
+    def test_plain_response_no_claim_fast_exits(self, tmp_path):
+        """A neutral short response with no claim → fast exit."""
+        result = self._run_with_message(tmp_path, "Here is the information you requested.")
+        assert result.returncode == 0
+
+
+# ── LLM subprocess: mock stub behavior ───────────────────────────────────────
+
+
+class TestLLMSubprocess:
+    def _setup_with_edit_tool(self, tmp_path: Path, assistant_msg: str) -> tuple[dict, Path]:
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            {"type": "tool_use", "name": "Edit", "id": "t1"},
+            {"role": "assistant", "content": assistant_msg},
+        ]
+        write_transcript(transcript, entries)
+        state_path = tmp_path / "state.json"
+        seed_state(state_path, session_id, line_count=1)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message=assistant_msg,
+        )
+        return payload, state_path
+
+    def test_llm_pass_exits_0(self, tmp_path):
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
+        result = run_hook(payload, state_path=state_path, plugin_root=str(tmp_path / "plugin"))
+        assert result.returncode == 0
+
+    def test_llm_fail_exits_2_with_findings(self, tmp_path):
+        write_mock_llm(
+            tmp_path / "plugin",
+            decision="fail",
+            findings=["No tests run.", "TODOs remain."],
+        )
+        payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
+        result = run_hook(payload, state_path=state_path, plugin_root=str(tmp_path / "plugin"))
+        assert result.returncode == 2
+        assert "No tests run" in result.stderr
+        assert "TODOs remain" in result.stderr
+
+    def test_llm_fail_exits_2_no_findings_still_has_message(self, tmp_path):
+        write_mock_llm(tmp_path / "plugin", decision="fail", findings=None)
+        payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
+        result = run_hook(payload, state_path=state_path, plugin_root=str(tmp_path / "plugin"))
+        assert result.returncode == 2
+        assert result.stderr.strip()  # something printed
+
+    def test_missing_llm_script_fails_open(self, tmp_path):
+        """No stop-hook-llm.py → subprocess fails → fail-open → exit 0."""
+        (tmp_path / "plugin" / "hooks").mkdir(parents=True, exist_ok=True)
+        # No llm script written
+        payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
+        result = run_hook(payload, state_path=state_path, plugin_root=str(tmp_path / "plugin"))
+        assert result.returncode == 0
+
+    def test_llm_unreachable_fails_open(self, tmp_path):
+        """LLM script at unreachable path → FileNotFoundError → fail-open → exit 0."""
+        payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
+        result = run_hook(payload, state_path=state_path, plugin_root="/nonexistent/path")
+        assert result.returncode == 0
+
+
+# ── State file management ────────────────────────────────────────────────────
+
+
+class TestStateManagement:
+    def test_state_updated_after_pass(self, tmp_path):
+        """State file reflects new line count after a passing run."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = "sess-state-update"
+        entries = [
+            {"role": "user", "content": "What is Python?"},
+            {"role": "assistant", "content": "A programming language."},
+            {"role": "user", "content": "Thank you."},
+            {"role": "assistant", "content": "You're welcome."},
+        ]
+        write_transcript(transcript, entries)
+        state_path = tmp_path / "state.json"
+        seed_state(state_path, session_id, line_count=2)  # saw first 2 lines
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="You're welcome.",
+        )
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0
+
+        state = json.loads(state_path.read_text())
+        assert session_id in state
+        assert state[session_id]["last_transcript_line_count"] == len(entries)
+
+    def test_stale_sessions_pruned(self, tmp_path):
+        """Sessions older than 24h are removed from state on next run."""
+        state_path = tmp_path / "state.json"
+        old_session = "sess-old"
+        fresh_session = "sess-fresh"
+        old_time = __import__("time").time() - (25 * 3600)  # 25h ago
+
+        state = {
+            old_session: {
+                "last_diff_hash": "",
+                "last_fire_timestamp": old_time,
+                "last_transcript_line_count": 0,
+            },
+        }
+        state_path.write_text(json.dumps(state))
+
+        # Fire with a new session — triggers cleanup
+        payload = make_payload(session_id=fresh_session)
+        run_hook(payload, state_path=state_path)
+
+        new_state = json.loads(state_path.read_text())
+        assert old_session not in new_state
+        assert fresh_session in new_state
+
+    def test_multiple_sessions_isolated(self, tmp_path):
+        """Two sessions maintain independent state."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+        write_transcript(transcript, entries)
+        state_path = tmp_path / "state.json"
+
+        sid_a = "sess-a"
+        sid_b = "sess-b"
+
+        # First fire for A
+        run_hook(
+            make_payload(session_id=sid_a, transcript_path=str(transcript)),
+            state_path=state_path,
+        )
+        # First fire for B
+        run_hook(
+            make_payload(session_id=sid_b, transcript_path=str(transcript)),
+            state_path=state_path,
+        )
+
+        state = json.loads(state_path.read_text())
+        assert sid_a in state
+        assert sid_b in state
+
+
+# ── Non-git directory ─────────────────────────────────────────────────────────
+
+
+class TestNonGitDirectory:
+    def test_non_git_dir_exits_0(self, tmp_path):
+        """Hook in a non-git directory should not crash — fails gracefully."""
+        non_git = tmp_path / "not-a-repo"
+        non_git.mkdir()
+
+        transcript = non_git / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Hello."},
+            {"role": "assistant", "content": "Hi there."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id, line_count=1)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            cwd=str(non_git),
+            last_assistant_message="Hi there.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0
+
+    def test_missing_transcript_exits_0(self, tmp_path):
+        """Missing transcript file → graceful fast exit."""
+        session_id = str(uuid.uuid4())
+        seed_state(tmp_path / "state.json", session_id, line_count=0)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path="/nonexistent/path/transcript.jsonl",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0
+
+
+# ── Agent/Task tool signals ───────────────────────────────────────────────────
+
+
+class TestAgentToolSignals:
+    def test_task_tool_triggers_llm_path(self, tmp_path):
+        """Task tool → subagent signal → LLM path."""
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Do the work."},
+            {"type": "tool_use", "name": "Task", "id": "t1"},
+            {"role": "assistant", "content": "I've completed the task. Everything is ready."},
+        ]
+        write_transcript(transcript, entries)
+        state_path = tmp_path / "state.json"
+        seed_state(state_path, session_id, line_count=1)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="I've completed the task. Everything is ready.",
+        )
+        result = run_hook(payload, state_path=state_path, plugin_root=str(tmp_path / "plugin"))
+        assert result.returncode == 0  # mock LLM passes
+
+
+# ── Invalid/malformed stdin ───────────────────────────────────────────────────
+
+
+class TestMalformedInput:
+    def test_empty_stdin_exits_0(self, tmp_path):
+        result = subprocess.run(
+            ["uv", "run", str(SCRIPT)],
+            input="",
+            capture_output=True,
+            text=True,
+            env={**os.environ, "STOP_HOOK_STATE_PATH": str(tmp_path / "state.json")},
+        )
+        assert result.returncode == 0
+
+    def test_non_json_stdin_exits_0(self, tmp_path):
+        result = subprocess.run(
+            ["uv", "run", str(SCRIPT)],
+            input="not json at all",
+            capture_output=True,
+            text=True,
+            env={**os.environ, "STOP_HOOK_STATE_PATH": str(tmp_path / "state.json")},
+        )
+        assert result.returncode == 0
+
+    def test_json_array_stdin_exits_0(self, tmp_path):
+        result = subprocess.run(
+            ["uv", "run", str(SCRIPT)],
+            input="[1, 2, 3]",
+            capture_output=True,
+            text=True,
+            env={**os.environ, "STOP_HOOK_STATE_PATH": str(tmp_path / "state.json")},
+        )
+        assert result.returncode == 0

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -168,13 +168,13 @@ class TestFirstFire:
         assert result.returncode == 0
 
 
-# ── Fast-exit: zero new transcript lines ──────────────────────────────────────
+# ── Fast-exit: no new transcript content ──────────────────────────────────────
 
 
-class TestZeroNewLines:
-    def test_zero_new_lines_exits_0(self, tmp_path):
+class TestZeroNewContent:
+    def test_no_new_content_exits_0(self, tmp_path):
         transcript = tmp_path / "transcript.jsonl"
-        session_id = "sess-zero-lines"
+        session_id = "sess-no-new-content"
         entries = [
             {"role": "user", "content": "hello"},
             {"role": "assistant", "content": "hi"},
@@ -616,7 +616,7 @@ class TestLLMSubprocess:
 
 class TestStateManagement:
     def test_state_updated_after_pass(self, tmp_path):
-        """State file reflects new line count after a passing run."""
+        """State file reflects new byte offset after a passing run."""
         transcript = tmp_path / "transcript.jsonl"
         session_id = "sess-state-update"
         entries = [
@@ -937,3 +937,106 @@ class TestHackDirModified:
         )
         result = run_hook(payload, state_path=tmp_path / "state.json")
         assert result.returncode == 0
+
+
+# ── State migration: old format ───────────────────────────────────────────────
+
+
+class TestStateMigration:
+    def test_old_line_count_state_degrades_gracefully(self, tmp_path):
+        """Old state with last_transcript_line_count is handled via .get() defaults."""
+        state_path = tmp_path / "state.json"
+        session_id = "sess-migration"
+        # Write old-format state (pre-byte-offset migration)
+        old_state = {
+            session_id: {
+                "last_diff_hash": "",
+                "last_fire_timestamp": time.time(),
+                "last_transcript_line_count": 5,  # old key name
+            }
+        }
+        state_path.write_text(json.dumps(old_state))
+
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {"role": "user", "content": "Hello."},
+            {"role": "assistant", "content": "Hi."},
+        ]
+        write_transcript(transcript, entries)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="Hi.",
+        )
+        result = run_hook(payload, state_path=state_path)
+        # Old key is ignored, byte_offset defaults to 0 → full re-scan → exit 0
+        assert result.returncode == 0
+
+        # Verify state was rewritten with new schema
+        new_state = json.loads(state_path.read_text())
+        assert "last_transcript_byte_offset" in new_state[session_id]
+        assert "last_transcript_line_count" not in new_state[session_id]
+
+
+# ── Multi-fire integration ────────────────────────────────────────────────────
+
+
+class TestMultiFireIntegration:
+    def test_three_sequential_fires_with_transcript_growth(self, tmp_path):
+        """Fire hook 3 times as transcript grows — verifies byte offset tracking."""
+        transcript = tmp_path / "transcript.jsonl"
+        state_path = tmp_path / "state.json"
+        session_id = "sess-multi-fire"
+
+        # Fire 1: first fire, initializes state
+        entries_v1 = [
+            {"role": "user", "content": "Fix the bug."},
+        ]
+        write_transcript(transcript, entries_v1)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="",
+        )
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0
+        state = json.loads(state_path.read_text())
+        assert state[session_id]["last_transcript_byte_offset"] == 0  # first fire sets 0
+
+        # Fire 2: transcript has grown, hook parses new content
+        entries_v2 = entries_v1 + [
+            {"role": "assistant", "content": "Looking into it."},
+        ]
+        write_transcript(transcript, entries_v2)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="Looking into it.",
+        )
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0
+        state = json.loads(state_path.read_text())
+        fire2_offset = state[session_id]["last_transcript_byte_offset"]
+        assert fire2_offset > 0
+        # first_user_message should now be cached
+        assert state[session_id]["first_user_message"] == "Fix the bug."
+
+        # Fire 3: transcript grows again, only new bytes parsed
+        entries_v3 = entries_v2 + [
+            {"role": "user", "content": "Is it done yet?"},
+            {"role": "assistant", "content": "Almost."},
+        ]
+        write_transcript(transcript, entries_v3)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="Almost.",
+        )
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0
+        state = json.loads(state_path.read_text())
+        fire3_offset = state[session_id]["last_transcript_byte_offset"]
+        assert fire3_offset > fire2_offset
+        # first_user_message stays cached
+        assert state[session_id]["first_user_message"] == "Fix the bug."

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -9,6 +9,7 @@ import json
 import os
 import subprocess
 import textwrap
+import time
 import uuid
 from pathlib import Path
 
@@ -66,19 +67,26 @@ def write_transcript(path: Path, entries: list[dict]) -> None:
     path.write_text("\n".join(lines) + "\n")
 
 
+def transcript_offset(entries: list[dict], seen: int) -> int:
+    """Byte offset after `seen` JSONL entries (matches write_transcript format)."""
+    return sum(len(json.dumps(e)) + 1 for e in entries[:seen])
+
+
 def seed_state(
     state_path: Path,
     session_id: str,
     *,
-    line_count: int = 5,
+    byte_offset: int = 0,
     diff_hash: str = "",
+    first_user_message: str | None = None,
 ) -> None:
     """Write initial state so the hook treats this as a second fire."""
     state = {
         session_id: {
             "last_diff_hash": diff_hash,
-            "last_fire_timestamp": __import__("time").time(),
-            "last_transcript_line_count": line_count,
+            "last_fire_timestamp": time.time(),
+            "last_transcript_byte_offset": byte_offset,
+            "first_user_message": first_user_message,
         }
     }
     state_path.write_text(json.dumps(state))
@@ -150,7 +158,7 @@ class TestFirstFire:
         entry = state[session_id]
         assert "last_diff_hash" in entry
         assert "last_fire_timestamp" in entry
-        assert "last_transcript_line_count" in entry
+        assert "last_transcript_byte_offset" in entry
 
     def test_first_fire_with_corrupt_state_exits_0(self, tmp_path):
         state_path = tmp_path / "state.json"
@@ -172,8 +180,12 @@ class TestZeroNewLines:
             {"role": "assistant", "content": "hi"},
         ]
         write_transcript(transcript, entries)
-        # Seed state at current line count — no new lines since last fire
-        seed_state(tmp_path / "state.json", session_id, line_count=len(entries))
+        # Seed state at end of file — no new content since last fire
+        seed_state(
+            tmp_path / "state.json",
+            session_id,
+            byte_offset=transcript_offset(entries, len(entries)),
+        )
 
         payload = make_payload(session_id=session_id, transcript_path=str(transcript))
         result = run_hook(payload, state_path=tmp_path / "state.json")
@@ -192,7 +204,7 @@ class TestShortResponseFastExit:
             {"role": "assistant", "content": "It is 3pm."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
 
         payload = make_payload(
             session_id=session_id,
@@ -212,7 +224,7 @@ class TestShortResponseFastExit:
             {"role": "assistant", "content": long_msg},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
 
         # No plugin root → LLM fails open → still exits 0, but didn't short-circuit
         payload = make_payload(
@@ -242,7 +254,7 @@ class TestQuestionClassification:
             {"role": "assistant", "content": assistant_msg},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
         payload = make_payload(
             session_id=session_id,
             transcript_path=str(transcript),
@@ -291,7 +303,7 @@ class TestExitWithGuidance:
             {"role": "assistant", "content": "Here is a summary."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
 
         # Pass cwd=tmp_path (non-git dir) so git diff returns empty string,
         # matching the seeded empty diff_hash — otherwise diff_changed=True blocks this path.
@@ -317,7 +329,7 @@ class TestExitWithGuidance:
             {"role": "assistant", "content": "It reads files."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
 
         payload = make_payload(
             session_id=session_id,
@@ -343,7 +355,7 @@ class TestWriteToolSignals:
             {"role": "assistant", "content": "I've completed the fix. The changes are ready."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
         return session_id, transcript, "I've completed the fix. The changes are ready."
 
     def test_edit_tool_triggers_llm_path(self, tmp_path):
@@ -428,7 +440,7 @@ class TestMCPWriteToolSignals:
             {"role": "assistant", "content": assistant_msg},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
         return session_id, transcript
 
     def test_mcp_read_only_tool_does_not_trigger(self, tmp_path):
@@ -497,7 +509,7 @@ class TestCompletionClaims:
             {"role": "assistant", "content": assistant_msg},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
         payload = make_payload(
             session_id=session_id,
             transcript_path=str(transcript),
@@ -551,7 +563,7 @@ class TestLLMSubprocess:
         ]
         write_transcript(transcript, entries)
         state_path = tmp_path / "state.json"
-        seed_state(state_path, session_id, line_count=1)
+        seed_state(state_path, session_id, byte_offset=transcript_offset(entries, 1))
         payload = make_payload(
             session_id=session_id,
             transcript_path=str(transcript),
@@ -615,7 +627,7 @@ class TestStateManagement:
         ]
         write_transcript(transcript, entries)
         state_path = tmp_path / "state.json"
-        seed_state(state_path, session_id, line_count=2)  # saw first 2 lines
+        seed_state(state_path, session_id, byte_offset=transcript_offset(entries, 2))
 
         payload = make_payload(
             session_id=session_id,
@@ -627,20 +639,22 @@ class TestStateManagement:
 
         state = json.loads(state_path.read_text())
         assert session_id in state
-        assert state[session_id]["last_transcript_line_count"] == len(entries)
+        assert state[session_id]["last_transcript_byte_offset"] == transcript_offset(
+            entries, len(entries)
+        )
 
     def test_stale_sessions_pruned(self, tmp_path):
         """Sessions older than 24h are removed from state on next run."""
         state_path = tmp_path / "state.json"
         old_session = "sess-old"
         fresh_session = "sess-fresh"
-        old_time = __import__("time").time() - (25 * 3600)  # 25h ago
+        old_time = time.time() - (25 * 3600)  # 25h ago
 
         state = {
             old_session: {
                 "last_diff_hash": "",
                 "last_fire_timestamp": old_time,
-                "last_transcript_line_count": 0,
+                "last_transcript_byte_offset": 0,
             },
         }
         state_path.write_text(json.dumps(state))
@@ -695,7 +709,7 @@ class TestNonGitDirectory:
             {"role": "assistant", "content": "Hi there."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, line_count=1)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
 
         payload = make_payload(
             session_id=session_id,
@@ -709,7 +723,7 @@ class TestNonGitDirectory:
     def test_missing_transcript_exits_0(self, tmp_path):
         """Missing transcript file → graceful fast exit."""
         session_id = str(uuid.uuid4())
-        seed_state(tmp_path / "state.json", session_id, line_count=0)
+        seed_state(tmp_path / "state.json", session_id, byte_offset=0)
         payload = make_payload(
             session_id=session_id,
             transcript_path="/nonexistent/path/transcript.jsonl",
@@ -734,7 +748,7 @@ class TestAgentToolSignals:
         ]
         write_transcript(transcript, entries)
         state_path = tmp_path / "state.json"
-        seed_state(state_path, session_id, line_count=1)
+        seed_state(state_path, session_id, byte_offset=transcript_offset(entries, 1))
 
         payload = make_payload(
             session_id=session_id,
@@ -777,4 +791,149 @@ class TestMalformedInput:
             text=True,
             env={**os.environ, "STOP_HOOK_STATE_PATH": str(tmp_path / "state.json")},
         )
+        assert result.returncode == 0
+
+
+# ── hack/ directory modification detection ────────────────────────────────────
+
+
+class TestHackDirModified:
+    def test_hack_plans_recently_modified_triggers_llm(self, tmp_path):
+        """Recently modified file in hack/plans/ → planning trigger → LLM invoked."""
+        hack_plans = tmp_path / "hack" / "plans"
+        hack_plans.mkdir(parents=True)
+        (hack_plans / "2026-03-16-test.md").write_text("# Plan")
+
+        write_mock_llm(tmp_path / "plugin", decision="fail", findings=["Planning incomplete."])
+
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Create a plan."},
+            {
+                "role": "assistant",
+                "content": "I've written the plan to hack/plans/. The planning is complete.",
+            },
+        ]
+        write_transcript(transcript, entries)
+        seed_state(
+            tmp_path / "state.json",
+            session_id,
+            byte_offset=transcript_offset(entries, 1),
+        )
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            cwd=str(tmp_path),
+            last_assistant_message=(
+                "I've written the plan to hack/plans/. The planning is complete."
+            ),
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        # LLM was invoked (not fast-exited) and returned fail
+        assert result.returncode == 2
+        assert "Planning incomplete" in result.stderr
+
+    def test_hack_research_with_websearch_triggers_llm(self, tmp_path):
+        """WebSearch + hack/research/ modified → research trigger → LLM invoked."""
+        hack_research = tmp_path / "hack" / "research"
+        hack_research.mkdir(parents=True)
+        (hack_research / "2026-03-16-test.md").write_text("# Research")
+
+        write_mock_llm(tmp_path / "plugin", decision="fail", findings=["Research incomplete."])
+
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        long_msg = (
+            "I've completed the research and written findings to hack/research/. "
+            "The analysis covers technical feasibility, cost implications, "
+            "and implementation complexity across multiple dimensions. "
+            "All key claims are backed by primary source research. The research is complete."
+        )
+        entries = [
+            {"role": "user", "content": "Research this topic."},
+            {"type": "tool_use", "name": "WebSearch", "id": "t1"},
+            {"role": "assistant", "content": long_msg},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(
+            tmp_path / "state.json",
+            session_id,
+            byte_offset=transcript_offset(entries, 1),
+        )
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            cwd=str(tmp_path),
+            last_assistant_message=long_msg,
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        assert result.returncode == 2
+        assert "Research incomplete" in result.stderr
+
+    def test_hack_dir_old_file_does_not_trigger(self, tmp_path):
+        """File in hack/plans/ older than 5 minutes → no planning trigger."""
+        hack_plans = tmp_path / "hack" / "plans"
+        hack_plans.mkdir(parents=True)
+        old_file = hack_plans / "old-plan.md"
+        old_file.write_text("# Old plan")
+        # Set mtime to 10 minutes ago
+        old_mtime = time.time() - 600
+        os.utime(old_file, (old_mtime, old_mtime))
+
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "What time is it?"},
+            {"role": "assistant", "content": "It's 3pm."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(
+            tmp_path / "state.json",
+            session_id,
+            byte_offset=transcript_offset(entries, 1),
+        )
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            cwd=str(tmp_path),
+            last_assistant_message="It's 3pm.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        # Short response, no signals → fast exit 0
+        assert result.returncode == 0
+
+    def test_no_hack_dir_does_not_trigger(self, tmp_path):
+        """No hack/ directory → no planning/research trigger."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "What time is it?"},
+            {"role": "assistant", "content": "It's 3pm."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(
+            tmp_path / "state.json",
+            session_id,
+            byte_offset=transcript_offset(entries, 1),
+        )
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            cwd=str(tmp_path),
+            last_assistant_message="It's 3pm.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
         assert result.returncode == 0


### PR DESCRIPTION
## Summary

- Replace slow agent-type Stop hook with fast command-type two-script architecture
- stop-hook.py: zero-dep stdlib-only, <200ms deterministic triage with 7 fast-exit paths
- stop-hook-llm.py: Vertex AI Sonnet evaluation, invoked only when substantial work detected
- Add No Data Loss Gate to quality-gate skill
- Add Output Location section to deep-research skill for hack/research/ persistence
- 40 new subprocess black-box tests
- Version bumps: dev-guard 1.34.0->1.35.0, code-quality 2.3.0->2.4.0