### PR TITLE
feat(dev-guard): adds guard-stats command and session tracking

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.37.0",
+      "version": "1.38.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/commands/guard-stats/COMMAND.md
+++ b/dev-guard/commands/guard-stats/COMMAND.md
@@ -1,0 +1,24 @@
+---
+name: guard-stats
+description: Show actionable metrics from dev-guard audit database
+arguments:
+  - name: days
+    description: "Number of days to look back (default: 7)"
+    required: false
+---
+
+# Guard Stats
+
+Show actionable metrics from the dev-guard audit database.
+
+## Your Task
+
+Run the guard-stats script and present the output to the user:
+
+```bash
+uv run ${CLAUDE_PLUGIN_ROOT}/hooks/guard-stats.py $DAYS
+```
+
+Where `$DAYS` is the days argument (default 7 if not provided).
+
+Present the output as-is — it's already formatted. If any section shows warnings or actionable suggestions, highlight them.

--- a/dev-guard/commands/guard-stats/COMMAND.md
+++ b/dev-guard/commands/guard-stats/COMMAND.md
@@ -1,6 +1,6 @@
 ---
 name: guard-stats
-description: Show actionable metrics from dev-guard audit database
+description: Show actionable dev-guard metrics with improvement suggestions
 arguments:
   - name: days
     description: "Number of days to look back (default: 7)"
@@ -9,11 +9,11 @@ arguments:
 
 # Guard Stats
 
-Show actionable metrics from the dev-guard audit database.
+Analyze dev-guard metrics and suggest concrete improvements.
 
-## Your Task
+## Step 1: Collect Data
 
