### PR TITLE
fix(code-quality): uses fresh agents for quality-gate Pass 2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "source": "./code-quality",
       "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -244,24 +244,27 @@ Collect:
 ### Subagent Execution (2 passes each — BOTH mandatory)
 
 Each subagent runs TWO passes. Pass 2 is NOT optional — it catches issues the subagent
-missed on Pass 1 and verifies your fixes didn't introduce new problems. Give each agent
-a `name` in Pass 1 so you can resume it with `SendMessage` in Pass 2.
+missed on Pass 1 and verifies your fixes didn't introduce new problems.
+
+Pass 2 resumes the Pass 1 agent via `SendMessage` using the **agent ID** (not the name).
+This preserves the agent's full conversation history from Pass 1. You MUST use the agent
+ID returned in the Pass 1 result — using the agent name routes to a team inbox instead.
 
 **Subagent A: Completeness Reviewer (opus)**
 
 ```
 PASS 1:
-  Agent(
-    name="completeness-reviewer",
+  pass1_result = Agent(
     description="Completeness review",
     model="opus",
     prompt=<see references/subagent-prompts.md, Subagent A Pass 1>
   )
+  → Save pass1_result.agentId
   → Fix ALL findings
 
 PASS 2 (MANDATORY — do not skip):
   SendMessage(
-    to="completeness-reviewer",
+    to=<agentId from Pass 1>,
     message="Here are the fixes I made: {summary_of_fixes}.
              Review them. Also: what did YOU miss on your first pass?
              You had fresh eyes but still have blind spots. Look again.",
@@ -274,17 +277,17 @@ PASS 2 (MANDATORY — do not skip):
 
 ```
 PASS 1:
-  Agent(
-    name="adversarial-reviewer",
+  pass1_result = Agent(
     description="Adversarial review",
     model="opus",
     prompt=<see references/subagent-prompts.md, Subagent B Pass 1>
   )
+  → Save pass1_result.agentId
   → Fix ALL findings
 
 PASS 2 (MANDATORY — do not skip):
   SendMessage(
-    to="adversarial-reviewer",
+    to=<agentId from Pass 1>,
     message="Here are the fixes: {summary_of_fixes}.
              Verify they're correct. What else breaks in production?",
     summary="Pass 2 adversarial re-review"

--- a/code-quality/skills/quality-gate/references/subagent-prompts.md
+++ b/code-quality/skills/quality-gate/references/subagent-prompts.md
@@ -126,7 +126,6 @@ Report any remaining issues.
 
 ```
 Agent(
-  name="completeness-reviewer",
   description="Completeness review of changes",
   model="opus",
   prompt=<pass_1_prompt_above>
@@ -137,27 +136,29 @@ Agent(
 
 ```
 Agent(
-  name="adversarial-reviewer",
   description="Adversarial review of changes",
   model="opus",
   prompt=<pass_1_prompt_above>
 )
 ```
 
-### Resuming for Pass 2
+### Pass 2 (Resume via SendMessage)
 
-Use `SendMessage` to resume the stopped subagent. The agent auto-resumes in the
-background with its full conversation history preserved.
+Resume each stopped subagent using `SendMessage` with the **agent ID** (not the name).
+The agent auto-resumes in the background with its full Pass 1 conversation history.
+
+**IMPORTANT:** Use the agent ID returned in the Pass 1 result (e.g., `a73950bb8e403961f`).
+Using the agent name routes to a team inbox and silently fails to resume the agent.
 
 ```
 SendMessage(
-  to="completeness-reviewer",
+  to=<agentId from Pass 1>,
   message=<pass_2_prompt_above>,
   summary="Pass 2 completeness re-review"
 )
 
 SendMessage(
-  to="adversarial-reviewer",
+  to=<agentId from Pass 1>,
   message=<pass_2_prompt_above>,
   summary="Pass 2 adversarial re-review"
 )


### PR DESCRIPTION
## Summary
- Fixes quality-gate Pass 2 agents not spawning due to removed `Agent(resume=...)` parameter (v2.1.77)
- Uses `SendMessage(to=<agentId>)` to resume stopped subagents with full conversation history
- Key finding: must use the **agent ID** (not the name) — using the name silently routes to a team inbox
- Verified via smoke test: spawn named agent, stop, resume via SendMessage with agent ID — confirmed working