### PR TITLE
fix(code-quality): uses SendMessage for quality-gate Pass 2 resume

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "source": "./code-quality",
       "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -244,28 +244,28 @@ Collect:
 ### Subagent Execution (2 passes each — BOTH mandatory)
 
 Each subagent runs TWO passes. Pass 2 is NOT optional — it catches issues the subagent
-missed on Pass 1 and verifies your fixes didn't introduce new problems. You MUST save
-the agent ID from Pass 1 to resume for Pass 2.
+missed on Pass 1 and verifies your fixes didn't introduce new problems. Give each agent
+a `name` in Pass 1 so you can resume it with `SendMessage` in Pass 2.
 
 **Subagent A: Completeness Reviewer (opus)**
 
 ```
 PASS 1:
-  agent_result = Agent(
+  Agent(
+    name="completeness-reviewer",
     description="Completeness review",
     model="opus",
     prompt=<see references/subagent-prompts.md, Subagent A Pass 1>
   )
-  → Save agent_result.agentId
   → Fix ALL findings
 
 PASS 2 (MANDATORY — do not skip):
-  Agent(
-    description="Completeness re-review",
-    resume=<saved agentId from Pass 1>,
-    prompt="Here are the fixes I made: {summary_of_fixes}.
-            Review them. Also: what did YOU miss on your first pass?
-            You had fresh eyes but still have blind spots. Look again."
+  SendMessage(
+    to="completeness-reviewer",
+    message="Here are the fixes I made: {summary_of_fixes}.
+             Review them. Also: what did YOU miss on your first pass?
+             You had fresh eyes but still have blind spots. Look again.",
+    summary="Pass 2 completeness re-review"
   )
   → Fix ALL findings from Pass 2
 ```
@@ -274,20 +274,20 @@ PASS 2 (MANDATORY — do not skip):
 
 ```
 PASS 1:
-  agent_result = Agent(
+  Agent(
+    name="adversarial-reviewer",
     description="Adversarial review",
     model="opus",
     prompt=<see references/subagent-prompts.md, Subagent B Pass 1>
   )
-  → Save agent_result.agentId
   → Fix ALL findings
 
 PASS 2 (MANDATORY — do not skip):
-  Agent(
-    description="Adversarial re-review",
-    resume=<saved agentId from Pass 1>,
-    prompt="Here are the fixes: {summary_of_fixes}.
-            Verify they're correct. What else breaks in production?"
+  SendMessage(
+    to="adversarial-reviewer",
+    message="Here are the fixes: {summary_of_fixes}.
+             Verify they're correct. What else breaks in production?",
+    summary="Pass 2 adversarial re-review"
   )
   → Fix ALL findings from Pass 2
 ```

--- a/code-quality/skills/quality-gate/references/subagent-prompts.md
+++ b/code-quality/skills/quality-gate/references/subagent-prompts.md
@@ -122,23 +122,23 @@ Report any remaining issues.
 
 ## Spawning Instructions
 
-### Subagent A
+### Subagent A (Pass 1)
 
 ```
 Agent(
+  name="completeness-reviewer",
   description="Completeness review of changes",
-  subagent_type="general-purpose",
   model="opus",
   prompt=<pass_1_prompt_above>
 )
 ```
 
-### Subagent B
+### Subagent B (Pass 1)
 
 ```
 Agent(
+  name="adversarial-reviewer",
   description="Adversarial review of changes",
-  subagent_type="general-purpose",
   model="opus",
   prompt=<pass_1_prompt_above>
 )
@@ -146,10 +146,19 @@ Agent(
 
 ### Resuming for Pass 2
 
+Use `SendMessage` to resume the stopped subagent. The agent auto-resumes in the
+background with its full conversation history preserved.
+
 ```
-Agent(
-  description="Second-pass review verification",
-  resume=<agent_id_from_pass_1>,
-  prompt=<pass_2_prompt_above>
+SendMessage(
+  to="completeness-reviewer",
+  message=<pass_2_prompt_above>,
+  summary="Pass 2 completeness re-review"
+)
+
+SendMessage(
+  to="adversarial-reviewer",
+  message=<pass_2_prompt_above>,
+  summary="Pass 2 adversarial re-review"
 )
 ```


### PR DESCRIPTION
## Summary
- Replaces removed `Agent(resume=...)` parameter with `SendMessage(to=...)` for quality-gate Pass 2 subagent resumption
- The `resume` parameter was dropped from the Agent tool in Claude Code v2.1.77, causing Pass 2 agents to silently fail to spawn
- Adds `name` parameter to Pass 1 agent calls so they're addressable via SendMessage