-Run the guard-stats script and present the output to the user:
+Run the guard-stats script:
 
 ```bash
 uv run ${CLAUDE_PLUGIN_ROOT}/hooks/guard-stats.py $DAYS
@@ -21,4 +21,31 @@ uv run ${CLAUDE_PLUGIN_ROOT}/hooks/guard-stats.py $DAYS
 
 Where `$DAYS` is the days argument (default 7 if not provided).
 
-Present the output as-is — it's already formatted. If any section shows warnings or actionable suggestions, highlight them.
+## Step 2: Analyze and Recommend
+
+After reviewing the output, provide actionable recommendations for each section:
+
+**Guard Decisions:** For high-frequency blocks, read both `~/.claude/CLAUDE.md` (global) and the
+project's `CLAUDE.md` to check whether the blocked behavior is already addressed. Most
+high-frequency blocks (cat-file, grep, python, echo) are global agent behavior issues — suggest
+changes to the global CLAUDE.md. Project-specific patterns go in the project CLAUDE.md. If a rule
+is already addressed, suggest rewording for emphasis. If not, draft a specific addition.
+
+**Trust Opportunities:** For rules asked 50+ times, recommend whether to trust permanently
+(`/trust add <rule> --scope always`) or investigate why the rule triggers so often.
+
+**RTK Compression:** If the expansion rate (full reads / compressions) exceeds 25%, identify which
+commands are being re-read and suggest bypassing RTK for those commands. If expansion is low,
+confirm RTK is delivering value.
+
+**Stop Hook:** If error rate > 0%, diagnose why the LLM is unreachable (credentials, network,
+timeout). If specific findings repeat, identify the pattern and suggest a workflow change.
+If pass rate is 100% over a long period, question whether the LLM prompt is too lenient.
+
+**Session Summaries:** If friction rate is high (>15%), suggest rule tuning. If specific projects
+have disproportionate block rates, investigate project-specific issues.
+
+## Step 3: Present
+
+Show the raw stats output first, then your analysis with specific, implementable recommendations.
+Do not give vague advice like "consider reviewing" — provide exact changes to make.

--- a/dev-guard/hooks/guard-stats.py
+++ b/dev-guard/hooks/guard-stats.py
@@ -9,6 +9,7 @@ specific changes to rules, CLAUDE.md, or infrastructure.
 """
 
 import contextlib
+import datetime
 import json
 import os
 import sqlite3
@@ -21,7 +22,7 @@ _DB_PATH = Path(
 
 # Default to 7 days; accept days as first CLI argument
 try:
-    _DAYS = int(sys.argv[1]) if len(sys.argv) > 1 else 7
+    _DAYS = max(1, int(sys.argv[1])) if len(sys.argv) > 1 else 7
 except (ValueError, OverflowError):
     _DAYS = 7
 
@@ -38,8 +39,6 @@ def _connect() -> sqlite3.Connection | None:
 
 
 def _cutoff() -> str:
-    import datetime
-
     return (
         datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=_DAYS)
     ).isoformat()

--- a/dev-guard/hooks/guard-stats.py
+++ b/dev-guard/hooks/guard-stats.py
@@ -217,7 +217,7 @@ def _session_summaries(conn: sqlite3.Connection, since: str) -> None:
         except (json.JSONDecodeError, TypeError):
             continue
 
-    print(f"  Sessions: {len(rows)}   Tool calls: {total_tools:,}")
+    print(f"  Sessions: {len(rows)}   Guarded tool calls: {total_tools:,}")
     print(f"  Blocked: {total_blocked:,}   Asked: {total_asked:,}")
     if total_tools > 0:
         friction = 100 * (total_blocked + total_asked) // total_tools

--- a/dev-guard/hooks/guard-stats.py
+++ b/dev-guard/hooks/guard-stats.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""Guard Stats — actionable metrics from the dev-guard audit database.
+
+Queries ~/.claude/logs/dev-guard.db and formats insights that suggest
+specific changes to rules, CLAUDE.md, or infrastructure.
+"""
+
+import contextlib
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+_DB_PATH = Path(
+    os.environ.get("GUARD_DB_PATH", str(Path.home() / ".claude" / "logs" / "dev-guard.db"))
+)
+
+# Default to 7 days; accept days as first CLI argument
+try:
+    _DAYS = int(sys.argv[1]) if len(sys.argv) > 1 else 7
+except (ValueError, OverflowError):
+    _DAYS = 7
+
+
+def _connect() -> sqlite3.Connection | None:
+    if not _DB_PATH.exists():
+        print("No guard database found. Run some sessions first.")
+        return None
+    try:
+        return sqlite3.connect(str(_DB_PATH), timeout=2)
+    except sqlite3.Error:
+        print(f"Cannot open {_DB_PATH}")
+        return None
+
+
+def _cutoff() -> str:
+    import datetime
+
+    return (
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=_DAYS)
+    ).isoformat()
+
+
+def _section(title: str) -> None:
+    print(f"\n{title}")
+    print("-" * len(title))
+
+
+def _guard_decisions(conn: sqlite3.Connection, since: str) -> None:
+    rows = conn.execute(
+        "SELECT category, action, COUNT(*) FROM events "
+        "WHERE ts > ? GROUP BY category, action ORDER BY COUNT(*) DESC",
+        (since,),
+    ).fetchall()
+    if not rows:
+        return
+
+    _section("Guard Decisions")
+
+    total = sum(r[2] for r in rows)
+    blocked = sum(r[2] for r in rows if r[1] == "blocked")
+    asked = sum(r[2] for r in rows if r[1] in ("ask", "asked"))
+    bypassed = sum(r[2] for r in rows if r[1] == "bypassed")
+    block_pct = 100 * blocked // max(total, 1)
+    print(f"  Total: {total:,}   Blocked: {blocked:,} ({block_pct}%)")
+    print(f"  Asked: {asked:,}   Bypassed: {bypassed:,}")
+
+    # Top blocked rules — these are the actionable ones
+    top_blocks = conn.execute(
+        "SELECT rule, COUNT(*) as n FROM events "
+        "WHERE ts > ? AND action = 'blocked' AND rule IS NOT NULL "
+        "GROUP BY rule ORDER BY n DESC LIMIT 5",
+        (since,),
+    ).fetchall()
+    if top_blocks:
+        print("  Top blocks (consider CLAUDE.md reinforcement):")
+        for rule, count in top_blocks:
+            print(f"    {rule:30s} {count:>5,}")
+
+
+def _trust_insights(conn: sqlite3.Connection, since: str) -> None:
+    # Most-asked rules that haven't been trusted
+    top_asks = conn.execute(
+        "SELECT rule, COUNT(*) as n FROM events "
+        "WHERE ts > ? AND action = 'ask' AND rule IS NOT NULL "
+        "GROUP BY rule ORDER BY n DESC LIMIT 5",
+        (since,),
+    ).fetchall()
+    if not top_asks:
+        return
+
+    _section("Trust Opportunities")
+
+    trusted_rules = {
+        r[0] for r in conn.execute("SELECT DISTINCT rule_name FROM trusted_rules").fetchall()
+    }
+    for rule, count in top_asks:
+        status = "trusted" if rule in trusted_rules else "not trusted"
+        if status == "not trusted" and count >= 5:
+            print(f"  {rule:30s} asked {count:>4,}x — consider: /trust add {rule}")
+
+
+def _rtk_stats(conn: sqlite3.Connection, since: str) -> None:
+    rows = conn.execute(
+        "SELECT event_type, COUNT(*) FROM rtk_events WHERE ts > ? GROUP BY event_type",
+        (since,),
+    ).fetchall()
+    if not rows:
+        return
+
+    _section("RTK Compression")
+
+    stats = dict(rows)
+    compressed = stats.get("compressed", 0)
+    full_reads = stats.get("full_read", 0)
+    if compressed == 0:
+        return
+
+    expansion_pct = 100 * full_reads // compressed
+    print(f"  Compressed: {compressed:,}   Full reads: {full_reads:,} ({expansion_pct}% expansion)")
+    if expansion_pct > 25:
+        print("  WARNING: >25% expansion rate — agents are re-reading compressed output frequently")
+
+    # Top compressed commands
+    top = conn.execute(
+        "SELECT command, COUNT(*) as n FROM rtk_events "
+        "WHERE ts > ? AND event_type = 'compressed' "
+        "GROUP BY command ORDER BY n DESC LIMIT 5",
+        (since,),
+    ).fetchall()
+    if top:
+        print("  Top compressed:")
+        for cmd, count in top:
+            print(f"    {(cmd or '')[:50]:50s} {count:>4,}")
+
+
+def _stop_hook_stats(conn: sqlite3.Connection, since: str) -> None:
+    rows = conn.execute(
+        "SELECT outcome, COUNT(*) FROM stop_hook_events WHERE ts > ? GROUP BY outcome",
+        (since,),
+    ).fetchall()
+    if not rows:
+        return
+
+    _section("Stop Hook")
+
+    stats = dict(rows)
+    total = sum(stats.values())
+    passes = stats.get("llm_pass", 0)
+    fails = stats.get("llm_fail", 0)
+    errors = stats.get("llm_error", 0)
+    print(f"  LLM evaluations: {total}   Pass: {passes}   Fail: {fails}   Error: {errors}")
+    print("  (fast-exit invocations not counted — only events reaching LLM)")
+
+    if errors > 0:
+        error_pct = 100 * errors // total
+        print(
+            f"  ERROR RATE: {error_pct}% — LLM may be unreachable, "
+            f"stop hook is silently failing open"
+        )
+
+    # Average LLM time (exclude errors)
+    row = conn.execute(
+        "SELECT AVG(llm_duration_ms) FROM stop_hook_events "
+        "WHERE ts > ? AND outcome != 'llm_error' AND llm_duration_ms IS NOT NULL",
+        (since,),
+    ).fetchone()
+    if row and row[0]:
+        print(f"  Avg LLM time: {row[0]:.0f}ms")
+
+    # Recent failures
+    failures = conn.execute(
+        "SELECT ts, detail FROM stop_hook_events "
+        "WHERE ts > ? AND outcome = 'llm_fail' AND detail IS NOT NULL "
+        "ORDER BY ts DESC LIMIT 3",
+        (since,),
+    ).fetchall()
+    if failures:
+        print("  Recent catches:")
+        for ts, detail in failures:
+            try:
+                findings = json.loads(detail)
+                first = findings[0] if isinstance(findings, list) and findings else str(detail)[:60]
+            except (json.JSONDecodeError, IndexError):
+                first = str(detail)[:60]
+            print(f"    {ts[:10]}: {first}")
+
+
+def _session_summaries(conn: sqlite3.Connection, since: str) -> None:
+    rows = conn.execute(
+        "SELECT key, value FROM session_state WHERE key LIKE 'summary:%' AND updated_ts > ?",
+        (since,),
+    ).fetchall()
+    if not rows:
+        return
+
+    _section("Session Summaries")
+
+    total_tools = 0
+    total_blocked = 0
+    total_asked = 0
+    cwds: dict[str, int] = {}
+    for _key, value in rows:
+        try:
+            s = json.loads(value)
+            total_tools += s.get("tool_calls", 0)
+            total_blocked += s.get("blocked", 0)
+            total_asked += s.get("asked", 0)
+            cwd = s.get("cwd")
+            if cwd:
+                # Shorten to last 2 path components
+                short = "/".join(Path(cwd).parts[-2:])
+                cwds[short] = cwds.get(short, 0) + 1
+        except (json.JSONDecodeError, TypeError):
+            continue
+
+    print(f"  Sessions: {len(rows)}   Tool calls: {total_tools:,}")
+    print(f"  Blocked: {total_blocked:,}   Asked: {total_asked:,}")
+    if total_tools > 0:
+        friction = 100 * (total_blocked + total_asked) // total_tools
+        print(f"  Friction rate: {friction}% of tool calls hit a guard rule")
+
+    if cwds:
+        print("  By project:")
+        for cwd, count in sorted(cwds.items(), key=lambda x: -x[1])[:5]:
+            print(f"    {cwd:40s} {count} session(s)")
+
+
+def main() -> None:
+    conn = _connect()
+    if conn is None:
+        sys.exit(0)
+
+    since = _cutoff()
+    print(f"Dev Guard Stats (last {_DAYS} days)")
+    print("=" * 40)
+
+    for section_fn in (
+        _guard_decisions,
+        _trust_insights,
+        _rtk_stats,
+        _stop_hook_stats,
+        _session_summaries,
+    ):
+        with contextlib.suppress(sqlite3.OperationalError):
+            section_fn(conn, since)
+
+    print()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -88,6 +88,17 @@
         ]
       }
     ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py --session-end"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -112,9 +112,7 @@ def _build_prompt(ctx: dict) -> str:
     if recent_msgs:
         lines += ["", "## Recent Assistant Messages"]
         for i, msg in enumerate(recent_msgs, 1):
-            # Cap at 4000 chars per message to bound prompt size/cost
-            preview = msg[:4000] + "\n[...truncated]" if len(msg) > 4000 else msg
-            lines += [f"**Message {i}:**", preview, ""]
+            lines += [f"**Message {i}:**", msg, ""]
 
     # Add work-type-specific evaluation criteria
     lines += ["", "## Evaluation Criteria"]

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -145,7 +145,8 @@ def _build_prompt(ctx: dict) -> str:
         )
         criteria.append(
             "BRANCH SAFETY: Are changes on a feature branch (not main/master) "
-            "or appropriately staged?"
+            "or appropriately staged? Note: --force-with-lease on feature branches "
+            "is safe and expected (it prevents overwriting others' work)."
         )
 
     if work_type in ("research", "mixed") or "research" in trigger_reasons:

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -88,7 +88,6 @@ def _build_prompt(ctx: dict) -> str:
     diff_stat = ctx.get("git_diff_stat")
     trigger_reasons = ctx.get("trigger_reasons") or []
     work_type = ctx.get("work_type", "conversation")
-
     # Build context section
     lines = [
         "You are a quality gate for a Claude Code session. "
@@ -112,10 +111,8 @@ def _build_prompt(ctx: dict) -> str:
 
     if recent_msgs:
         lines += ["", "## Recent Assistant Messages"]
-        for i, msg in enumerate(recent_msgs[-3:], 1):
-            # Truncate very long messages for prompt efficiency
-            preview = msg[:800] + "..." if len(msg) > 800 else msg
-            lines += [f"**Message {i}:**", preview, ""]
+        for i, msg in enumerate(recent_msgs, 1):
+            lines += [f"**Message {i}:**", msg, ""]
 
     # Add work-type-specific evaluation criteria
     lines += ["", "## Evaluation Criteria"]

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -112,7 +112,9 @@ def _build_prompt(ctx: dict) -> str:
     if recent_msgs:
         lines += ["", "## Recent Assistant Messages"]
         for i, msg in enumerate(recent_msgs, 1):
-            lines += [f"**Message {i}:**", msg, ""]
+            # Cap at 4000 chars per message to bound prompt size/cost
+            preview = msg[:4000] + "\n[...truncated]" if len(msg) > 4000 else msg
+            lines += [f"**Message {i}:**", preview, ""]
 
     # Add work-type-specific evaluation criteria
     lines += ["", "## Evaluation Criteria"]
@@ -143,7 +145,7 @@ def _build_prompt(ctx: dict) -> str:
         criteria.append(
             "BRANCH SAFETY: Are changes on a feature branch (not main/master) "
             "or appropriately staged? Note: --force-with-lease on feature branches "
-            "is safe and expected (it prevents overwriting others' work)."
+            "is safe and expected (it fails if the remote has commits you haven't seen)."
         )
 
     if work_type in ("research", "mixed") or "research" in trigger_reasons:

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -39,7 +39,7 @@ _STATE_TTL_SECONDS = 24 * 3600  # 24 hours
 _GIT_TIMEOUT = 5  # seconds
 _LLM_TIMEOUT = 60  # seconds
 _SHORT_RESPONSE_CHARS = 200
-_RECENT_MESSAGES_LIMIT = 5
+_RECENT_MESSAGES_LIMIT = 10
 _HACK_RECENT_SECONDS = 300  # 5 minutes
 _DB_PATH = Path(
     os.environ.get("GUARD_DB_PATH", str(Path.home() / ".claude" / "logs" / "dev-guard.db"))

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -531,6 +531,7 @@ def _get_db() -> sqlite3.Connection | None:
     global _db_conn
     if _db_conn is not None:
         return _db_conn
+    conn = None
     try:
         _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
         old_umask = os.umask(0o177)
@@ -557,6 +558,8 @@ def _get_db() -> sqlite3.Connection | None:
         _db_conn = conn
         return conn
     except (OSError, sqlite3.Error):
+        if conn is not None:
+            conn.close()
         return None
 
 

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -17,10 +17,12 @@ State file: ~/.claude/stop-hook-state.json (overridable via STOP_HOOK_STATE_PATH
 """
 
 import contextlib
+import datetime
 import hashlib
 import json
 import os
 import re
+import sqlite3
 import subprocess
 import sys
 import time
@@ -39,6 +41,11 @@ _LLM_TIMEOUT = 60  # seconds
 _SHORT_RESPONSE_CHARS = 200
 _RECENT_MESSAGES_LIMIT = 5
 _HACK_RECENT_SECONDS = 300  # 5 minutes
+_DB_PATH = Path(
+    os.environ.get("GUARD_DB_PATH", str(Path.home() / ".claude" / "logs" / "dev-guard.db"))
+)
+_LOG_RETENTION_DAYS = 30
+_db_conn: sqlite3.Connection | None = None
 
 # MCP tool names that are read-only (do NOT trigger write-signal detection)
 _MCP_READ_ONLY = frozenset(
@@ -516,6 +523,87 @@ def _determine_work_type(
     return "mixed"
 
 
+# ── Audit Logging ────────────────────────────────────────────────────────────
+
+
+def _get_db() -> sqlite3.Connection | None:
+    """Get or create SQLite connection to the shared guard DB."""
+    global _db_conn
+    if _db_conn is not None:
+        return _db_conn
+    try:
+        _DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        old_umask = os.umask(0o177)
+        try:
+            conn = sqlite3.connect(str(_DB_PATH), timeout=2)
+        finally:
+            os.umask(old_umask)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=1000")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS stop_hook_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL,
+                session_id TEXT,
+                outcome TEXT NOT NULL,
+                trigger_reasons TEXT,
+                work_type TEXT,
+                llm_duration_ms INTEGER,
+                detail TEXT
+            )
+        """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_stop_ts ON stop_hook_events(ts)")
+        conn.commit()
+        _db_conn = conn
+        return conn
+    except (OSError, sqlite3.Error):
+        return None
+
+
+def _log_stop_event(
+    session_id: str,
+    outcome: str,
+    *,
+    trigger_reasons: list[str] | None = None,
+    work_type: str | None = None,
+    llm_duration_ms: int | None = None,
+    detail: str | None = None,
+) -> None:
+    """Log a stop hook event. Prunes old rows periodically."""
+    conn = _get_db()
+    if conn is None:
+        return
+    try:
+        ts = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        conn.execute(
+            "INSERT INTO stop_hook_events "
+            "(ts, session_id, outcome, trigger_reasons, work_type, llm_duration_ms, detail) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                ts,
+                session_id,
+                outcome,
+                json.dumps(trigger_reasons) if trigger_reasons else None,
+                work_type,
+                llm_duration_ms,
+                detail,
+            ),
+        )
+        conn.commit()
+        # Prune rows older than retention period (1-in-20 chance to avoid overhead)
+        import random
+
+        if random.randint(1, 20) == 1:
+            cutoff = (
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(days=_LOG_RETENTION_DAYS)
+            ).isoformat()
+            conn.execute("DELETE FROM stop_hook_events WHERE ts < ?", (cutoff,))
+            conn.commit()
+    except (sqlite3.Error, OSError):
+        pass
+
+
 # ── LLM Delegation ───────────────────────────────────────────────────────────
 
 
@@ -753,7 +841,29 @@ def main() -> None:
 
     # ── Invoke LLM ───────────────────────────────────────────────────────────
     plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
+    t0 = time.monotonic()
     decision, findings = _invoke_llm(llm_context, plugin_root)
+    llm_ms = int((time.monotonic() - t0) * 1000)
+
+    # ── Log the outcome ──────────────────────────────────────────────────────
+    if decision == "fail":
+        outcome = "llm_fail"
+        detail = json.dumps(findings) if findings else None
+    elif findings is None and llm_ms < 500:
+        # _invoke_llm returns (pass, None) on errors — if it's too fast, likely an error
+        outcome = "llm_error"
+        detail = None
+    else:
+        outcome = "llm_pass"
+        detail = None
+    _log_stop_event(
+        session_id,
+        outcome,
+        trigger_reasons=trigger_reasons,
+        work_type=work_type,
+        llm_duration_ms=llm_ms,
+        detail=detail,
+    )
 
     # ── Update state regardless of decision ─────────────────────────────────
     state = _update_session_state(

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -610,11 +610,13 @@ def _log_stop_event(
 def _invoke_llm(
     context: dict,
     plugin_root: str,
-) -> tuple[str, list[str] | None]:
+) -> tuple[str, list[str] | None, bool]:
     """Invoke stop-hook-llm.py subprocess.
 
-    Returns (decision, findings) where decision is 'pass' or 'fail'.
-    Falls back to 'pass' (fail-open) on any error.
+    Returns (decision, findings, error) where:
+      decision: 'pass' or 'fail'
+      findings: list of finding strings, or None
+      error: True if the LLM was unreachable/broken (fail-open)
     """
     llm_script = Path(plugin_root) / "hooks" / "stop-hook-llm.py"
 
@@ -626,20 +628,19 @@ def _invoke_llm(
             timeout=_LLM_TIMEOUT,
         )
         if result.returncode not in (0, 2):
-            # Unexpected exit code — fail-open
-            return "pass", None
+            return "pass", None, True
 
         stdout = result.stdout.strip()
         if not stdout:
-            return "pass", None
+            return "pass", None, True
 
         try:
             response = json.loads(stdout)
         except (json.JSONDecodeError, ValueError):
-            return "pass", None
+            return "pass", None, True
 
         if not isinstance(response, dict):
-            return "pass", None
+            return "pass", None, True
 
         decision = response.get("decision", "pass")
         if decision not in ("pass", "fail"):
@@ -649,11 +650,10 @@ def _invoke_llm(
         if not isinstance(findings, list):
             findings = None
 
-        return decision, findings
+        return decision, findings, False
 
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        # Fail-open: any infrastructure error → allow stop
-        return "pass", None
+        return "pass", None, True
 
 
 # ── Exit Helpers ─────────────────────────────────────────────────────────────
@@ -842,17 +842,16 @@ def main() -> None:
     # ── Invoke LLM ───────────────────────────────────────────────────────────
     plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
     t0 = time.monotonic()
-    decision, findings = _invoke_llm(llm_context, plugin_root)
+    decision, findings, llm_error = _invoke_llm(llm_context, plugin_root)
     llm_ms = int((time.monotonic() - t0) * 1000)
 
     # ── Log the outcome ──────────────────────────────────────────────────────
-    if decision == "fail":
-        outcome = "llm_fail"
-        detail = json.dumps(findings) if findings else None
-    elif findings is None and llm_ms < 500:
-        # _invoke_llm returns (pass, None) on errors — if it's too fast, likely an error
+    if llm_error:
         outcome = "llm_error"
         detail = None
+    elif decision == "fail":
+        outcome = "llm_fail"
+        detail = json.dumps(findings) if findings else None
     else:
         outcome = "llm_pass"
         detail = None

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -2996,6 +2996,66 @@ def _validate_rules_entries(
     return issues, len(entries)
 
 
+def _session_start_tracking() -> None:
+    """Store session CWD mapping and surface unresolved stop hook findings."""
+    try:
+        raw = sys.stdin.buffer.read(_MAX_INPUT_BYTES)
+        data = json.loads(raw) if raw else {}
+    except (json.JSONDecodeError, EOFError, ValueError):
+        data = {}
+
+    session_id = data.get("session_id", "")
+    cwd = data.get("cwd", "")
+    if not session_id:
+        return
+
+    conn = _init_db()
+    if not conn:
+        return
+
+    ts = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    try:
+        # Store session → CWD mapping and update last_session_id
+        conn.execute(
+            "INSERT OR REPLACE INTO session_state (key, value, updated_ts) VALUES (?, ?, ?)",
+            (_SESSION_ID_KEY, session_id, ts),
+        )
+        if cwd:
+            conn.execute(
+                "INSERT OR REPLACE INTO session_state (key, value, updated_ts) VALUES (?, ?, ?)",
+                (f"cwd:{session_id}", cwd, ts),
+            )
+        # Initialize tool call counter (OR IGNORE: don't reset on plugin reload)
+        conn.execute(
+            "INSERT OR IGNORE INTO session_state (key, value, updated_ts) VALUES (?, ?, ?)",
+            (f"tools:{session_id}", "0", ts),
+        )
+        conn.commit()
+    except (sqlite3.Error, OSError):
+        pass
+
+    # Surface unresolved stop hook findings from sessions in the same CWD
+    if cwd:
+        try:
+            cutoff = (
+                datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=24)
+            ).isoformat()
+            # Join through session_state to find sessions with matching CWD
+            row = conn.execute(
+                "SELECT e.detail FROM stop_hook_events e "
+                "JOIN session_state s ON s.key = 'cwd:' || e.session_id "
+                "WHERE e.outcome = 'llm_fail' AND e.ts > ? AND s.value = ? "
+                "ORDER BY e.ts DESC LIMIT 1",
+                (cutoff, cwd),
+            ).fetchone()
+            if row and row[0]:
+                findings = json.loads(row[0])
+                if isinstance(findings, list) and findings:
+                    print(f"Previous stop hook finding: {findings[0]}")
+        except (sqlite3.Error, json.JSONDecodeError, OSError):
+            pass
+
+
 def _validate_config() -> int:
     """Validate all config sources: unified config and env var overrides.
 
@@ -3003,6 +3063,9 @@ def _validate_config() -> int:
       - Success (exit 0): stdout (shown in transcript)
       - Failure (exit 2): stderr (fed back to Claude)
     """
+    # Track session CWD and surface unresolved findings
+    _session_start_tracking()
+
     url_path = os.environ.get("URL_GUARD_EXTRA_RULES")
     cmd_path = os.environ.get("COMMAND_GUARD_EXTRA_RULES")
     dirs_path = os.environ.get("GIT_TRUSTED_DIRS")
@@ -3059,6 +3122,72 @@ def _validate_config() -> int:
     rtk_msg = _ensure_rtk_config()
     if rtk_msg:
         print(rtk_msg)
+    return 0
+
+
+def _handle_session_end() -> int:
+    """Compute and store session summary at session end."""
+    try:
+        raw = sys.stdin.buffer.read(_MAX_INPUT_BYTES)
+        data = json.loads(raw) if raw else {}
+    except (json.JSONDecodeError, EOFError, ValueError):
+        data = {}
+
+    session_id = data.get("session_id", "")
+    if not session_id:
+        return 0
+
+    conn = _init_db()
+    if not conn:
+        return 0
+
+    ts = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    try:
+        # Get tool call count
+        row = conn.execute(
+            "SELECT value FROM session_state WHERE key = ?", (f"tools:{session_id}",)
+        ).fetchone()
+        tool_count = int(row[0]) if row else 0
+
+        # Get event breakdown for this session
+        breakdown = {}
+        for action, count in conn.execute(
+            "SELECT action, COUNT(*) FROM events WHERE session_id = ? GROUP BY action",
+            (session_id,),
+        ):
+            breakdown[action] = count
+
+        # Get CWD
+        row = conn.execute(
+            "SELECT value FROM session_state WHERE key = ?", (f"cwd:{session_id}",)
+        ).fetchone()
+        cwd = row[0] if row else None
+
+        summary = {
+            "tool_calls": tool_count,
+            "blocked": breakdown.get("blocked", 0),
+            "asked": breakdown.get("ask", 0),
+            "bypassed": breakdown.get("bypassed", 0),
+            "cwd": cwd,
+        }
+
+        conn.execute(
+            "INSERT OR REPLACE INTO session_state (key, value, updated_ts) VALUES (?, ?, ?)",
+            (f"summary:{session_id}", json.dumps(summary), ts),
+        )
+        conn.commit()
+
+        # Prune old session keys (older than 30 days)
+        cutoff = (
+            datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=30)
+        ).isoformat()
+        conn.execute(
+            "DELETE FROM session_state WHERE updated_ts < ? AND key != ?", (cutoff, _SESSION_ID_KEY)
+        )
+        conn.commit()
+    except (sqlite3.Error, OSError, ValueError, TypeError):
+        pass
+
     return 0
 
 
@@ -3288,6 +3417,9 @@ def main() -> None:
     if "--validate" in sys.argv:
         sys.exit(_validate_config())
 
+    if "--session-end" in sys.argv:
+        sys.exit(_handle_session_end())
+
     data = _parse_hook_input()
 
     # Extract session/tool context for logging
@@ -3315,6 +3447,25 @@ def main() -> None:
     if hook_event == "PostToolUse":
         _handle_post_tool_use(data)
         sys.exit(0)
+
+    # Increment tool call counter (PreToolUse only — Post hooks don't count)
+    if _session_id:
+        try:
+            conn = _init_db()
+            if conn:
+                conn.execute(
+                    "INSERT INTO session_state (key, value, updated_ts) "
+                    "VALUES (?, '1', ?) "
+                    "ON CONFLICT(key) DO UPDATE SET "
+                    "value = CAST(value AS INTEGER) + 1, updated_ts = excluded.updated_ts",
+                    (
+                        f"tools:{_session_id}",
+                        datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                    ),
+                )
+                conn.commit()
+        except (sqlite3.Error, OSError):
+            pass
 
     tool_name = data.get("tool_name", "")
     tool_input = data.get("tool_input", {})

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -3166,7 +3166,7 @@ def _handle_session_end() -> int:
         summary = {
             "tool_calls": tool_count,
             "blocked": breakdown.get("blocked", 0),
-            "asked": breakdown.get("ask", 0),
+            "asked": breakdown.get("ask", 0) + breakdown.get("asked", 0),
             "bypassed": breakdown.get("bypassed", 0),
             "cwd": cwd,
         }

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -408,6 +408,17 @@ def _init_db() -> sqlite3.Connection | None:
             );
             CREATE INDEX IF NOT EXISTS idx_rtk_session ON rtk_events(session_id);
             CREATE INDEX IF NOT EXISTS idx_rtk_type ON rtk_events(event_type);
+            CREATE TABLE IF NOT EXISTS stop_hook_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts TEXT NOT NULL,
+                session_id TEXT,
+                outcome TEXT NOT NULL,
+                trigger_reasons TEXT,
+                work_type TEXT,
+                llm_duration_ms INTEGER,
+                detail TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_stop_ts ON stop_hook_events(ts);
         """)
         conn.commit()
         os.chmod(str(_DB_PATH), 0o600)  # Owner-only file access

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -2996,7 +2996,7 @@ def _validate_rules_entries(
     return issues, len(entries)
 
 
-def _session_start_tracking() -> None:
+def _handle_session_start() -> None:
     """Store session CWD mapping and surface unresolved stop hook findings."""
     try:
         raw = sys.stdin.buffer.read(_MAX_INPUT_BYTES)
@@ -3064,7 +3064,7 @@ def _validate_config() -> int:
       - Failure (exit 2): stderr (fed back to Claude)
     """
     # Track session CWD and surface unresolved findings
-    _session_start_tracking()
+    _handle_session_start()
 
     url_path = os.environ.get("URL_GUARD_EXTRA_RULES")
     cmd_path = os.environ.get("COMMAND_GUARD_EXTRA_RULES")

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -48,6 +48,8 @@ def run_hook(
     env = os.environ.copy()
     if state_path is not None:
         env["STOP_HOOK_STATE_PATH"] = str(state_path)
+        # Isolate DB writes so tests don't pollute real guard stats
+        env["GUARD_DB_PATH"] = str(state_path.parent / "test-guard.db")
     if plugin_root:
         env["CLAUDE_PLUGIN_ROOT"] = plugin_root
     if extra_env:

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -3927,8 +3927,14 @@ class TestCdGitCompound:
         assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
 
     def test_git_without_cd_allowed(self):
-        """Plain git push is allowed (no cd prefix)."""
-        result = run_bash("git -C /some/repo push origin HEAD:main")
+        """Plain git -C push is allowed (no cd prefix, cd-git-compound doesn't fire)."""
+        # Use CWD (which is trusted) to avoid git-untrusted-dir blocking
+        cwd = os.getcwd()
+        result = run_guard(
+            "Bash",
+            {"command": f"git -C {cwd} push origin HEAD:main"},
+            env={**os.environ, "DEV_GUARD_CONFIG": "/nonexistent"},
+        )
         assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
 
     def test_cd_and_intervening_cmd_then_git_blocked(self):
@@ -3955,9 +3961,14 @@ class TestCdGitCompound:
 
 
 def _run_with_trusted_dirs(command, dirs_file):
-    """Run the guard with a custom trusted dirs file (GIT_TRUSTED_DIRS)."""
+    """Run the guard with a custom trusted dirs file (GIT_TRUSTED_DIRS).
+
+    Clears the unified config so only the env var file is used.
+    """
     env = os.environ.copy()
     env["GIT_TRUSTED_DIRS"] = str(dirs_file)
+    # Override unified config to prevent ~/.claude/dev-guard.json from interfering
+    env["DEV_GUARD_CONFIG"] = str(dirs_file.parent / "nonexistent-config.json")
     return run_guard("Bash", {"command": command}, env=env)
 
 
@@ -3982,8 +3993,10 @@ class TestGitTrustedDirs:
         assert_guard(result, 2, "git-untrusted-dir", "untrusted-git-c")
 
     def test_no_trusted_dirs_allows_all(self):
-        """Without GIT_TRUSTED_DIRS, all git commands are allowed."""
-        result = run_bash("git -C /any/path status")
+        """Without GIT_TRUSTED_DIRS or unified config, all git commands are allowed."""
+        env = {**os.environ, "DEV_GUARD_CONFIG": "/nonexistent"}
+        env.pop("GIT_TRUSTED_DIRS", None)
+        result = run_guard("Bash", {"command": "git -C /any/path status"}, env=env)
         assert result.returncode == 0, f"Expected pass, stderr: {result.stderr}"
 
     def test_git_version_always_allowed(self, tmp_path):

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -4704,3 +4704,285 @@ class TestRTKConfig:
         assert "history_days = 90" in patched
         assert "max_files = 20" in patched
         assert "exclude_commands = []" in patched
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Session Tracking: SessionStart, SessionEnd, Tool Counter
+# ═══════════════════════════════════════════════════════════════════════════════
+
+GUARD_STATS_SCRIPT = os.path.join(os.path.dirname(__file__), os.pardir, "hooks", "guard-stats.py")
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    """Isolated DB + env for session tracking tests."""
+    db_path = tmp_path / "test-guard.db"
+    env = {
+        **os.environ,
+        "GUARD_DB_PATH": str(db_path),
+        "DEV_GUARD_CONFIG": str(tmp_path / "nonexistent.json"),
+    }
+    env.pop("RTK_DISABLED", None)
+    return env, db_path
+
+
+def _run_session_start(env, session_id="test-session", cwd="/test/project"):
+    """Run --validate (SessionStart) with session data on stdin."""
+    payload = json.dumps({"session_id": session_id, "cwd": cwd})
+    return subprocess.run(
+        ["uv", "run", SCRIPT, "--validate"],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _run_session_end(env, session_id="test-session"):
+    """Run --session-end with session data on stdin."""
+    payload = json.dumps({"session_id": session_id})
+    return subprocess.run(
+        ["uv", "run", SCRIPT, "--session-end"],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestSessionStart:
+    """SessionStart hook stores CWD and initializes tool counter."""
+
+    def test_stores_cwd(self, session_db):
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1", cwd="/my/project")
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT value FROM session_state WHERE key = 'cwd:s1'").fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "/my/project"
+
+    def test_initializes_tool_counter(self, session_db):
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1")
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT value FROM session_state WHERE key = 'tools:s1'").fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "0"
+
+    def test_updates_last_session_id(self, session_db):
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1")
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT value FROM session_state WHERE key = 'last_session_id'"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "s1"
+
+    def test_tool_counter_not_reset_on_second_start(self, session_db):
+        """INSERT OR IGNORE: counter survives plugin reload."""
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1")
+        # Simulate tool calls by manually setting counter
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("UPDATE session_state SET value = '42' WHERE key = 'tools:s1'")
+        conn.commit()
+        conn.close()
+        # Second SessionStart (plugin reload) should NOT reset counter
+        _run_session_start(env, session_id="s1")
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT value FROM session_state WHERE key = 'tools:s1'").fetchone()
+        conn.close()
+        assert row[0] == "42"
+
+
+class TestToolCounter:
+    """Tool call counter increments on PreToolUse, not PostToolUse."""
+
+    def test_increments_on_pre_tool_use(self, session_db):
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1")
+        # Run a PreToolUse guard check
+        run_guard(
+            "Bash",
+            {"command": "date"},
+            env=env,
+            payload_extra={"session_id": "s1"},
+        )
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT value FROM session_state WHERE key = 'tools:s1'").fetchone()
+        conn.close()
+        assert int(row[0]) >= 1
+
+    def test_no_increment_on_post_tool_use(self, session_db):
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1")
+        # Run a PostToolUse event
+        run_guard(
+            "Read",
+            {"file_path": "/some/file.txt"},
+            env=env,
+            payload_extra={"session_id": "s1", "hook_event_name": "PostToolUse"},
+        )
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT value FROM session_state WHERE key = 'tools:s1'").fetchone()
+        conn.close()
+        assert row[0] == "0"
+
+
+class TestSessionEnd:
+    """SessionEnd computes and stores session summary."""
+
+    def test_stores_summary(self, session_db):
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1", cwd="/my/project")
+        # Simulate some tool calls
+        for _ in range(3):
+            run_guard(
+                "Bash",
+                {"command": "date"},
+                env=env,
+                payload_extra={"session_id": "s1"},
+            )
+        _run_session_end(env, session_id="s1")
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT value FROM session_state WHERE key = 'summary:s1'").fetchone()
+        conn.close()
+        assert row is not None
+        summary = json.loads(row[0])
+        assert summary["tool_calls"] >= 3
+        assert summary["cwd"] == "/my/project"
+        assert "blocked" in summary
+        assert "asked" in summary
+
+    def test_summary_counts_blocked_events(self, session_db):
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1")
+        # Trigger a blocked command (grep is blocked by deny rule)
+        run_guard(
+            "Bash",
+            {"command": "grep foo bar.txt"},
+            env=env,
+            payload_extra={"session_id": "s1"},
+        )
+        _run_session_end(env, session_id="s1")
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute("SELECT value FROM session_state WHERE key = 'summary:s1'").fetchone()
+        conn.close()
+        summary = json.loads(row[0])
+        assert summary["blocked"] >= 1
+
+    def test_no_session_id_is_noop(self, session_db):
+        """SessionEnd with no session_id exits cleanly."""
+        env, _db_path = session_db
+        result = subprocess.run(
+            ["uv", "run", SCRIPT, "--session-end"],
+            input="{}",
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Guard Stats Script
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestGuardStats:
+    """guard-stats.py query and formatting tests."""
+
+    def test_empty_db(self, session_db):
+        """Stats on an empty DB produces header but no crash."""
+        env, db_path = session_db
+        # Create the DB with tables by running a guard check
+        run_guard(
+            "Bash",
+            {"command": "date"},
+            env=env,
+            payload_extra={"session_id": "s1"},
+        )
+        result = subprocess.run(
+            ["uv", "run", GUARD_STATS_SCRIPT, "1"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "Dev Guard Stats" in result.stdout
+
+    def test_shows_guard_decisions(self, session_db):
+        """Stats shows guard decisions after some blocked commands."""
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1")
+        # Generate some blocks
+        for cmd in ["grep foo", "cat file.txt", "grep bar"]:
+            run_guard(
+                "Bash",
+                {"command": cmd},
+                env=env,
+                payload_extra={"session_id": "s1"},
+            )
+        result = subprocess.run(
+            ["uv", "run", GUARD_STATS_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "Guard Decisions" in result.stdout
+        assert "Blocked" in result.stdout
+
+    def test_shows_session_summaries(self, session_db):
+        """Stats shows session summaries after SessionEnd."""
+        env, db_path = session_db
+        _run_session_start(env, session_id="s1", cwd="/my/project")
+        run_guard(
+            "Bash",
+            {"command": "date"},
+            env=env,
+            payload_extra={"session_id": "s1"},
+        )
+        _run_session_end(env, session_id="s1")
+        result = subprocess.run(
+            ["uv", "run", GUARD_STATS_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "Session Summaries" in result.stdout
+        assert "Guarded tool calls" in result.stdout
+
+    def test_no_db_file(self, tmp_path):
+        """Stats with no DB file exits gracefully."""
+        env = {
+            **os.environ,
+            "GUARD_DB_PATH": str(tmp_path / "nonexistent.db"),
+        }
+        result = subprocess.run(
+            ["uv", "run", GUARD_STATS_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "No guard database" in result.stdout
+
+    def test_negative_days_clamped(self, session_db):
+        """Negative days argument is clamped to 1."""
+        env, _db_path = session_db
+        # Create DB by running a guard check
+        run_guard("Bash", {"command": "date"}, env=env, payload_extra={"session_id": "s1"})
+        result = subprocess.run(
+            ["uv", "run", GUARD_STATS_SCRIPT, "-5"],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "last 1 days" in result.stdout


### PR DESCRIPTION
## Summary

- Adds stop hook audit logging to `dev-guard.db` (`stop_hook_events` table) with outcome, trigger reasons, work type, and LLM duration
- Adds session CWD tracking and tool call counter via `session_state` key patterns (`cwd:{id}`, `tools:{id}`)
- Adds SessionStart hook: stores CWD mapping, surfaces unresolved stop hook findings from last 24h
- Adds SessionEnd hook: computes and stores session summary (`summary:{id}`) with block/ask/bypass counts and friction rate
- Adds `/guard-stats` command with actionable metrics: guard decisions, trust opportunities, RTK compression, stop hook health, session summaries with per-project breakdown
- Automatic 30-day retention pruning on session_state keys
- Bumps dev-guard 1.37.0 to 1.38.0