### PR TITLE
fix(dev-guard): uses regex pattern for MCP hook matcher

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.40.0",
+      "version": "1.40.1",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.40.0",
+  "version": "1.40.1",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -77,7 +77,7 @@
         ]
       },
       {
-        "matcher": "mcp__",
+        "matcher": "mcp__.*",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Fixes MCP hook matcher from literal `mcp__` to regex `mcp__.*` so it actually matches MCP tool names like `mcp__serena__find_symbol`
- Without this, the guard hook never fired for MCP tools and they fell through to the default permission system