### PR TITLE
fix(dev-guard): adds GitHub MCP read-only tools to stop-hook list

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -75,6 +75,15 @@
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-push-review.sh"
           }
         ]
+      },
+      {
+        "matcher": "mcp__",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/dev-guard/hooks/mcp_constants.py
+++ b/dev-guard/hooks/mcp_constants.py
@@ -1,0 +1,160 @@
+"""Shared MCP constants for dev-guard hooks.
+
+Keys are server-qualified: "server_id__func_name" where server_id is the middle
+segment from tool_name.split("__", 2). This prevents a malicious MCP server from
+getting auto-approved by naming its tools to match known read-only function names.
+"""
+
+
+def _qualify(server: str, tools: list[str]) -> list[str]:
+    """Build server-qualified keys: 'server__func'."""
+    return [f"{server}__{t}" for t in tools]
+
+
+# MCP tool names that are read-only (auto-approved by guard, no write-signal in stop-hook)
+# Format: "server_id__func_name" — matched via mcp_key() helper below
+MCP_READ_ONLY: frozenset[str] = frozenset(
+    _qualify(
+        "serena",
+        [
+            "activate_project",
+            "check_onboarding_performed",
+            "find_file",
+            "find_referencing_symbols",
+            "find_symbol",
+            "get_current_config",
+            "get_symbols_overview",
+            "initial_instructions",
+            "list_dir",
+            "list_memories",
+            "onboarding",
+            "read_memory",
+            "search_for_pattern",
+        ],
+    )
+    + _qualify(
+        "plugin_claude-mem_mcp-search",
+        [
+            "get_observations",
+            "search",
+            "smart_outline",
+            "smart_search",
+            "smart_unfold",
+            "timeline",
+        ],
+    )
+    + _qualify("context7", ["resolve-library-id", "query-docs"])
+    + _qualify("sequential-thinking", ["sequentialthinking"])
+    + _qualify(
+        "playwright",
+        [
+            "browser_snapshot",
+            "browser_console_messages",
+            "browser_network_requests",
+            "browser_tabs",
+        ],
+    )
+    + _qualify(
+        "plugin_hcm-jira-administrator-agent_mcp-atlassian-prod",
+        [
+            # Jira read
+            "atlassianUserInfo",
+            "fetchAtlassian",
+            "getAccessibleAtlassianResources",
+            "getIssueLinkTypes",
+            "getJiraIssue",
+            "getJiraIssueRemoteIssueLinks",
+            "getJiraIssueTypeMetaWithFields",
+            "getJiraProjectIssueTypesMetadata",
+            "getTransitionsForJiraIssue",
+            "getVisibleJiraProjects",
+            "lookupJiraAccountId",
+            "searchAtlassian",
+            "searchJiraIssuesUsingJql",
+            # Confluence read
+            "getConfluenceCommentChildren",
+            "getConfluencePage",
+            "getConfluencePageDescendants",
+            "getConfluencePageFooterComments",
+            "getConfluencePageInlineComments",
+            "getConfluenceSpaces",
+            "getPagesInConfluenceSpace",
+            "searchConfluenceUsingCql",
+        ],
+    )
+    + _qualify(
+        "metadata-service",
+        ["get_cluster_info", "get_cluster_cves", "list_clusters"],
+    )
+    + _qualify(
+        "plugin_github-mcp_github",
+        [
+            "actions_get",
+            "actions_list",
+            "get_code_scanning_alert",
+            "get_commit",
+            "get_copilot_job_status",
+            "get_dependabot_alert",
+            "get_discussion",
+            "get_discussion_comments",
+            "get_file_contents",
+            "get_gist",
+            "get_global_security_advisory",
+            "get_job_logs",
+            "get_label",
+            "get_latest_release",
+            "get_me",
+            "get_notification_details",
+            "get_release_by_tag",
+            "get_secret_scanning_alert",
+            "get_tag",
+            "get_team_members",
+            "get_teams",
+            "github_support_docs_search",
+            "issue_read",
+            "list_branches",
+            "list_code_scanning_alerts",
+            "list_commits",
+            "list_dependabot_alerts",
+            "list_discussion_categories",
+            "list_discussions",
+            "list_gists",
+            "list_global_security_advisories",
+            "list_issue_types",
+            "list_issues",
+            "list_label",
+            "list_notifications",
+            "list_org_repository_security_advisories",
+            "list_pull_requests",
+            "list_releases",
+            "list_repository_security_advisories",
+            "list_secret_scanning_alerts",
+            "list_tags",
+            "projects_get",
+            "projects_list",
+            "pull_request_read",
+            "run_secret_scanning",
+            "search_code",
+            "search_issues",
+            "search_orgs",
+            "search_pull_requests",
+            "search_repositories",
+            "search_users",
+        ],
+    )
+)
+
+# Serena think_about_* prefix — server-qualified
+MCP_THINK_PREFIX = "serena__think_about_"
+
+
+def mcp_key(tool_name: str) -> str:
+    """Extract server-qualified key from full MCP tool name.
+
+    'mcp__serena__find_symbol' -> 'serena__find_symbol'
+    'mcp__plugin_github-mcp_github__actions_get' -> 'plugin_github-mcp_github__actions_get'
+    """
+    parts = tool_name.split("__", 2)
+    if len(parts) >= 3:
+        return f"{parts[1]}__{parts[2]}"
+    return ""

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -29,6 +29,9 @@ import time
 from pathlib import Path
 from typing import NoReturn
 
+sys.path.insert(0, str(Path(__file__).parent))
+from mcp_constants import MCP_READ_ONLY, MCP_THINK_PREFIX, mcp_key  # noqa: E402
+
 # ── Constants ────────────────────────────────────────────────────────────────
 
 _MAX_INPUT = 10 * 1024 * 1024  # 10 MB
@@ -47,28 +50,10 @@ _DB_PATH = Path(
 _LOG_RETENTION_DAYS = 30
 _db_conn: sqlite3.Connection | None = None
 
-# MCP tool names that are read-only (do NOT trigger write-signal detection)
-_MCP_READ_ONLY = frozenset(
-    {
-        "find_symbol",
-        "get_symbols_overview",
-        "search_for_pattern",
-        "list_dir",
-        "list_memories",
-        "read_memory",
-        "check_onboarding_performed",
-        "resolve-library-id",
-        "query-docs",
-        "sequentialthinking",
-        "browser_snapshot",
-        "browser_console_messages",
-        "browser_network_requests",
-        "browser_tabs",
-    }
-)
-
-# think_about_* prefix — checked separately
-_MCP_THINK_PREFIX = "think_about_"
+# MCP read-only tools and think prefix — imported from shared module
+_MCP_READ_ONLY = MCP_READ_ONLY
+_MCP_THINK_PREFIX = MCP_THINK_PREFIX
+_mcp_key = mcp_key
 
 # Write tool names (native Claude tools)
 _WRITE_TOOLS = frozenset({"Edit", "Write", "NotebookEdit"})
@@ -399,12 +384,11 @@ def _is_mcp_write_tool(tool_name: str) -> bool:
     """Return True if this MCP tool call represents a write operation."""
     if not tool_name.startswith("mcp__"):
         return False
-    # Strip mcp__<server>__ prefix to get the function name
-    parts = tool_name.split("__", 2)
-    func_name = parts[2] if len(parts) >= 3 else ""
-    if func_name in _MCP_READ_ONLY:
+    # Use server-qualified key to prevent cross-server name spoofing
+    key = _mcp_key(tool_name)
+    if key in _MCP_READ_ONLY:
         return False
-    return not func_name.startswith(_MCP_THINK_PREFIX)
+    return not key.startswith(_MCP_THINK_PREFIX)
 
 
 def _detect_write_signals(tool_calls: list[str]) -> list[str]:

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -24,6 +24,11 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import NamedTuple
 
+sys.path.insert(0, str(Path(__file__).parent))
+from mcp_constants import MCP_READ_ONLY as _MCP_READ_ONLY  # noqa: E402
+from mcp_constants import MCP_THINK_PREFIX as _MCP_THINK_PREFIX  # noqa: E402
+from mcp_constants import mcp_key as _mcp_key  # noqa: E402
+
 try:
     import tomllib
 except ImportError:
@@ -3486,6 +3491,18 @@ def main() -> None:
 
     if tool_name == "WebFetch":
         _handle_webfetch(tool_input)
+
+    # MCP tool auto-approval: known read-only tools bypass permission system
+    # Uses server-qualified keys to prevent cross-server name spoofing
+    if tool_name.startswith("mcp__"):
+        key = _mcp_key(tool_name)
+        if key in _MCP_READ_ONLY or key.startswith(_MCP_THINK_PREFIX):
+            _log_event("guard", "mcp-allow", rule="mcp-read-only", command=tool_name)
+            print(_hook_output("allow", "MCP read-only tool — auto-approved by guard"))
+            sys.exit(0)
+        # Unknown MCP tools: passthrough to settings.json permissions
+        _log_event("guard", "mcp-passthrough", rule="mcp-unknown", command=tool_name)
+        sys.exit(0)
 
     if tool_name != "Bash":
         sys.exit(0)

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -4986,3 +4986,162 @@ class TestGuardStats:
         )
         assert result.returncode == 0
         assert "last 1 days" in result.stdout
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MCP tool auto-approval guard
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMCPKeyFunction:
+    """Tests for the mcp_key() extraction helper in mcp_constants.py."""
+
+    def test_serena_tool(self):
+        from mcp_constants import mcp_key
+
+        assert mcp_key("mcp__serena__find_symbol") == "serena__find_symbol"
+
+    def test_github_mcp_tool(self):
+        from mcp_constants import mcp_key
+
+        assert (
+            mcp_key("mcp__plugin_github-mcp_github__actions_get")
+            == "plugin_github-mcp_github__actions_get"
+        )
+
+    def test_claude_mem_tool(self):
+        from mcp_constants import mcp_key
+
+        assert (
+            mcp_key("mcp__plugin_claude-mem_mcp-search__search")
+            == "plugin_claude-mem_mcp-search__search"
+        )
+
+    def test_jira_tool(self):
+        from mcp_constants import mcp_key
+
+        assert (
+            mcp_key("mcp__plugin_hcm-jira-administrator-agent_mcp-atlassian-prod__getJiraIssue")
+            == "plugin_hcm-jira-administrator-agent_mcp-atlassian-prod__getJiraIssue"
+        )
+
+    def test_short_name_returns_empty(self):
+        from mcp_constants import mcp_key
+
+        assert mcp_key("mcp__serena") == ""
+
+    def test_empty_returns_empty(self):
+        from mcp_constants import mcp_key
+
+        assert mcp_key("") == ""
+
+
+class TestMCPReadOnlyFrozenset:
+    """Spot-check that key tools are in the frozenset with correct server qualification."""
+
+    def test_serena_read_tool_present(self):
+        from mcp_constants import MCP_READ_ONLY
+
+        assert "serena__find_symbol" in MCP_READ_ONLY
+
+    def test_github_read_tool_present(self):
+        from mcp_constants import MCP_READ_ONLY
+
+        assert "plugin_github-mcp_github__actions_get" in MCP_READ_ONLY
+
+    def test_jira_read_tool_present(self):
+        from mcp_constants import MCP_READ_ONLY
+
+        assert (
+            "plugin_hcm-jira-administrator-agent_mcp-atlassian-prod__getJiraIssue" in MCP_READ_ONLY
+        )
+
+    def test_serena_write_tool_absent(self):
+        from mcp_constants import MCP_READ_ONLY
+
+        assert "serena__write_memory" not in MCP_READ_ONLY
+
+    def test_jira_write_tool_absent(self):
+        from mcp_constants import MCP_READ_ONLY
+
+        assert (
+            "plugin_hcm-jira-administrator-agent_mcp-atlassian-prod__createJiraIssue"
+            not in MCP_READ_ONLY
+        )
+
+    def test_bare_name_not_present(self):
+        """Bare function names should NOT match — must be server-qualified."""
+        from mcp_constants import MCP_READ_ONLY
+
+        assert "find_symbol" not in MCP_READ_ONLY
+        assert "actions_get" not in MCP_READ_ONLY
+
+    def test_cross_server_spoofing_blocked(self):
+        """An evil server reusing a known function name should NOT match."""
+        from mcp_constants import MCP_READ_ONLY, mcp_key
+
+        evil_tool = "mcp__evil-server__find_symbol"
+        key = mcp_key(evil_tool)
+        assert key == "evil-server__find_symbol"
+        assert key not in MCP_READ_ONLY
+
+
+class TestMCPGuardIntegration:
+    """Integration tests: run the guard with MCP tool names and verify output."""
+
+    def test_known_readonly_mcp_tool_approved(self, session_db):
+        """A known read-only GitHub MCP tool should get permissionDecision: allow."""
+        env, _ = session_db
+        result = run_guard(
+            "mcp__plugin_github-mcp_github__get_me",
+            {},
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "permissionDecision" in result.stdout
+        assert '"allow"' in result.stdout
+
+    def test_serena_readonly_tool_approved(self, session_db):
+        """A known read-only Serena tool should get permissionDecision: allow."""
+        env, _ = session_db
+        result = run_guard(
+            "mcp__serena__find_symbol",
+            {"name_path": "Foo"},
+            env=env,
+        )
+        assert result.returncode == 0
+        assert '"allow"' in result.stdout
+
+    def test_serena_think_tool_approved(self, session_db):
+        """think_about_* tools should get permissionDecision: allow."""
+        env, _ = session_db
+        result = run_guard(
+            "mcp__serena__think_about_task_adherence",
+            {"query": "Am I on track?"},
+            env=env,
+        )
+        assert result.returncode == 0
+        assert '"allow"' in result.stdout
+
+    def test_unknown_mcp_tool_passthrough(self, session_db):
+        """An unknown MCP tool should passthrough (exit 0, no permissionDecision)."""
+        env, _ = session_db
+        result = run_guard(
+            "mcp__serena__write_memory",
+            {"name": "test"},
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "permissionDecision" not in result.stdout
+
+    def test_evil_server_spoofing_passthrough(self, session_db):
+        """A tool from an unknown server using a known name should NOT get allow."""
+        env, _ = session_db
+        result = run_guard(
+            "mcp__evil-server__find_symbol",
+            {},
+            env=env,
+        )
+        assert result.returncode == 0
+        # Should NOT get permissionDecision: allow (server not recognized)
+        assert '"allow"' not in result.stdout


### PR DESCRIPTION
## Summary

- Adds 49 GitHub MCP read-only tool names to the stop-hook `_MCP_READ_ONLY` frozenset
- All tools are read-only since the github-mcp plugin uses `X-MCP-Readonly: true`
- Bumps dev-guard 1.39.0 to 1.40.0