### PR TITLE
feat(code-quality): adds swarm eval improvements

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "source": "./code-quality",
       "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
       "category": "quality",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
     },
     {
       "name": "dev-essentials",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "source": "./dev-essentials",
       "description": "Essential development utilities: LSP navigation, uv-python enforcement, test execution, incremental planning, and session management",
       "category": "productivity",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents and skills: architecture, security, QA, performance review plus file-audit, bug-investigation, unfuck, and swarm orchestration",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/skills/bug-investigation/SKILL.md
+++ b/code-quality/skills/bug-investigation/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   "I'm going to report bugs", "let's hunt bugs", "investigate these issues", or describes
   wanting to report issues one-by-one while agents investigate in parallel. Also activates
   when the user reports a bug/issue and a BUGS.md file exists or was recently created.
-allowed-tools: [Read, Write, Edit, Glob, Grep, Task, Bash, AskUserQuestion]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Agent, Bash, AskUserQuestion]
 ---
 
 # Bug Investigation Workflow

--- a/code-quality/skills/bug-investigation/SKILL.md
+++ b/code-quality/skills/bug-investigation/SKILL.md
@@ -99,7 +99,7 @@ Assign the next sequential BUG-NNN ID. Track the counter internally.
 
 ### 2. Spawn a Background Investigation Agent
 
-Use the Task tool with these parameters:
+Use the Agent tool with these parameters:
 - `subagent_type: "general-purpose"`
 - `run_in_background: true`
 - `description: "BUG-NNN: <short title>"`
@@ -159,7 +159,7 @@ what you found and what remains unclear.
 ### 4. Batch Multiple Bugs
 
 If the user reports multiple bugs in a single message, launch ALL investigation agents
-in parallel (single message, multiple Task tool calls). Each gets its own sequential
+in parallel (single message, multiple Agent tool calls). Each gets its own sequential
 BUG-NNN ID.
 
 ### 5. Acknowledge Briefly
@@ -267,7 +267,7 @@ Mitigation strategies:
 ### Per Bug
 ```
 1. Assign BUG-NNN
-2. Task(subagent_type="general-purpose", run_in_background=true, description="BUG-NNN: title")
+2. Agent(subagent_type="general-purpose", run_in_background=true, description="BUG-NNN: title")
 3. Acknowledge: "BUG-NNN launched — investigating [title]"
 ```
 

--- a/code-quality/skills/deep-research/SKILL.md
+++ b/code-quality/skills/deep-research/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Use when user requests deep research, comprehensive analysis, or thorough investigation.
   Triggers on: "research X thoroughly", "deep dive into", "comprehensive analysis of",
   "investigate X exhaustively", "compare X options", "evaluate alternatives for"
-allowed-tools: [WebSearch, WebFetch, Read, Glob, Grep, Task]
+allowed-tools: [WebSearch, WebFetch, Read, Glob, Grep, Agent]
 ---
 
 # deep-research — 5-Hop Deep Research Mode

--- a/code-quality/skills/deep-research/SKILL.md
+++ b/code-quality/skills/deep-research/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Use when user requests deep research, comprehensive analysis, or thorough investigation.
   Triggers on: "research X thoroughly", "deep dive into", "comprehensive analysis of",
   "investigate X exhaustively", "compare X options", "evaluate alternatives for"
-allowed-tools: [WebSearch, WebFetch, Read, Glob, Grep, Agent]
+allowed-tools: [WebSearch, WebFetch, Read, Write, Glob, Grep]
 ---
 
 # deep-research — 5-Hop Deep Research Mode

--- a/code-quality/skills/deep-research/SKILL.md
+++ b/code-quality/skills/deep-research/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Use when user requests deep research, comprehensive analysis, or thorough investigation.
   Triggers on: "research X thoroughly", "deep dive into", "comprehensive analysis of",
   "investigate X exhaustively", "compare X options", "evaluate alternatives for"
-allowed-tools: [WebSearch, WebFetch, Read, Write, Glob, Grep]
+allowed-tools: [WebSearch, WebFetch, Read, Write, Glob, Grep, Agent]
 ---
 
 # deep-research — 5-Hop Deep Research Mode

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -8,7 +8,7 @@ description: |
   - "Validate library usage"
   - "Review the entire project"
   Analyzes files in parallel with LSP and Context7, detecting issues, duplicates, and documentation drift.
-allowed-tools: [LSP, Read, Grep, Glob, Task, Write, Bash, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs]
+allowed-tools: [LSP, Read, Grep, Glob, Write, Bash, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs]
 ---
 
 # file-audit

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -8,7 +8,7 @@ description: |
   - "Validate library usage"
   - "Review the entire project"
   Analyzes files in parallel with LSP and Context7, detecting issues, duplicates, and documentation drift.
-allowed-tools: [LSP, Read, Grep, Glob, Write, Bash, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs]
+allowed-tools: [LSP, Read, Grep, Glob, Write, Bash, Agent, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs]
 ---
 
 # file-audit

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -92,8 +92,8 @@ IF total_files <= 20 (or /map-reduce unavailable):
     REPEAT until queue empty:
         1. Get next batch of 3-5 "pending" files
         2. Mark batch as "in_progress", save queue
-        3. Spawn 3-5 Task agents IN PARALLEL:
-           Task(
+        3. Spawn 3-5 agents IN PARALLEL:
+           Agent(
              subagent_type="general-purpose",
              prompt=analyzer_prompt(file_path, project_memory)
            )

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -8,7 +8,7 @@ description: |
   - "Validate library usage"
   - "Review the entire project"
   Analyzes files in parallel with LSP and Context7, detecting issues, duplicates, and documentation drift.
-allowed-tools: [LSP, Read, Grep, Glob, Write, Bash, Agent, mcp__plugin_context7_context7__resolve-library-id, mcp__plugin_context7_context7__query-docs]
+allowed-tools: [LSP, Read, Grep, Glob, Write, Bash, Agent, Skill, mcp__context7__resolve-library-id, mcp__context7__query-docs]
 ---
 
 # file-audit

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -75,18 +75,31 @@ else:
 
 ### Step 2: Parallel Processing Loop
 
+**For large projects (20+ files), use /map-reduce for structured parallel analysis:**
+
 ```
-REPEAT until queue empty:
-    1. Get next batch of 3-5 "pending" files
-    2. Mark batch as "in_progress", save queue
-    3. Spawn 3-5 Task agents IN PARALLEL:
-       Task(
-         subagent_type="general-purpose",
-         prompt=analyzer_prompt(file_path, project_memory)
-       )
-    4. Wait for all agents to complete
-    5. Collect result JSONs + extracted patterns
-    6. Mark batch as "completed", save queue
+IF total_files > 20:
+    Invoke /map-reduce with by-directory or by-batch split:
+    - Mapper prompt = single-file analyzer prompt (adapted for multi-file chunks)
+    - Reducer = post-analysis deduplication + cross-referencing (see Phase 3)
+    - Each ChunkAssignment contains: list of files for that chunk, analyzer instructions,
+      cross-reference manifest of exported symbols from other chunks
+    - ChunkResults contain findings with confidence: "verified" or "chunk-local"
+    - Reducer cross-validates chunk-local findings before producing final output
+    - Fallback: if /map-reduce skill is unavailable, proceed with direct approach below
+
+IF total_files <= 20 (or /map-reduce unavailable):
+    REPEAT until queue empty:
+        1. Get next batch of 3-5 "pending" files
+        2. Mark batch as "in_progress", save queue
+        3. Spawn 3-5 Task agents IN PARALLEL:
+           Task(
+             subagent_type="general-purpose",
+             prompt=analyzer_prompt(file_path, project_memory)
+           )
+        4. Wait for all agents to complete
+        5. Collect result JSONs + extracted patterns
+        6. Mark batch as "completed", save queue
 ```
 
 ### Step 3: Post-Analysis Duplicate Detection
@@ -337,6 +350,8 @@ When LSP is unavailable for a file type:
 3. **Review todos first**: Generated TODOs are prioritized by severity
 4. **Trust but verify**: Issues are evidence-based but review before bulk fixes
 5. **Update project memory**: If drift detected, decide whether to update code or docs
+6. **Large projects**: For 20+ files, /map-reduce provides structured chunk tracking, retry-on-failure
+   for individual mapper agents, and reducer-based deduplication of cross-chunk findings
 
 ---
 

--- a/code-quality/skills/file-audit/references/analyzer-prompt.md
+++ b/code-quality/skills/file-audit/references/analyzer-prompt.md
@@ -6,10 +6,10 @@ This document contains the prompt template for spawning single-file analyzer age
 
 ## Usage
 
-When spawning a file analyzer, use the Task tool with this prompt:
+When spawning a file analyzer, use the Agent tool with this prompt:
 
 ```python
-Task(
+Agent(
     subagent_type="general-purpose",
     prompt=generate_analyzer_prompt(file_path, project_context),
     description=f"Analyze {file_path}"
@@ -362,7 +362,7 @@ prompt = ANALYZER_TEMPLATE.format(
     NOTES_MD_SUMMARY=project_memory.get("notes", "No NOTES.md found")
 )
 
-result = Task(
+result = Agent(
     subagent_type="general-purpose",
     prompt=prompt,
     description=f"Analyze {file_path}"

--- a/code-quality/skills/file-audit/references/analyzer-prompt.md
+++ b/code-quality/skills/file-audit/references/analyzer-prompt.md
@@ -109,7 +109,7 @@ For each external library used:
 
 1. **Resolve library ID:**
    ```
-   mcp__plugin_context7_context7__resolve-library-id(
+   mcp__context7__resolve-library-id(
      libraryName="<library_name>",
      query="<function_name> usage"
    )
@@ -117,7 +117,7 @@ For each external library used:
 
 2. **Query documentation:**
    ```
-   mcp__plugin_context7_context7__query-docs(
+   mcp__context7__query-docs(
      libraryId="<resolved_id>",
      query="is <function_name> deprecated, correct usage, common mistakes"
    )

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: map-reduce
 description: Parallelized workload processing with structured chunking, mapper agents, and reducer synthesis. Use for codebase-wide analysis, bulk transformations, and large file audits (20+ files).
-allowed-tools: [Read, Write, Edit, Glob, Grep, Task, Bash, AskUserQuestion, CronCreate, CronDelete, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, CronCreate, CronDelete, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet]
 ---
 
 # /map-reduce — Parallelized Workload Processing

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: map-reduce
 description: Parallelized workload processing with structured chunking, mapper agents, and reducer synthesis. Use for codebase-wide analysis, bulk transformations, and large file audits (20+ files).
-allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, CronCreate, CronDelete, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, CronCreate, CronDelete, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet]
 ---
 
 # /map-reduce — Parallelized Workload Processing

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: map-reduce
+description: Parallelized workload processing with structured chunking, mapper agents, and reducer synthesis. Use for codebase-wide analysis, bulk transformations, and large file audits (20+ files).
+allowed-tools: [Read, Write, Edit, Glob, Grep, Task, Bash, AskUserQuestion, CronCreate, CronDelete, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet]
+---
+
+# /map-reduce — Parallelized Workload Processing
+
+Splits large workloads into parallelizable chunks, assigns independent mapper agents to each
+chunk, then synthesizes results through a single reducer agent with cross-chunk validation.
+Use for codebase-wide analysis, bulk transformations, and large file audits (20+ files).
+
+## Quick Start
+
+```
+/map-reduce "find all files with TODO comments"          # Analysis workload
+/map-reduce "apply deprecation fix across all files"     # Implementation workload
+/map-reduce --split-strategy by-directory "audit auth/"  # Explicit split strategy
+```
+
+---
+
+## Architecture
+
+```
+LEAD (you)
+├── Phase 0: Plan & Split
+│   ├── Analyze workload
+│   ├── Build cross-reference manifest
+│   ├── Split into N chunks (max 8, module-aware)
+│   └── Write ChunkAssignments
+│
+├── Phase 1: Map (parallel)
+│   ├── Spawn N mapper agents simultaneously
+│   ├── Each mapper processes its chunk independently
+│   ├── CronCreate watchdog monitors progress
+│   └── Collect ChunkResults
+│
+├── Phase 2: Reduce
+│   ├── Spawn single reducer agent (opus)
+│   ├── Cross-chunk validation (4-step protocol)
+│   └── Produce ReductionResult
+│
+└── Phase 3: Deliver
+    ├── Fidelity report (>20% invalidation threshold)
+    ├── Present or apply results
+    └── Write map-reduce-report.md
+```
+
+---
+
+## Workflow Phases
+
+### Phase 0: Plan & Split
+
+1. **Analyze the workload** — determine the split strategy:
+   - `by-file`: each mapper gets an explicit list of files (best for heterogeneous workloads)
+   - `by-directory`: each mapper gets a subtree (best for large, tree-structured codebases)
+   - `by-item`: each mapper gets items from a list (best for non-file workloads: APIs, symbols, records)
+   - `custom`: user-provided split logic (ask via AskUserQuestion if needed)
+
+2. **Module-aware splitting:** when splitting by-directory, respect module boundaries — keep
+   tightly coupled files in the same chunk. Use import/directory structure to determine coupling.
+   Never split a single module (e.g., `auth/`) across chunks. If a module is too large for one
+   chunk, treat it as its own chunk even if that makes the chunk larger than average.
+
+3. **Cross-reference manifest:** before splitting, build a lightweight manifest of exported
+   symbols per file — function names, class names, and file paths for all files NOT in each
+   chunk. Include this manifest in every ChunkAssignment so mappers can distinguish between
+   "unused in my chunk" vs "might be used elsewhere." See `references/fidelity-guide.md`.
+
+4. **Cap at 8 mappers:** if the workload naturally splits into more, merge the smallest chunks.
+   If the user wants more than 8, use AskUserQuestion to confirm — document in fidelity-guide.md
+   that uncapped splitting is a known fidelity risk.
+
+5. **Create audit trail:** `hack/map-reduce/YYYY-MM-DD/` (append `-2`, `-3` for multiple runs).
+   Write `hack/map-reduce/YYYY-MM-DD/chunks/` subdirectory for ChunkResult files.
+
+6. **Create tasks upfront:** use TaskCreate with addBlockedBy for the full task graph (one task
+   per chunk + one for reduction + one for delivery) so progress is visible from the start.
+
+### Phase 1: Map (parallel)
+
+1. **Spawn N mapper agents in parallel** — all at once, not sequentially. Use `general-purpose`
+   type with `sonnet` model. Each mapper receives a ChunkAssignment (see
+   `references/communication-schema.md`).
+
+2. **Mappers are fully isolated** — they do NOT communicate with each other. Each processes
+   only the files/items in its chunk.
+
+3. **Boundary-aware findings:** mappers MUST classify every finding with a `confidence` field:
+   - `verified`: file-internal issues (syntax, style, complexity, security) — self-contained,
+     no cross-chunk risk
+   - `chunk-local`: findings that depend on cross-chunk context — specifically:
+     - "Unused code" where the symbol is exported or public
+     - "Missing dependency" where the import is from a path outside the chunk
+
+4. **CronCreate watchdog:** after spawning all mappers, create a CronCreate job (60-second
+   interval) that checks TaskList for `in_progress` tasks with no recent updates. If any mapper
+   has been idle for 2+ consecutive checks, the watchdog pings the lead to investigate. The
+   watchdog reports only — it never intervenes directly. CronDelete the watchdog when Phase 1
+   completes (also delete in error/escalation paths to avoid orphaned crons).
+
+5. **Failure handling:** if a mapper fails or times out, retry once with a fresh agent using
+   the same ChunkAssignment. If the retry also fails, mark the chunk as `failed` in the audit
+   trail, record it in `failed_chunks`, and continue to Phase 2 with the remaining results.
+
+6. **Each mapper writes** its ChunkResult to `{run_dir}/chunks/chunk-{id}.json`.
+
+### Phase 2: Reduce
+
+1. **Spawn a single reducer agent** — `general-purpose` type, `opus` model (judgment-heavy
+   synthesis). The reducer receives a ReductionInput pointing to all ChunkResult files.
+
+2. **Cross-chunk validation (mandatory 4-step protocol):**
+
+   **Step 1 — Unused code cross-check:** for every `chunk-local` "unused code" finding, search
+   other chunks' results for references to that symbol. If found in another chunk → invalidate
+   the finding. If not found anywhere → promote to `verified`.
+
+   **Step 2 — Missing dependency cross-check:** for every `chunk-local` "missing dependency"
+   finding, check if the dependency exists in another chunk's file list. If yes → invalidate.
+   If no → promote to `verified`.
+
+   **Step 3 — Deduplication:** for duplicate findings across chunks (same issue, different
+   chunks found it), merge by evidence + location, keeping the most detailed description. Never
+   silently drop a finding — if two chunks found the same issue with different evidence, keep
+   both evidence strings in the merged finding.
+
+   **Step 4 — Conflict resolution:** for conflicting findings (chunk A says "unused", chunk B
+   references it), always resolve in favor of "used" — false negatives are better than false
+   positives for destructive actions (deletions, removals).
+
+3. **Reducer output:** a ReductionResult written to `{run_dir}/reduction-result.json`. All
+   findings in the ReductionResult have `confidence: "verified"` — the reducer promotes or
+   invalidates all `chunk-local` findings before outputting.
+
+4. **For implementation workloads:** reducer also checks cross-chunk consistency — are there
+   conflicting changes proposed by different mappers to the same shared interface or file?
+   Flag these as `cross_chunk_issues` in the ReductionResult.
+
+### Phase 3: Deliver
+
+1. **Fidelity report:** check `invalidated_findings` count in ReductionResult. If more than 20%
+   of total findings were invalidated during cross-chunk validation, warn the user:
+   > "Chunk boundaries may have been poorly chosen — {N} of {total} findings ({pct}%) were
+   > invalidated by cross-chunk validation. Consider re-running with different splits or a
+   > single-agent analysis."
+
+2. **For analysis workloads:** present the synthesized summary and findings to the user.
+   Offer to write a detailed report or create actionable TODO items.
+
+3. **For implementation workloads:** apply changes in priority order (by severity), run tests
+   after each batch, verify nothing regressed. Roll back on test failure.
+
+4. **Write final report** to `{run_dir}/map-reduce-report.md` with:
+   - Summary statistics (files analyzed, total findings, deduplicated, invalidated)
+   - Per-severity breakdown
+   - Cross-chunk issues (if any)
+   - Fidelity warnings (if any)
+   - Chunk failure list (if any chunks failed)
+
+---
+
+## When to Use /map-reduce vs. Alternatives
+
+| Scenario | Recommended Approach |
+|----------|----------------------|
+| Analysis across 20+ files | `/map-reduce` |
+| Bulk transformation (same fix, many files) | `/map-reduce` |
+| Large file audit (50+ files) | `/map-reduce` |
+| Architectural analysis (circular deps, data flow) | Single agent (needs full-codebase view) |
+| Small workload (<20 files) | Direct parallel agents (less overhead) |
+| Tightly coupled codebase (>50% cross-imports) | Single agent (chunking is meaningless) |
+| Full implementation task | `/swarm` |
+| Codebase cleanup | `/unfuck` |
+
+---
+
+## Lead Responsibilities
+
+### Context Bundle
+
+Every mapper and the reducer receive a context bundle (see `references/communication-schema.md`).
+The bundle includes: project name, task description, run_dir, the tool guard reminder, and the
+cross-reference manifest (embedded in ChunkAssignment for mappers).
+
+### Watchdog Management
+
+Create the CronCreate watchdog after all mappers are spawned. Track its job ID. Delete it:
+- After all Phase 1 mappers complete (success path)
+- In any error or escalation path
+- Before returning control to the user
+
+Never leave an orphaned cron job.
+
+### Audit Trail
+
+```
+hack/map-reduce/
+└── YYYY-MM-DD/
+    ├── chunks/
+    │   ├── chunk-1.json        # ChunkResult from mapper 1
+    │   ├── chunk-2.json        # ChunkResult from mapper 2
+    │   └── ...
+    ├── reduction-result.json   # ReductionResult from reducer
+    └── map-reduce-report.md    # Final human-readable report
+```
+
+---
+
+## References
+
+| File | Content |
+|------|---------|
+| `references/communication-schema.md` | JSON schemas for ChunkAssignment, ChunkResult, ReductionInput, ReductionResult |
+| `references/agent-prompts.md` | Full prompt templates for mapper and reducer agents |
+| `references/fidelity-guide.md` | Fidelity risks, mitigations, and when NOT to use map-reduce |

--- a/code-quality/skills/map-reduce/references/agent-prompts.md
+++ b/code-quality/skills/map-reduce/references/agent-prompts.md
@@ -1,0 +1,309 @@
+# Agent Prompt Templates
+
+This file contains the full prompt templates for mapper and reducer agents in the /map-reduce
+skill. The lead agent pastes the context bundle and the relevant prompt section into each
+spawned agent's Task prompt parameter.
+
+---
+
+## Context Bundle Template
+
+Prepend this to EVERY agent prompt. The lead fills in all `{placeholder}` values before spawning.
+
+```
+=== MAP-REDUCE CONTEXT ===
+Project: {project_name}
+Task: {original_task_description}
+Branch: {branch_name}
+Run directory: {run_dir}
+Chunk results directory: {run_dir}/chunks/
+
+IMPORTANT — Tool Selection Guard:
+This repo has a tool-selection-guard hook. You MUST use native tools:
+- Glob (not ls/find), Read (not cat/head/tail), Grep (not grep/rg)
+- Write/Edit (not echo/sed/awk), output text directly (not echo/printf)
+- Bash is ONLY for: git, uv/uvx, npx, make, and system commands
+If a Bash command is blocked, switch to the equivalent native tool.
+
+IMPORTANT — Turn Counting:
+Track your turn count — the number of tool-call rounds you have completed since spawning.
+Include "turn_count": N in your ChunkResult or ReductionResult output. This helps the lead
+monitor your progress and context health.
+
+=== END CONTEXT ===
+```
+
+After the context bundle, add the agent-specific prompt below.
+
+---
+
+## Mapper Agent Prompt
+
+**Type:** `general-purpose` | **Model:** sonnet | **Mode:** default
+
+```markdown
+# Mapper Agent — /map-reduce
+
+{context_bundle}
+
+## Your Role
+
+You are a Mapper agent. You process an assigned chunk of the workload independently and produce
+a structured ChunkResult. You do NOT communicate with other mappers. You operate in full
+isolation from other chunks.
+
+## Your Assignment
+
+Read your ChunkAssignment from: `{chunk_assignment_path}`
+
+The assignment contains:
+- `chunk_id`: your unique identifier
+- `files`: the files you are responsible for (or `items` for non-file workloads)
+- `instructions`: what you must do with your chunk
+- `cross_reference_manifest`: exported symbols from files OUTSIDE your chunk
+- `output_path`: where to write your ChunkResult
+
+## Processing Steps
+
+### Step 1: Read Your Assignment
+
+Read the ChunkAssignment JSON from `{chunk_assignment_path}`. Understand:
+- What files/items you are processing
+- What analysis or transformation is required
+- What symbols exist outside your chunk (from the manifest)
+
+### Step 2: Process Each File/Item
+
+For each file in your chunk:
+1. Read the file completely
+2. Perform the requested analysis or transformation
+3. Collect findings
+
+### Step 3: Classify Every Finding with a Confidence Level
+
+This is critical for result quality. Every finding MUST have a `confidence` field:
+
+**Use `confidence: "verified"` when:**
+- The finding is entirely self-contained within your chunk
+- Examples: syntax errors, style violations, logic bugs in internal functions,
+  unused local variables (never exported), security vulnerabilities in internal code
+
+**Use `confidence: "chunk-local"` when:**
+- The finding's validity depends on something OUTSIDE your chunk
+- Specifically:
+  - "Unused code" finding where the symbol is exported or public → mark `chunk-local`
+    and set `cross_chunk_dependency` to the symbol name
+  - "Missing dependency" finding where the import path is outside your chunk → mark
+    `chunk-local` and set `cross_chunk_dependency` to the import path
+- Rule: if a symbol is exported/public and you can't find references in your chunk,
+  do NOT report it as unused — mark it `chunk-local`. The reducer will check other chunks.
+
+### Step 4: Use the Cross-Reference Manifest
+
+The `cross_reference_manifest` in your ChunkAssignment lists exported symbols from files
+outside your chunk. Use it to:
+- Check if a symbol you can't find locally is exported by another file
+- Before marking something as "missing" or "unused", check the manifest
+- If you find a reference to a manifest symbol, note it in your finding's evidence
+
+The manifest is lightweight (symbol names only). If you need full type signatures, read the
+referenced file directly.
+
+### Step 5: Write Your ChunkResult
+
+Write your complete ChunkResult JSON to `{output_path}` (from the ChunkAssignment).
+
+Format:
+```json
+{
+  "schema": "ChunkResult",
+  "chunk_id": "{chunk_id}",
+  "status": "complete | partial | failed",
+  "findings": [
+    {
+      "id": "MAP-{chunk_id}-001",
+      "severity": "critical | high | medium | low | informational",
+      "confidence": "verified | chunk-local",
+      "file": "path/to/file.py",
+      "line": 42,
+      "description": "Clear description of the issue",
+      "evidence": "Quoted code or specific observation",
+      "suggested_action": "What should be done",
+      "cross_chunk_dependency": "symbol_name_or_import_path | null"
+    }
+  ],
+  "summary": "Overview of what was found in this chunk",
+  "files_modified": [],
+  "turn_count": {your_turn_count}
+}
+```
+
+### Step 6: Notify the Lead
+
+After writing your ChunkResult, send a brief summary to the lead via SendMessage:
+```
+Chunk {chunk_id} complete. Status: complete. Found {N} findings ({X} verified, {Y} chunk-local).
+Output written to {output_path}. turn_count: {N}
+```
+
+## Key Rules
+
+- Process ONLY your assigned files/items. Do not read files outside your chunk unless
+  they appear in the cross_reference_manifest and you need their exported symbols.
+- Mark every finding with `confidence: "verified"` or `"chunk-local"` — no exceptions.
+- For exported/public symbols with no local references: ALWAYS mark `chunk-local`, never
+  report as definitively unused.
+- Be thorough within your chunk. Evidence-based findings only — no speculation.
+- If you encounter a file you cannot read or process, mark it in your summary and continue
+  with the remaining files. Set `status: "partial"` if you skip any files.
+```
+
+---
+
+## Reducer Agent Prompt
+
+**Type:** `general-purpose` | **Model:** opus | **Mode:** default
+
+```markdown
+# Reducer Agent — /map-reduce
+
+{context_bundle}
+
+## Your Role
+
+You are the Reducer. You receive all ChunkResults from the parallel mappers and synthesize
+them into a single, authoritative ReductionResult. Your job is high-judgment synthesis:
+deduplication, cross-chunk validation, conflict resolution, and final ranking.
+
+## Your Input
+
+Read your ReductionInput from: `{reduction_input_path}`
+
+The ReductionInput contains:
+- `total_chunks` and `completed_chunks`: how many chunks ran
+- `failed_chunks`: any chunks that did not complete (handle gracefully)
+- `chunk_results_dir`: directory containing all ChunkResult files
+- `reduction_instructions`: specific synthesis guidance for this workload
+- `output_path`: where to write your ReductionResult
+
+## Processing Steps
+
+### Step 1: Load All Chunk Results
+
+Use Glob to find all `chunk-*.json` files in `{chunk_results_dir}`. Read each one.
+Build a complete picture of all findings across all chunks before doing any synthesis.
+
+### Step 2: Cross-Chunk Validation (mandatory 4-step protocol)
+
+**This is the most important step. Execute all 4 steps without exception.**
+
+**Step 2.1 — Unused code cross-check:**
+For every finding with `confidence: "chunk-local"` and description related to unused code:
+- Extract the symbol name from `cross_chunk_dependency`
+- Search all OTHER chunks' results for any reference to that symbol in their findings, evidence,
+  or in the files within those chunks (read the files if necessary)
+- If the symbol IS referenced in another chunk: invalidate this finding (increment `invalidated_findings`)
+- If the symbol is NOT referenced anywhere: promote to `confidence: "verified"`
+
+**Step 2.2 — Missing dependency cross-check:**
+For every finding with `confidence: "chunk-local"` and description related to a missing dependency:
+- Extract the import path from `cross_chunk_dependency`
+- Check if that path exists in any other chunk's `files` list
+- If the dependency EXISTS in another chunk: invalidate (increment `invalidated_findings`)
+- If it does NOT exist: promote to `confidence: "verified"`
+
+**Step 2.3 — Deduplication:**
+For findings that appear in multiple chunks (same file, same line, same issue type):
+- Merge into a single finding
+- Combine evidence strings from all sources (keep both, separated by " | ")
+- Keep the highest severity across all instances
+- Record all source chunk_ids in `source_chunks`
+- Never silently drop a finding — if merging loses detail, keep the fuller description
+
+**Step 2.4 — Conflict resolution:**
+For conflicting findings (e.g., chunk A says "symbol X is unused", chunk B has a reference to
+symbol X in its evidence):
+- Always resolve in favor of "used" — false negatives beat false positives for destructive
+  actions (deletions, removals, deprecations)
+- Record the conflict resolution in `fidelity_warnings`
+- Do NOT report the symbol as unused
+
+### Step 3: Rank by Severity
+
+Sort final findings: critical → high → medium → low → informational. Within each severity
+level, sort by file path for consistency.
+
+### Step 4: Check Cross-Chunk Consistency (implementation workloads)
+
+If this is an implementation workload (mappers proposed code changes):
+- Check if any two chunks propose conflicting changes to the same file or interface
+- Flag all conflicts in `cross_chunk_issues`
+- Do NOT apply conflicting changes — escalate to the lead
+
+### Step 5: Write ReductionResult
+
+Write your complete ReductionResult JSON to `{output_path}` (from the ReductionInput).
+
+Format:
+```json
+{
+  "schema": "ReductionResult",
+  "status": "complete | partial",
+  "total_findings": {raw_count_before_dedup},
+  "deduplicated_findings": {count_after_dedup},
+  "invalidated_findings": {count_of_invalidated_chunk_local},
+  "by_severity": {
+    "critical": 0,
+    "high": 0,
+    "medium": 0,
+    "low": 0,
+    "informational": 0
+  },
+  "findings": [
+    {
+      "id": "MAP-chunk-1-001 or MERGED-001",
+      "severity": "critical | high | medium | low | informational",
+      "confidence": "verified",
+      "file": "path/to/file.py",
+      "line": 42,
+      "description": "Merged/deduplicated description",
+      "evidence": "Combined evidence from all source chunks",
+      "suggested_action": "Recommended action",
+      "source_chunks": ["chunk-1", "chunk-2"]
+    }
+  ],
+  "cross_chunk_issues": [
+    "Description of any conflict between chunk proposals"
+  ],
+  "fidelity_warnings": [
+    "Any concerns about chunk boundary effects, resolved conflicts, or quality caveats"
+  ],
+  "summary": "Executive summary of all findings after synthesis"
+}
+```
+
+All findings in your output MUST have `confidence: "verified"`. You have completed the
+cross-chunk validation — there are no more `chunk-local` findings.
+
+### Step 6: Notify the Lead
+
+After writing your ReductionResult, send a summary to the lead via SendMessage:
+```
+Reduction complete. Status: complete.
+Raw findings: {total}, After dedup: {deduplicated}, Invalidated: {invalidated}.
+By severity: critical={N}, high={N}, medium={N}, low={N}, informational={N}.
+Fidelity warnings: {count}. Cross-chunk issues: {count}.
+Output written to {output_path}.
+```
+
+## Key Rules
+
+- Execute ALL 4 cross-chunk validation steps. Do not skip any.
+- For destructive findings (unused code, dead imports), resolve ambiguity in favor of "used" —
+  false negatives are better than false positives.
+- Report `invalidated_findings` count accurately — this is used for the fidelity report.
+- All findings in your output must have `confidence: "verified"` — you are the final authority.
+- If failed_chunks is non-empty, note in `fidelity_warnings` that results may be incomplete
+  for those areas of the codebase.
+- Never invent findings that weren't reported by mappers. Synthesis only — no new analysis.
+```

--- a/code-quality/skills/map-reduce/references/communication-schema.md
+++ b/code-quality/skills/map-reduce/references/communication-schema.md
@@ -1,0 +1,187 @@
+# Communication Schema
+
+This file contains all JSON schemas for inter-agent communication within the `/map-reduce` skill.
+Every message passed between agents via SendMessage and every file written to the audit trail
+follows one of these schemas. The Lead uses these schemas to validate incoming messages and to
+construct outgoing context for each agent.
+
+---
+
+## ChunkAssignment (Lead → Mapper)
+
+Sent by the Lead to assign a chunk to a mapper agent. Written to `{run_dir}/chunks/chunk-{id}.json`
+before spawning the mapper (so the mapper can read it on startup if preferred over inline prompt).
+
+```json
+{
+  "schema": "ChunkAssignment",
+  "chunk_id": "string — e.g. 'chunk-1'",
+  "chunk_description": "string — what this chunk covers (e.g. 'auth/ directory: login, session, token files')",
+  "files": ["string — file paths in this chunk"],
+  "items": ["string — items to process if item-based split (empty array if file-based)"],
+  "instructions": "string — what the mapper should do with this chunk (analysis, transformation, etc.)",
+  "cross_reference_manifest": [
+    {
+      "file": "string — file path outside this chunk",
+      "exported_symbols": ["string — function/class names exported from this file"]
+    }
+  ],
+  "output_path": "string — where to write ChunkResult (e.g. 'hack/map-reduce/YYYY-MM-DD/chunks/chunk-1.json')",
+  "context": {
+    "project": "string — project name",
+    "task": "string — original user task description",
+    "branch": "string — current git branch name",
+    "run_dir": "string — path to hack/map-reduce/YYYY-MM-DD",
+    "tool_guard": "Use Read/Write/Edit/Glob/Grep/Bash for file ops. No raw shell for file reads."
+  }
+}
+```
+
+**Notes:**
+- `files` and `items` are mutually exclusive (one will be populated, the other empty).
+- `cross_reference_manifest` contains entries for ALL files NOT in this chunk. Mappers use
+  this to check whether an "unused" symbol might be referenced outside their chunk.
+- The manifest is intentionally lightweight — only exported/public symbol names, not full
+  signatures. Mappers that need full type info must read the referenced file directly.
+
+---
+
+## ChunkResult (Mapper → Lead)
+
+Written by each mapper to `{output_path}` from its ChunkAssignment. The mapper also sends a
+summary to the Lead via SendMessage when complete.
+
+```json
+{
+  "schema": "ChunkResult",
+  "chunk_id": "string — matches ChunkAssignment chunk_id",
+  "status": "complete | partial | failed",
+  "findings": [
+    {
+      "id": "string — MAP-{chunk_id}-NNN (e.g. MAP-chunk-1-001)",
+      "severity": "critical | high | medium | low | informational",
+      "confidence": "verified | chunk-local",
+      "file": "string — file path",
+      "line": "integer | null — line number if applicable",
+      "description": "string — clear description of the issue or finding",
+      "evidence": "string — quoted code snippet or specific observation",
+      "suggested_action": "string — what should be done about this finding",
+      "cross_chunk_dependency": "string | null — symbol or file in another chunk this finding depends on"
+    }
+  ],
+  "summary": "string — overview of what was found or done in this chunk",
+  "files_modified": ["string — file paths modified (if implementation workload; empty for analysis)"],
+  "turn_count": "integer — mapper's self-reported tool-call round count since spawn"
+}
+```
+
+**Confidence field semantics:**
+- `verified`: the finding is self-contained within this chunk. No cross-chunk context needed
+  to confirm it. Examples: syntax errors, style violations, security vulnerabilities in internal
+  logic, unused local variables.
+- `chunk-local`: the finding's validity depends on context outside this chunk. The reducer
+  MUST cross-validate before treating it as confirmed. Examples: exported symbol with no
+  references (might be used in another chunk), import from a path not in this chunk (might
+  exist in another chunk).
+
+**Status semantics:**
+- `complete`: mapper processed all assigned files/items successfully
+- `partial`: mapper processed some files but encountered errors on others (list in `summary`)
+- `failed`: mapper could not complete the assignment (fatal error)
+
+---
+
+## ReductionInput (Lead → Reducer)
+
+Sent by the Lead to the reducer agent after all mappers complete. The reducer reads individual
+ChunkResult files from `chunk_results_dir` rather than receiving them inline (to avoid message
+size limits).
+
+```json
+{
+  "schema": "ReductionInput",
+  "total_chunks": "integer — total number of chunks assigned",
+  "completed_chunks": "integer — number of chunks with status 'complete' or 'partial'",
+  "failed_chunks": ["string — chunk_ids that returned status 'failed'"],
+  "chunk_results_dir": "string — path to {run_dir}/chunks/ directory",
+  "reduction_instructions": "string — how to synthesize: deduplicate, cross-validate, rank by severity, merge evidence",
+  "output_path": "string — where to write ReductionResult (e.g. 'hack/map-reduce/YYYY-MM-DD/reduction-result.json')",
+  "context": {
+    "project": "string — project name",
+    "task": "string — original user task description",
+    "branch": "string — current git branch name",
+    "run_dir": "string — path to hack/map-reduce/YYYY-MM-DD",
+    "tool_guard": "Use Read/Write/Edit/Glob/Grep/Bash for file ops. No raw shell for file reads."
+  }
+}
+```
+
+**Note:** The reducer reads all `chunk-*.json` files from `chunk_results_dir` using Glob,
+then processes them. The Lead does NOT inline all chunk data — that would exceed message limits
+for large workloads.
+
+---
+
+## ReductionResult (Reducer → Lead)
+
+Written by the reducer to `{output_path}` from the ReductionInput. The reducer also sends a
+summary to the Lead via SendMessage when complete.
+
+```json
+{
+  "schema": "ReductionResult",
+  "status": "complete | partial",
+  "total_findings": "integer — raw finding count across all chunks before deduplication",
+  "deduplicated_findings": "integer — finding count after deduplication",
+  "invalidated_findings": "integer — chunk-local findings disproven by cross-chunk validation",
+  "by_severity": {
+    "critical": 0,
+    "high": 0,
+    "medium": 0,
+    "low": 0,
+    "informational": 0
+  },
+  "findings": [
+    {
+      "id": "string — original MAP-{chunk_id}-NNN id or MERGED-NNN for merged findings",
+      "severity": "critical | high | medium | low | informational",
+      "confidence": "verified",
+      "file": "string — file path",
+      "line": "integer | null",
+      "description": "string — merged/deduplicated description",
+      "evidence": "string — combined evidence from all chunks that found this issue",
+      "suggested_action": "string — recommended action",
+      "source_chunks": ["string — chunk_ids that originally found this issue"]
+    }
+  ],
+  "cross_chunk_issues": [
+    "string — conflicts or inconsistencies between chunks (e.g. 'chunk-1 proposes removing function X, chunk-3 adds a new call to function X')"
+  ],
+  "fidelity_warnings": [
+    "string — any concerns about chunk boundary effects on result quality"
+  ],
+  "summary": "string — executive summary of all findings after synthesis"
+}
+```
+
+**Note:** All findings in `ReductionResult.findings` have `confidence: "verified"`. The reducer
+promotes or invalidates all `chunk-local` findings from mappers before writing output. The
+`invalidated_findings` count records how many `chunk-local` findings were disproven.
+
+---
+
+## Audit Trail Directory Structure
+
+```
+hack/map-reduce/
+└── YYYY-MM-DD/               # or YYYY-MM-DD-2, YYYY-MM-DD-3 for multiple runs
+    ├── chunks/
+    │   ├── chunk-1.json      # ChunkResult from mapper 1 (written by mapper)
+    │   ├── chunk-2.json      # ChunkResult from mapper 2
+    │   └── ...               # Up to 8 chunk files
+    ├── reduction-result.json # ReductionResult from reducer
+    └── map-reduce-report.md  # Final human-readable report (written by Lead)
+```
+
+The Lead resolves `{run_dir}` in Phase 0 and passes it to all agents in their context bundle.
+Agents write directly to `{run_dir}/...` without needing to know the date or sequence number.

--- a/code-quality/skills/map-reduce/references/fidelity-guide.md
+++ b/code-quality/skills/map-reduce/references/fidelity-guide.md
@@ -1,0 +1,89 @@
+# Fidelity Guide
+
+This file documents the known fidelity risks of map-reduce analysis, the mitigations baked into
+the skill, and guidance on when NOT to use map-reduce. Read this before running /map-reduce on
+a workload where result accuracy is critical.
+
+---
+
+## Fidelity Risks
+
+| Risk | Description | Severity |
+|------|-------------|----------|
+| Cross-chunk blindness | Mapper reports a symbol as unused because all references to it are in a different chunk. Without cross-chunk validation, this produces false-positive "remove this" recommendations. | High |
+| Deduplication loss | Two mappers independently find the same issue. Naive merging keeps one and drops the other, losing evidence or nuance from the dropped instance. | Medium |
+| Context fragmentation | Architectural issues that span chunk boundaries (e.g., a circular dependency between module A in chunk 1 and module B in chunk 2) are invisible to individual mappers. Each chunk sees only one side of the problem. | High |
+| Chunk boundary artifacts | Tightly coupled files split across chunks produce misleading findings — one chunk lacks the context the other provides. A function call in chunk 1 that references a function defined in chunk 2 looks like a missing reference to chunk 1's mapper. | Medium |
+| False confidence | A finding marked `verified` that is actually wrong because the mapper could not see the full picture. This happens when mappers incorrectly classify `chunk-local` findings as `verified`. | High |
+
+---
+
+## Mitigations
+
+These mitigations are mandatory — they are baked into the skill protocol, not optional
+configuration.
+
+| Mitigation | Where Enforced | Addresses |
+|------------|----------------|-----------|
+| Module-aware splitting | Phase 0 (Plan & Split) | Chunk boundary artifacts |
+| Cross-reference manifest | Phase 0 → ChunkAssignment schema | Cross-chunk blindness |
+| `confidence` field on findings | Phase 1 mapper output (ChunkResult schema) | False confidence |
+| `chunk-local` vs `verified` classification | Phase 1 mapper prompts | Cross-chunk blindness |
+| 4-step cross-chunk validation | Phase 2 reducer protocol | Cross-chunk blindness, deduplication loss |
+| "Resolve toward used" rule | Phase 2 reducer prompts | False positives on destructive actions |
+| `invalidated_findings` count | Phase 2 reducer output (ReductionResult schema) | Fidelity monitoring |
+| Fidelity report threshold | Phase 3 (>20% invalidation warns user) | Chunk boundary artifacts |
+
+---
+
+## When NOT to Use Map-Reduce
+
+These scenarios are better served by a single agent or a different skill:
+
+**Architectural analysis (circular dependencies, full data flow)**
+- Requires full-codebase view simultaneously. Chunking makes cross-component relationships
+  invisible to individual mappers. The reducer can partially reconstruct this, but will miss
+  subtler patterns. Use a single powerful agent with the full codebase in context instead.
+
+**Small workloads (<20 files)**
+- The overhead of chunking, manifest building, parallel spawning, and reduction exceeds
+  the benefit for small workloads. Direct parallel agents (3-5, no structured chunking)
+  are simpler and equally effective.
+
+**Tightly coupled codebases (>50% of files import from >50% of other files)**
+- When coupling is so high that chunking is meaningless (almost every file is a cross-chunk
+  dependency for every other file), the cross-reference manifest becomes enormous and the
+  `chunk-local` → `verified` promotion rate approaches 100%. Use a single agent instead.
+
+**Security audits requiring trust boundary analysis**
+- Trust boundaries often span modules and directories. A mapper seeing only part of a trust
+  boundary cannot assess whether the boundary is correctly enforced. Use `code-quality:security`
+  directly for security audits that require holistic trust boundary analysis.
+
+**Refactoring with semantic dependencies**
+- When a rename or refactor has semantic implications that span the codebase (e.g., changing
+  an interface contract), mappers working in isolation may apply the transformation incorrectly
+  in their chunk. Use `/swarm` with a single Implementer for semantically-connected refactors.
+
+---
+
+## Fidelity Report Interpretation
+
+After every /map-reduce run, the Lead checks the `invalidated_findings` count in the
+ReductionResult and computes the invalidation rate:
+
+```
+invalidation_rate = invalidated_findings / total_findings
+```
+
+| Rate | Interpretation | Action |
+|------|----------------|--------|
+| 0–5% | Normal — very few cross-chunk false positives | Proceed normally |
+| 5–20% | Elevated — some chunk boundaries were suboptimal | Note in report, no action required |
+| >20% | High — chunk boundaries were poorly chosen | Warn user, suggest re-running with different splits or single-agent analysis |
+
+A high invalidation rate means the mapper chunk boundaries did not respect the actual
+dependency structure of the codebase. Consider:
+- Switching from `by-directory` to `by-module` splitting
+- Using the import graph to determine natural chunk boundaries
+- Running a single-agent analysis if the codebase is too tightly coupled to chunk effectively

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -34,13 +34,14 @@ digraph quality_gate {
   rankdir=TB;
   node [shape=box];
   detect [label="Step 0: Detect work type"];
-  layer1 [label="Layer 1: Self-Review Loop\n5 rounds, rotating lenses"];
+  layer1 [label="Layer 1: Self-Review Loop\n6 rounds, rotating lenses"];
+  layer1_5 [label="Layer 1.5: Domain Expert Review\n4 parallel reviewers (code/mixed only)"];
   layer2 [label="Layer 2: Fresh-Context Subagents\n2 subagents x 2 passes"];
   memory [label="Memory Gate (BLOCKING)"];
   artifact [label="Artifact Gate (BLOCKING)"];
   nodataloss [label="No Data Loss Gate (BLOCKING)"];
   final [label="Final Verification"];
-  detect -> layer1 -> layer2 -> memory -> artifact -> nodataloss -> final;
+  detect -> layer1 -> layer1_5 -> layer2 -> memory -> artifact -> nodataloss -> final;
 }
 ```
 
@@ -65,7 +66,7 @@ Select the lens set for the detected type (see `references/lens-rubrics.md`).
 
 ## Layer 1: Self-Review Loop
 
-**5 rounds maximum. Exit early if a round produces zero findings AND the action audit is clean.**
+**6 rounds maximum (Round 6: Structural applies to Code/Mixed only). Exit early if a round produces zero findings AND the action audit is clean.**
 
 Each round uses a different adversarial lens. Rotating lenses prevent anchoring fatigue and ensure
 comprehensive coverage from different angles.
@@ -79,6 +80,7 @@ comprehensive coverage from different angles.
 | 3 | **Robustness** | How does this fail? Bad input, missing deps, concurrent access, edge cases? |
 | 4 | **Simplicity** | What's over-engineered? What could be deleted? What's AI slop? |
 | 5 | **Adversarial** | You are a hostile reviewer. The author claims this is done. Prove them wrong. |
+| 6 | **Structural** | What design flaws, race conditions, or failure modes exist in this system's architecture — not just in the current change, but in how it integrates? (Code/Mixed only) |
 
 Table shows code lenses. Other work types adapt lens names — e.g., planning uses "Feasibility"
 for Round 1, Q&A uses a reduced 3-round review. See `references/lens-rubrics.md` for all
@@ -202,6 +204,82 @@ catch categorically different issues — a clean Round 1 says nothing about Roun
 Starting from Round 4: if a round produces zero findings AND the action audit is clean, skip
 remaining rounds. Do NOT exit early just because you "feel done" — the `think_about_whether_you_are_done`
 tool must confirm.
+
+**Note on Round 6 (Structural):** Only applies to Code and Mixed work types. Skip for all
+other types. Structural lens focuses on integration architecture, not the current change in
+isolation — it may find issues even when Rounds 1-5 were clean.
+
+---
+
+## Layer 1.5: Domain Expert Review
+
+**Applies to: Code and Mixed work types only.** Skip for Research, Planning, Config, and
+Question work types.
+
+Domain reviewers catch categories of issues that self-review lenses systematically miss:
+security vulnerabilities require dedicated adversarial security reasoning; performance issues
+require cost-model thinking; QA issues require test coverage analysis; code review issues
+require holistic style and maintainability assessment. Layer 1 cannot replicate these because
+each domain has its own expert heuristics.
+
+**Layer 1.5 is NOT optional for code work.** Do not skip it because Layer 1 "seemed thorough."
+
+### Trigger
+
+Work type is **Code** or **Mixed** (with a code component).
+
+### Reviewer Spawning (4 in parallel)
+
+```
+Spawn all 4 reviewers simultaneously:
+
+Reviewer 1 — Security (code-quality:security):
+  Agent(
+    description="Security domain review",
+    model="sonnet",
+    prompt=<see references/subagent-prompts.md, Domain Reviewer: Security>
+  )
+
+Reviewer 2 — QA (code-quality:qa):
+  Agent(
+    description="QA domain review",
+    model="sonnet",
+    prompt=<see references/subagent-prompts.md, Domain Reviewer: QA>
+  )
+
+Reviewer 3 — Performance (code-quality:performance):
+  Agent(
+    description="Performance domain review",
+    model="sonnet",
+    prompt=<see references/subagent-prompts.md, Domain Reviewer: Performance>
+  )
+
+Reviewer 4 — Code Review (superpowers:code-reviewer):
+  Agent(
+    description="Code style and maintainability review",
+    model="sonnet",
+    prompt=<see references/subagent-prompts.md, Domain Reviewer: Code-Reviewer>
+  )
+```
+
+Each reviewer receives:
+- `git diff` of all changes
+- The original user request (verbatim)
+- CLAUDE.md / CONTRIBUTING.md project rules (if they exist)
+
+### Synthesis Protocol
+
+After all 4 reviewers complete, synthesize findings by severity:
+
+1. **Collect** all findings across the 4 reviewers
+2. **Classify** each finding: CRITICAL / HIGH / MEDIUM / LOW
+3. **Fix all CRITICAL and HIGH findings** before proceeding to Layer 2.
+   These are blocking. Do not carry them forward.
+4. **Record MEDIUM and LOW findings** — include them in the output report, fix if
+   straightforward, document as follow-up if genuinely deferred.
+
+**The synthesis step is not optional.** If you find yourself writing "domain review skipped"
+or "findings noted for later," stop. Fix the critical/high findings now.
 
 ---
 
@@ -411,11 +489,19 @@ QUALITY GATE
 Work type: [code / research / plan / config / question / mixed]
 
 Layer 1 — Self-Review:
-  Rounds completed: [N/5]
+  Rounds completed: [N/6]
   Issues found: [count]
   Issues fixed: [count]
   Identified-but-unactioned caught: [count]
   Project rules violations caught: [count]
+
+Layer 1.5 — Domain Expert Review: [N/A for non-code | COMPLETE]
+  Security reviewer: [count] findings ([critical/high/medium/low breakdown])
+  QA reviewer: [count] findings ([critical/high/medium/low breakdown])
+  Performance reviewer: [count] findings ([critical/high/medium/low breakdown])
+  Code-reviewer: [count] findings ([critical/high/medium/low breakdown])
+  Critical/High fixed before Layer 2: [count]
+  Medium/Low recorded: [count]
 
 Layer 2 — Subagent Reviews:
   Subagent A (Completeness): [count] findings across 2 passes — agent ID: [id]
@@ -450,6 +536,10 @@ Overall: [PASS / NEEDS WORK]
 | `sc:analyze` | Invoked in Round 1 (Correctness lens) for code files. |
 | `sc:improve` | Invoked in Round 4 (Simplicity lens) for dead code removal. |
 | `sc:reflect` | Replaced by Serena metacognitive tools (more targeted). |
+| `code-quality:security` | Spawned as domain reviewer in Layer 1.5 (code/mixed work types). |
+| `code-quality:qa` | Spawned as domain reviewer in Layer 1.5 (code/mixed work types). |
+| `code-quality:performance` | Spawned as domain reviewer in Layer 1.5 (code/mixed work types). |
+| `superpowers:code-reviewer` | Spawned as domain reviewer in Layer 1.5 (code/mixed work types). |
 | `verification-before-completion` | Embedded in Final Verification step. |
 | `session-end` | Complementary — quality-gate reviews accuracy; session-end does final save. |
 | `swarm` Phase 7 | Invokes quality-gate as the final validation step. |

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -4,6 +4,7 @@ description: |
   Use when about to claim ANY work is complete — code, research, planning,
   config, or general answers. Also after /swarm, /spawn, subagent-driven
   development, or any significant deliverable.
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, SendMessage, Skill]
 ---
 
 # Quality Gate

--- a/code-quality/skills/quality-gate/references/lens-rubrics.md
+++ b/code-quality/skills/quality-gate/references/lens-rubrics.md
@@ -60,6 +60,46 @@ structure. This file provides the specific questions and techniques for each len
 - **First-principles:** "State the fundamental purpose in one sentence. Review against that
   purpose, not the structure you created."
 
+### Round 6: Structural (Code/Mixed only)
+
+Core question: "What design flaws, race conditions, or failure modes exist in this system's
+architecture — not just in the current change, but in how it integrates?"
+
+This lens examines the change in its system context, not as an isolated unit. Correctness
+(Round 1) checks whether the code does what it says. Structural checks whether what it does
+is safe and coherent when integrated into the larger system.
+
+**Focus areas:**
+
+- **Concurrency issues:** Are there race conditions between this change and concurrent
+  callers? Shared mutable state accessed without synchronization? TOCTOU (time-of-check
+  time-of-use) windows? Are locks acquired in consistent order to prevent deadlock?
+
+- **State management gaps:** Does the change introduce state that can become inconsistent?
+  Are state transitions explicit and complete (no missing transitions or illegal states)?
+  Is initialization ordering guaranteed? Are cleanup paths symmetric with setup paths?
+
+- **Error propagation paths:** When this component fails, how does the failure propagate?
+  Does it fail loudly (crash, panic, exception) or silently (nil return, wrong result)?
+  Are callers equipped to handle the error signals this code produces? Does the failure
+  mode change under concurrent access?
+
+- **API contract violations:** Does this change break the implicit or explicit contract
+  of the interfaces it implements or calls? Are preconditions documented and enforced?
+  Do postconditions still hold after the change? Are invariants maintained across the
+  call boundary?
+
+- **Dependency ordering assumptions:** Does this code assume initialization order of
+  external dependencies? What happens if a dependency initializes after this code runs?
+  Are there circular dependencies introduced by this change? Does the code assume
+  availability of infrastructure (network, filesystem, database) without verifying?
+
+**First-principles:** "If this component were a black box, what contracts would callers
+rely on? Does this change honor those contracts under all observable conditions — including
+failure, concurrency, and abnormal load?"
+
+**Tool:** Use `sequential-thinking` MCP to trace each integration path step-by-step.
+
 ---
 
 ## Research Lenses

--- a/code-quality/skills/quality-gate/references/subagent-prompts.md
+++ b/code-quality/skills/quality-gate/references/subagent-prompts.md
@@ -4,6 +4,150 @@ Use these templates when spawning Layer 2 subagents. Replace `{placeholders}` wi
 
 ---
 
+## Layer 1.5: Domain Reviewer Prompts
+
+Use these templates when spawning Layer 1.5 domain reviewers. Replace `{placeholders}` with
+actual values. All 4 reviewers receive the same input context (diff, request, project rules).
+
+### Domain Reviewer: Security
+
+```
+You are a security engineer performing a focused security review.
+
+ORIGINAL REQUEST:
+{original_request}
+
+CHANGES TO REVIEW:
+{git_diff}
+
+PROJECT RULES:
+{claude_md_rules_if_any}
+
+FOCUS: Security vulnerabilities only — do not report style, performance, or completeness issues.
+
+CHECKLIST:
+1. Injection: command injection, SQL injection, path traversal, template injection?
+2. Authentication/Authorization: missing auth checks, privilege escalation paths, IDOR?
+3. Input validation: unsanitized user input reaching sensitive operations?
+4. Secrets/credentials: tokens, passwords, keys hardcoded or logged?
+5. Dependency risks: newly added dependencies with known CVEs or suspicious provenance?
+6. Error handling: stack traces, internal paths, or sensitive data exposed in errors?
+7. Configuration: insecure defaults, overly permissive settings, missing TLS?
+
+For each finding, report:
+- Vulnerability type and location (file:line)
+- Attack vector (how an adversary exploits it)
+- Severity: CRITICAL (exploitable remotely, data loss) / HIGH (exploitable with effort) / MEDIUM (limited impact) / LOW (defense in depth)
+- Suggested fix (brief)
+
+If no issues found, say "No security findings." Do not fabricate issues.
+```
+
+### Domain Reviewer: QA
+
+```
+You are a QA engineer performing a focused test coverage and quality review.
+
+ORIGINAL REQUEST:
+{original_request}
+
+CHANGES TO REVIEW:
+{git_diff}
+
+PROJECT RULES:
+{claude_md_rules_if_any}
+
+FOCUS: Test coverage, testability, and quality assurance concerns — not style or performance.
+
+CHECKLIST:
+1. Coverage: what changed code paths have no corresponding test coverage?
+2. Test quality: are existing tests meaningful, or just asserting the implementation exists?
+3. Edge cases: what boundary conditions are untested (empty, max, concurrent, error)?
+4. Regression risk: what existing behavior could break from this change, untested?
+5. Flakiness: are there tests that depend on timing, ordering, or external state?
+6. Testability: does the new code make testing harder (hidden dependencies, global state)?
+7. Contract: do tests verify behavior (what it does) or implementation (how it does it)?
+
+For each finding, report:
+- What scenario or path lacks coverage
+- Risk if it goes untested
+- Severity: CRITICAL (core path untested) / HIGH (likely regression path) / MEDIUM (edge case) / LOW (nice to have)
+- Suggested test approach (brief)
+
+If coverage is adequate, say "No QA findings." Do not fabricate issues.
+```
+
+### Domain Reviewer: Performance
+
+```
+You are a performance engineer performing a focused performance review.
+
+ORIGINAL REQUEST:
+{original_request}
+
+CHANGES TO REVIEW:
+{git_diff}
+
+PROJECT RULES:
+{claude_md_rules_if_any}
+
+FOCUS: Performance issues only — not correctness, style, or test coverage.
+
+CHECKLIST:
+1. Algorithmic complexity: O(N²) or worse where O(N) is achievable? Unbounded loops?
+2. Database/IO: N+1 queries? Missing indexes? Unbounded result sets? Missing pagination?
+3. Memory: unbounded accumulation? Large allocations in hot paths? Missing streaming?
+4. Concurrency: lock contention? Unnecessary synchronization? Missing parallelism?
+5. Caching: repeated expensive computations? Cache invalidation issues?
+6. Startup/cold path: expensive operations on every request that should be amortized?
+7. Resource cleanup: connections, file handles, or goroutines that outlive their scope?
+
+For each finding, report:
+- The performance problem and location (file:line)
+- Expected impact (scale at which it matters, latency/throughput effect)
+- Severity: CRITICAL (blocks scale, causes OOM/timeout) / HIGH (degrades at moderate load) / MEDIUM (noticeable at scale) / LOW (micro-optimization)
+- Suggested fix (brief)
+
+If no performance issues found, say "No performance findings." Do not fabricate issues.
+```
+
+### Domain Reviewer: Code-Reviewer
+
+```
+You are a senior engineer performing a holistic code quality review — style, maintainability,
+and readability. This is separate from correctness, security, or performance reviews.
+
+ORIGINAL REQUEST:
+{original_request}
+
+CHANGES TO REVIEW:
+{git_diff}
+
+PROJECT RULES:
+{claude_md_rules_if_any}
+
+FOCUS: Code quality, style, and maintainability — not correctness, security, or performance.
+
+CHECKLIST:
+1. Clarity: is the intent of the code clear without needing to trace execution?
+2. Naming: are identifiers precise and meaningful? Avoid vague names (data, info, handler)?
+3. Abstraction: are abstractions at the right level? Not too early, not too shallow?
+4. AI slop: narrating obvious logic in comments, filler docstrings, excessive hedging?
+5. Duplication: copy-paste that should be extracted? Or premature DRY that hurts readability?
+6. Conventions: does the code follow the project's existing patterns (from CLAUDE.md)?
+7. Dead code: commented-out blocks, unreachable branches, unused variables/imports?
+
+For each finding, report:
+- The quality concern and location (file:line)
+- Why it matters for long-term maintainability
+- Severity: HIGH (actively misleading or unmaintainable) / MEDIUM (degrades over time) / LOW (minor polish)
+- Suggested improvement (brief)
+
+If code quality is good, say "No code quality findings." Do not fabricate issues.
+```
+
+---
+
 ## Subagent A: Completeness Reviewer
 
 ### Pass 1 Prompt

--- a/code-quality/skills/speculative/SKILL.md
+++ b/code-quality/skills/speculative/SKILL.md
@@ -70,7 +70,7 @@ the lead sends one status check. If the competitor does not complete within a re
 additional time, the lead marks it as timed-out and proceeds with the results it has. A
 run with 1 of 2 competitors can still proceed — the judge evaluates what it received.
 
-**Failed competitor:** If a competitor sends a `ImplementationResult` with `status: "failed"`,
+**Failed competitor:** If a competitor sends an `ImplementationResult` with `status: "failed"`,
 the lead records the failure, CronDeletes the watchdog, and proceeds with remaining results.
 If ALL competitors fail, escalate to the user via `AskUserQuestion` before continuing.
 

--- a/code-quality/skills/speculative/SKILL.md
+++ b/code-quality/skills/speculative/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: speculative
+description: >-
+  Run competing implementations in parallel with isolated worktrees, then judge and select the
+  best approach. Use when multiple viable approaches exist and "try both and compare" beats
+  "guess and commit."
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, SendMessage, TaskCreate,
+  TaskUpdate, TaskList, TaskGet, CronCreate, CronDelete]
+---
+
+# /speculative — Competing Implementations with Judge Selection
+
+You MUST follow the phased approach described here. Do not collapse phases or implement
+the task yourself. Your role is orchestration — you define the spec, spawn competitors,
+coordinate the judge, and present the result to the user.
+
+---
+
+## Workflow Phases
+
+### Phase 0: Specification
+
+Gather the problem and success criteria before spawning anything.
+
+1. Use `AskUserQuestion` to clarify the task if the request is ambiguous. Resolve:
+   - What exactly are we comparing? (algorithm, architecture, approach)
+   - What does "better" mean for this problem? (performance, readability, maintainability, correctness, simplicity)
+   - How many competitors? (default: 2, max: 4 — more is slower, rarely more useful)
+   - Are there specific approaches to try, or should competitors choose their own?
+
+2. Define the evaluation criteria as a weighted list (weights must sum to 1.0):
+   - Correctness (does it work correctly and handle edge cases?)
+   - Readability (is the code clear and maintainable?)
+   - Performance (is it efficient for the expected load?)
+   - Simplicity (is it the minimum necessary complexity?)
+   - Add or substitute criteria based on user priorities
+
+3. Create the audit trail directory at `hack/speculative/YYYY-MM-DD/`. If the directory
+   already exists (multiple runs same day), append a sequence number.
+
+4. Create all tasks upfront with `TaskCreate` so the plan is visible from the start.
+
+### Phase 1: Fork (parallel, isolated)
+
+Spawn N competitor agents (sonnet, general-purpose) in parallel, each with `isolation: "worktree"`.
+
+Each competitor receives a `SpeculativeSpec` (see `references/communication-schema.md`) containing:
+- The problem description and success criteria
+- An approach hint if the user provided one (otherwise: null — competitor chooses its own approach)
+- Its competitor ID (e.g., `competitor-1`)
+- The path to its dedicated worktree
+- The output path for its `ImplementationResult`
+
+Competitors work in full isolation — they do NOT communicate with each other or with the lead
+during implementation. The lead does not intervene unless a competitor explicitly signals it
+is blocked.
+
+**CronCreate watchdog:** After spawning competitors, create a CronCreate job with a 60-second
+interval. The watchdog checks `TaskList` for competitor tasks with no recent updates and sends
+a status alert to the lead if any competitor has been idle for 2+ consecutive checks. The
+watchdog monitors — it does NOT intervene directly. CronDelete the watchdog when Phase 1
+completes (all competitors have submitted ImplementationResults).
+
+**Completion:** Each competitor writes its `ImplementationResult` to
+`{run_dir}/implementations/competitor-{id}.json` and signals completion via SendMessage.
+The lead waits for all competitors before proceeding to Phase 2.
+
+**Time cap:** If a competitor is significantly slower than others and all others have finished,
+the lead sends one status check. If the competitor does not complete within a reasonable
+additional time, the lead marks it as timed-out and proceeds with the results it has. A
+run with 1 of 2 competitors can still proceed — the judge evaluates what it received.
+
+**Failed competitor:** If a competitor sends a `ImplementationResult` with `status: "failed"`,
+the lead records the failure, CronDeletes the watchdog, and proceeds with remaining results.
+If ALL competitors fail, escalate to the user via `AskUserQuestion` before continuing.
+
+### Phase 2: Evaluate
+
+Spawn a single judge agent (opus, general-purpose) — this is a high-judgment task.
+
+The judge receives a `JudgmentRequest` containing:
+- All `ImplementationResult` objects from Phase 1
+- The original `SpeculativeSpec` (problem + success criteria + weights)
+- The audit trail path for writing its output
+
+**Important — judge independence:** The judge receives competitor self-assessments and approach
+descriptions, NOT raw code by default. This prevents bias from code style. If the judge needs
+to inspect code to make an informed decision, it reads specific files from each worktree path
+using the Read tool. The judge should only inspect code when self-reported results are
+insufficient to distinguish approaches.
+
+The judge produces a `JudgmentResult` (see `references/communication-schema.md`) with:
+- A winner (or "hybrid" if combining elements is better than either alone)
+- A scoring matrix with per-criterion scores for each competitor
+- Clear rationale for the decision
+- A `hybrid_recommended` flag with specific elements to combine (if applicable)
+
+The judge writes its result to `{run_dir}/judgment.json` and signals the lead.
+
+### Phase 3: Select & Merge
+
+Present the judgment to the user and execute the selection.
+
+1. Present the `JudgmentResult` to the user via `AskUserQuestion`:
+   - Show the scoring matrix (per-criterion scores, weighted totals)
+   - Show the winner and rationale
+   - If `hybrid_recommended`, explain what elements could be combined and from which competitors
+   - Ask: "Accept this selection, override to a different competitor, or proceed with hybrid?"
+
+2. Based on user response:
+   - **Accept winner:** Merge the winning worktree's changes into the main branch (see merge
+     procedure below).
+   - **Override:** User selects a different competitor — merge that worktree instead.
+   - **Hybrid:** Proceed to Phase 3.5.
+
+3. **Merge procedure for winner:**
+   - Identify the winning worktree path from the ImplementationResult
+   - Use `git diff <main-branch> <worktree-branch>` to show the changes
+   - Apply the winner's changes to the main working tree
+   - Run the test suite to verify the merge produced a clean state
+   - Report files changed
+
+4. **Cleanup:** Delete all loser worktrees. The winning worktree is cleaned up after its changes
+   are confirmed merged. Write the final report to `{run_dir}/speculative-report.md`.
+
+### Phase 3.5: Hybrid (conditional)
+
+Only triggered if the judge recommends hybrid AND the user approves. This is NOT the default path.
+
+1. The judge's `hybrid_elements` field lists specific elements to combine
+   (e.g., "competitor-1's error handling approach with competitor-2's data structure choice").
+
+2. Spawn a synthesis agent (sonnet, general-purpose) with:
+   - The hybrid_elements list from JudgmentResult
+   - Read access to both competitor worktrees
+   - Write access to the main branch working tree
+
+3. The synthesis agent combines the specified elements and produces a final implementation.
+   It reports back with files changed and test results.
+
+4. After synthesis, run the test suite to verify. Clean up all competitor worktrees.
+   Write the final report to `{run_dir}/speculative-report.md`.
+
+---
+
+## Orchestration Flow Diagram
+
+```
+User request
+     |
+     v
+Phase 0: Specification
+  +-- AskUserQuestion (ambiguity, criteria, competitor count)
+  +-- Create hack/speculative/YYYY-MM-DD/
+  +-- TaskCreate for all phases
+     |
+     v
+Phase 1: Fork (parallel, isolated)
+  +-- Spawn N competitors (sonnet, worktree isolation)
+  +-- CronCreate watchdog (60s interval)
+  +-- Wait for all ImplementationResults
+  +-- CronDelete watchdog
+     |
+     v
+Phase 2: Evaluate
+  +-- Spawn judge (opus)
+  +-- Judge reads ImplementationResults (+ worktree code if needed)
+  +-- Judge writes JudgmentResult to {run_dir}/judgment.json
+     |
+     v
+Phase 3: Select & Merge
+  +-- AskUserQuestion (present scoring matrix, get user approval)
+  +-- Merge winner into main branch
+  +-- Run tests
+  +-- Cleanup loser worktrees
+  +-- Write speculative-report.md
+     |
+     +--(if hybrid approved)---+
+                               v
+                     Phase 3.5: Hybrid
+                       +-- Spawn synthesis agent
+                       +-- Combine elements from multiple competitors
+                       +-- Run tests
+                       +-- Cleanup all worktrees
+                       +-- Write speculative-report.md
+```
+
+---
+
+## Lead Responsibilities
+
+You are the orchestrator. You define the spec, route competitor results to the judge, present
+the judgment to the user, and execute the merge. You never implement code yourself.
+
+### Task Graph
+
+Create tasks upfront in Phase 0 with `TaskCreate`. Mark them `in_progress` as each phase begins
+and `completed` when done. Blocked tasks (e.g., Phase 3.5 pending user decision) should remain
+`pending` until triggered.
+
+### Competitor Monitoring
+
+Track each competitor's status. When all competitors have reported, CronDelete the watchdog
+and proceed to Phase 2. If a competitor goes idle (no messages, no task updates), the watchdog
+alerts you — send one status check before assuming failure.
+
+### User Communication
+
+Phase 0 is the only mandatory user interaction before Phase 3. After gathering the spec and
+getting user confirmation on evaluation criteria and competitor count, competitors run without
+further user interaction until the judge has finished. The user resumes at Phase 3 to approve
+the selection.
+
+### Audit Trail
+
+Write all structured outputs to `hack/speculative/YYYY-MM-DD/`:
+- `implementations/competitor-{id}.json` — each competitor's ImplementationResult
+- `judgment.json` — judge's JudgmentResult
+- `speculative-report.md` — final human-readable completion report
+
+---
+
+## When to Skip Phases
+
+| Phase | Skip When |
+|-------|-----------|
+| Phase 3.5: Hybrid | Judge does not set `hybrid_recommended: true`, OR user declines hybrid |
+| NEVER SKIP | Phase 0 (specification), Phase 1 (competitors), Phase 2 (judge), Phase 3 (selection) |
+
+---
+
+## Cost Awareness
+
+This skill spawns 2-4 competitor agents plus a judge. Each competitor runs a full implementation.
+Use it only when the choice between approaches has real consequences and "try both" is genuinely
+better than the architect choosing one.
+
+### When to Use /speculative vs. Alternatives
+
+| Scenario | Recommended Approach |
+|----------|----------------------|
+| One clearly correct approach | Implement directly (no speculative needed) |
+| Multiple viable approaches, real trade-offs | `/speculative` |
+| Architectural decision with broad impact | `/speculative` with 2-3 competitors |
+| Algorithm selection (e.g., LRU vs TTL cache) | `/speculative` |
+| "I want to see which is faster" | `/speculative` with performance as top criterion |
+| Simple feature (1-3 files, obvious approach) | Single targeted subagent |
+| Large feature needing full pipeline rigor | `/swarm` (optionally with Phase 2.7 speculative fork) |
+
+### Model Cost Hierarchy
+
+| Role | Model | Rationale |
+|------|-------|-----------|
+| Competitors | sonnet | Implementation work — capable but cost-efficient |
+| Judge | opus | Judgment-heavy evaluation — worth the cost for fair comparison |
+| Synthesis (Phase 3.5) | sonnet | Mechanical combination of known elements |
+
+---
+
+## References
+
+| File | Content |
+|------|---------|
+| `references/communication-schema.md` | JSON schemas for SpeculativeSpec, ImplementationResult, JudgmentResult |
+| `references/agent-prompts.md` | Full prompt templates for competitor and judge agents |

--- a/code-quality/skills/speculative/SKILL.md
+++ b/code-quality/skills/speculative/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Run competing implementations in parallel with isolated worktrees, then judge and select the
   best approach. Use when multiple viable approaches exist and "try both and compare" beats
   "guess and commit."
-allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, SendMessage, TaskCreate,
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, SendMessage, TaskCreate,
   TaskUpdate, TaskList, TaskGet, CronCreate, CronDelete]
 ---
 

--- a/code-quality/skills/speculative/SKILL.md
+++ b/code-quality/skills/speculative/SKILL.md
@@ -58,8 +58,9 @@ is blocked.
 **CronCreate watchdog:** After spawning competitors, create a CronCreate job with a 60-second
 interval. The watchdog checks `TaskList` for competitor tasks with no recent updates and sends
 a status alert to the lead if any competitor has been idle for 2+ consecutive checks. The
-watchdog monitors — it does NOT intervene directly. CronDelete the watchdog when Phase 1
-completes (all competitors have submitted ImplementationResults).
+watchdog monitors — it does NOT intervene directly. CronDelete the watchdog before
+transitioning to Phase 2, including when all competitors fail or are timed out. Delete on all
+paths — never leave orphaned cron jobs at phase boundaries.
 
 **Completion:** Each competitor writes its `ImplementationResult` to
 `{run_dir}/implementations/competitor-{id}.json` and signals completion via SendMessage.

--- a/code-quality/skills/speculative/references/agent-prompts.md
+++ b/code-quality/skills/speculative/references/agent-prompts.md
@@ -1,0 +1,261 @@
+# Agent Prompt Templates
+
+This file contains the full prompt templates for agents in the `/speculative` skill. The lead
+agent fills in all `{placeholder}` values before spawning each agent.
+
+---
+
+## Context Bundle Template
+
+Prepend this to EVERY agent prompt. The lead fills in all `{placeholder}` values before spawning.
+
+```
+=== SPECULATIVE CONTEXT ===
+Project: {project_name}
+Task: {original_task_description}
+Branch: {branch_name}
+Run directory: {run_dir}
+
+IMPORTANT — Tool Selection Guard:
+This repo has a tool-selection-guard hook. You MUST use native tools:
+- Glob (not ls/find), Read (not cat/head/tail), Grep (not grep/rg)
+- Write/Edit (not echo/sed/awk), output text directly (not echo/printf)
+- Bash is ONLY for: git, uv/uvx, npx, make, and system commands
+If a Bash command is blocked, switch to the equivalent native tool.
+
+IMPORTANT — Turn Counting:
+Track your turn count — the number of tool-call rounds you have completed since spawning.
+Include "turn_count": N in your ImplementationResult. The lead uses this to monitor context
+health.
+
+=== END CONTEXT ===
+```
+
+After the context bundle, add the agent-specific prompt below.
+
+---
+
+## Competitor Agent Prompt
+
+**Type:** general-purpose | **Model:** sonnet | **Isolation:** worktree
+
+```markdown
+# Competitor — Speculative Execution Agent
+
+{context_bundle}
+
+## Your Role
+
+You are a competitor in a speculative execution run. You implement a solution to the problem
+below, working entirely in your assigned worktree. You do NOT communicate with other competitors.
+You work independently until your implementation is complete, then report your results.
+
+Your work is evaluated against stated criteria by an independent judge. The judge values:
+1. **Honest self-assessment** — inflated scores are penalized. Score yourself accurately.
+2. **Clear trade-off documentation** — every approach sacrifices something. Name it.
+3. **Correct test results** — run the tests and report actual numbers, not estimates.
+
+## Assignment
+
+Read your SpeculativeSpec from: `{spec_path}`
+
+The spec contains:
+- `problem` — what to implement
+- `success_criteria` — the criteria (with weights) your implementation is judged against
+- `approach_hint` — the approach to take (null = your choice)
+- `worktree_path` — your isolated working directory
+- `output_path` — where to write your ImplementationResult
+
+## Implementation Steps
+
+### Step 1: Understand the Problem
+
+Read the spec. Read relevant existing code using Read/Glob/Grep. Understand:
+- What does the problem require?
+- What existing code will your implementation interact with?
+- What constraints does the codebase impose (patterns, conventions, test approach)?
+
+### Step 2: Choose Your Approach
+
+If `approach_hint` is set, implement that approach. If it is null, choose the approach you
+believe best fits the success criteria. Document your choice — the judge will evaluate your
+reasoning.
+
+### Step 3: Implement in Your Worktree
+
+All file operations happen in `{worktree_path}`. This is your isolated workspace:
+- Create and modify files using Write/Edit tools
+- Do NOT modify files outside your worktree
+- Do NOT git commit — the lead handles merging after judgment
+
+Follow the existing codebase conventions for:
+- Naming, formatting, and style
+- Error handling patterns
+- Test file organization
+
+### Step 4: Run Tests
+
+Run the test suite from your worktree. Record the exact command, tests run, tests passed,
+and tests failed. If you cannot run tests (e.g., environment not set up), document why.
+
+### Step 5: Write Your Self-Assessment
+
+For EACH criterion in `success_criteria`, provide:
+- A score from 1-10 (be honest — the judge will independently verify)
+- A specific rationale (not "good readability" but "uses well-named functions with clear
+  single responsibilities; average function length is 8 lines")
+
+Also write a `trade_offs` field describing what your approach gives up. If you say "no
+trade-offs," the judge will interpret this as an incomplete self-assessment.
+
+### Step 6: Write Your ImplementationResult
+
+Write the `ImplementationResult` JSON to `output_path` from the spec. Include ALL fields
+from the schema (see `references/communication-schema.md`).
+
+Then send a message to the lead:
+
+```
+SendMessage(to="team-lead", content=JSON.stringify({
+  "schema": "ImplementationResult",
+  "competitor_id": "{competitor_id}",
+  "status": "complete",
+  "approach": "...",
+  ... (all fields)
+}))
+```
+
+Do NOT send a plain text message — the lead expects structured JSON.
+
+## Important Rules
+
+- Work ONLY in your worktree (`{worktree_path}`). Never touch the main branch.
+- No communication with other competitors — you should not know what they are building.
+- If you get blocked (a critical dependency is missing, the worktree is in bad state), set
+  `status: "partial"` or `status: "failed"` and describe the blocker in `approach`.
+- Do not ask the lead for clarification mid-implementation — if something is ambiguous,
+  make a reasonable assumption, document it in `approach`, and proceed.
+```
+
+---
+
+## Judge Agent Prompt
+
+**Type:** general-purpose | **Model:** opus
+
+```markdown
+# Judge — Speculative Execution Agent
+
+{context_bundle}
+
+## Your Role
+
+You are the judge in a speculative execution run. You evaluate competing implementations
+against the stated success criteria and produce an independent scoring matrix. Your goal is
+a fair, evidence-based judgment — not a consensus or compromise.
+
+You are the last line of quality before the user makes a selection. Your judgment determines
+which implementation gets merged into the codebase.
+
+## Assignment
+
+Read your JudgmentRequest from: `{request_path}`
+
+The request contains:
+- `problem` — the original problem
+- `success_criteria` — criteria with weights (all weights sum to 1.0)
+- `competitor_results` — list of competitors with their result paths and worktree paths
+- `output_path` — where to write your JudgmentResult
+
+## Evaluation Steps
+
+### Step 1: Read All ImplementationResults
+
+Read each competitor's ImplementationResult JSON. Understand:
+- What approach each competitor took
+- What their test results show
+- How they assessed themselves against the criteria
+
+### Step 2: Form Independent Scores
+
+For EACH competitor, score EACH criterion independently. Do NOT anchor to the competitor's
+self-assessment — treat it as one data point, not a ground truth.
+
+**Scoring guidance:**
+- 9-10: Exceptional. This aspect is better than most production code you'd encounter.
+- 7-8: Good. Clearly correct, no significant concerns.
+- 5-6: Adequate. Works, but has notable weaknesses worth documenting.
+- 3-4: Poor. Significant deficiencies that affect real use.
+- 1-2: Failing. Does not meet the criterion at a basic level.
+
+Use concrete evidence for each score. Do not use vague statements like "code is readable."
+Instead: "competitor-1's function names are clear (e.g., `validate_and_normalize_input`)
+and functions average 10 lines with single responsibilities — 8/10."
+
+### Step 3: Inspect Code If Needed
+
+If self-reported results are insufficient to distinguish approaches — or if you suspect a
+self-assessment is inaccurate — read specific files from the competitor's worktree:
+
+```
+Read({worktree_path}/{file})
+```
+
+Document which files you inspected in `code_inspected`. Only inspect code when it adds
+meaningful signal to the judgment.
+
+### Step 4: Compute Weighted Totals
+
+For each competitor, compute:
+```
+weighted_total = sum(score_i * weight_i for each criterion i)
+```
+
+The competitor with the highest weighted total is the winner, unless the hybrid analysis
+(Step 5) identifies a clearly superior combination.
+
+### Step 5: Consider Hybrid
+
+Ask yourself: "Is there a combination of elements from multiple competitors that would be
+strictly better than either alone?" This is NOT about splitting the difference — it is
+about identifying cases where one competitor's approach to a specific problem is clearly
+superior and can be cleanly combined with another's overall structure.
+
+Set `hybrid_recommended: true` ONLY when:
+1. The hybrid combination would score meaningfully higher than any single competitor
+2. The elements to combine are specific and actionable (not vague)
+3. A synthesis agent could implement the combination from your description alone
+
+If in doubt, choose the winner and leave `hybrid_recommended: false`. Hybrid paths add
+cost and complexity — recommend them only when the improvement is clear.
+
+### Step 6: Write Your JudgmentResult
+
+Write the `JudgmentResult` JSON to `output_path` from the request. Include ALL required
+fields (see `references/communication-schema.md`).
+
+Then send a message to the lead:
+
+```
+SendMessage(to="team-lead", content=JSON.stringify({
+  "schema": "JudgmentResult",
+  "winner": "competitor-N",
+  "scoring_matrix": [...],
+  "rationale": "...",
+  "code_inspected": [...],
+  "hybrid_recommended": false,
+  "hybrid_elements": []
+}))
+```
+
+## Important Rules
+
+- Your scores are independent of competitor self-assessments. Disagreement is expected.
+- Every criterion must be scored for every competitor. Missing scores are incomplete.
+- `rationale` must explain the winner selection, not just describe all competitors.
+- If `hybrid_recommended` is true, `hybrid_elements` must be specific enough for a
+  synthesis agent to act on them without access to your reasoning — include the source
+  competitor and a precise description of what to take from them.
+- Do not declare a hybrid winner without also naming what the base structure comes from
+  (which competitor's overall structure is preserved, with which elements added from others).
+```

--- a/code-quality/skills/speculative/references/communication-schema.md
+++ b/code-quality/skills/speculative/references/communication-schema.md
@@ -1,0 +1,192 @@
+# Communication Schema
+
+This file contains all JSON schemas for inter-agent communication within the `/speculative` skill.
+Every message passed between agents via `SendMessage` and every file written to the audit trail
+follows one of these schemas. The Lead uses these schemas to construct outgoing context and to
+validate incoming results.
+
+---
+
+## Context Bundle
+
+Every agent receives this bundle when spawned. The Lead constructs it in Phase 0.
+
+```json
+{
+  "project": "string — project name from repo root",
+  "task": "string — original user task description, verbatim",
+  "branch": "string — current git branch name",
+  "run_dir": "string — absolute or repo-relative path to hack/speculative/YYYY-MM-DD",
+  "tool_guard": "Use Read/Write/Edit/Glob/Grep/Bash for file ops. No raw shell for file reads."
+}
+```
+
+---
+
+## SpeculativeSpec (Lead → Competitor)
+
+Sent by the Lead to assign a problem to a competitor agent. Each competitor receives the same
+problem and criteria but may receive a different `approach_hint`.
+
+```json
+{
+  "schema": "SpeculativeSpec",
+  "problem": "string — what to implement, with full context",
+  "success_criteria": [
+    {
+      "criterion": "string — e.g. 'Correctness', 'Readability', 'Performance'",
+      "weight": "number 0-1 — relative importance (all weights must sum to 1.0)",
+      "description": "string — what 'success' means for this criterion"
+    }
+  ],
+  "approach_hint": "string | null — specific approach for this competitor to try, or null to let the competitor choose",
+  "competitor_id": "string — unique identifier, e.g. 'competitor-1'",
+  "worktree_path": "string — absolute path to this competitor's git worktree",
+  "output_path": "string — absolute path where competitor must write its ImplementationResult JSON",
+  "context": {
+    "project": "string",
+    "task": "string",
+    "branch": "string",
+    "run_dir": "string",
+    "tool_guard": "string"
+  }
+}
+```
+
+**Notes:**
+- If `approach_hint` is null, the competitor is free to choose any valid approach.
+- `worktree_path` is the competitor's isolated working directory — all file changes go here.
+- `output_path` is where the competitor writes its `ImplementationResult` JSON before signaling completion.
+
+---
+
+## ImplementationResult (Competitor → Lead)
+
+Written by the competitor to `{run_dir}/implementations/competitor-{id}.json` and sent as a
+SendMessage summary to the Lead when implementation is complete.
+
+```json
+{
+  "schema": "ImplementationResult",
+  "competitor_id": "string — matches the SpeculativeSpec competitor_id",
+  "status": "complete | partial | failed",
+  "approach": "string — clear description of the approach taken and the key design decisions",
+  "files_created": ["string — paths of newly created files (relative to worktree root)"],
+  "files_modified": ["string — paths of files modified (relative to worktree root)"],
+  "test_results": {
+    "tests_run": "integer — total test cases executed",
+    "tests_passed": "integer",
+    "tests_failed": "integer",
+    "command": "string — exact command used to run tests"
+  },
+  "self_assessment": [
+    {
+      "criterion": "string — must match a criterion from SpeculativeSpec.success_criteria",
+      "score": "number 1-10 — honest self-assessment (not inflated)",
+      "rationale": "string — specific reasoning for this score, not generic praise"
+    }
+  ],
+  "trade_offs": "string — what this approach gives up (be honest — judges penalize inflated self-reports)",
+  "failure_reason": "string | null — if status is 'failed', why it failed",
+  "turn_count": "integer — number of tool-call rounds completed since spawning"
+}
+```
+
+**Notes:**
+- `self_assessment` must cover EVERY criterion in the SpeculativeSpec. Missing criteria will
+  be flagged by the lead and the judge.
+- `trade_offs` is required. Approaches with no stated trade-offs will be treated as incomplete
+  self-assessments by the judge.
+- If `status` is `partial`, the competitor must describe what was completed and what was not
+  in the `approach` field.
+
+---
+
+## JudgmentRequest (Lead → Judge)
+
+Sent by the Lead to the judge agent with all competitor results and the original spec.
+
+```json
+{
+  "schema": "JudgmentRequest",
+  "problem": "string — original problem statement",
+  "success_criteria": [
+    {
+      "criterion": "string",
+      "weight": "number 0-1",
+      "description": "string"
+    }
+  ],
+  "competitor_results": [
+    {
+      "competitor_id": "string",
+      "worktree_path": "string — path to this competitor's worktree for code inspection",
+      "result_path": "string — path to this competitor's ImplementationResult JSON"
+    }
+  ],
+  "output_path": "string — where to write JudgmentResult JSON"
+}
+```
+
+---
+
+## JudgmentResult (Judge → Lead)
+
+Written by the judge to `{run_dir}/judgment.json` and sent as a SendMessage summary to the Lead.
+
+```json
+{
+  "schema": "JudgmentResult",
+  "winner": "string — competitor_id of the best implementation, OR 'hybrid' if combining is recommended",
+  "scoring_matrix": [
+    {
+      "competitor_id": "string",
+      "scores": [
+        {
+          "criterion": "string — matches success_criteria criterion name",
+          "score": "number 1-10 — judge's independent assessment",
+          "rationale": "string — specific evidence from the implementation"
+        }
+      ],
+      "weighted_total": "number — sum of (score * weight) across all criteria"
+    }
+  ],
+  "rationale": "string — narrative explanation of why the winner was chosen over alternatives",
+  "code_inspected": ["string — worktree paths/files the judge read directly (empty if none)"],
+  "hybrid_recommended": "boolean — true if combining elements from multiple competitors would be better than either alone",
+  "hybrid_elements": [
+    "string — specific element to combine, with source (e.g., 'competitor-1 error handling approach: its use of Result types prevents unchecked exceptions')"
+  ]
+}
+```
+
+**Notes:**
+- `winner` must be a valid `competitor_id` from the JudgmentRequest, OR the string `"hybrid"`.
+- If `winner` is `"hybrid"`, `hybrid_recommended` must be `true` and `hybrid_elements` must
+  be non-empty with specific, actionable descriptions.
+- `hybrid_elements` entries must name the source competitor and describe the specific element
+  precisely enough for a synthesis agent to implement it without seeing the original code.
+- The judge's `scores` are independent of the competitors' self-assessments. Disagreement is
+  expected — the judge has full context that competitors did not.
+
+---
+
+## Audit Trail Directory Structure
+
+All speculative run artifacts are written under a date-scoped directory. Multiple runs on the
+same date append a sequence number.
+
+```
+hack/speculative/
+└── YYYY-MM-DD/                    # or YYYY-MM-DD-2, YYYY-MM-DD-3 for multiple runs
+    ├── implementations/
+    │   ├── competitor-1.json          # competitor-1's ImplementationResult
+    │   ├── competitor-2.json          # competitor-2's ImplementationResult
+    │   └── competitor-N.json          # (up to competitor-4)
+    ├── judgment.json                  # Judge's JudgmentResult
+    └── speculative-report.md          # Human-readable completion report
+```
+
+The Lead resolves `{run_dir}` once in Phase 0 and passes it to all agents in their context
+bundle. Agents write directly to their assigned `output_path` without needing to resolve the
+date themselves.

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -168,6 +168,10 @@ If the user picks one approach directly, skip /speculative and continue to Phase
 **Scope:** Only the contested component(s) go through the speculative fork. Uncontested
 components proceed directly to Phase 3 without waiting (if pipeline-feasible).
 
+**Watchdog:** CronDelete the Phase 2.7 watchdog after all competitors complete (or are timed
+out/failed) and before merging the winning approach back into architect-plan.json. Delete on
+all paths including abort — never leave orphaned cron jobs at phase boundaries.
+
 **Escalation:** If the judge recommends hybrid AND the Lead agrees it's genuinely better,
 run Phase 3.5 of the speculative skill (synthesis agent) before continuing to swarm Phase 3.
 Note it in the audit trail.
@@ -249,7 +253,7 @@ and are written to `{run_dir}/reviews/structural-concurrency.json` and
 `{run_dir}/reviews/structural-integration.json`.
 
 **Routing:**
-- Critical/High STRUCT findings follow tuix's escalation routing rules (same as Phase 4)
+- Critical/High STRUCT findings follow the Phase 4 escalation routing rules
 - STRUCT escalations count toward the cumulative `design_escalation_count` cap (max 2 total
   re-implementations before human escalation)
 - STRUCT escalation events are logged to `{run_dir}/escalations.json`

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -490,7 +490,7 @@ After escalation, wait for user input before proceeding.
 | Code-Simplifier | Fixer made no changes in Phase 5 |
 | Phase 6: Docs | Purely internal refactor with no public API or documented behavior changes |
 | /unfuck sweep | Fewer than 20 files modified and not an architectural change |
-| NEVER SKIP | Phases 0, 1, 2, core Phase 3 (Implementer + Reviewer), Phase 7 (Verifier) |
+| NEVER SKIP | Phases 0, 1, 2, core Phase 3 (Implementer + Reviewer), Phase 4, Phase 4.5, Phase 7 (Verifier) |
 
 ---
 

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -9,8 +9,8 @@ description: >-
   checkpoint. Use when asked to "swarm this", "full team", "agent team",
   "full send", or when maximum rigor is needed on an implementation task.
   Auto-detects optional domain reviewers (UI, API, DB) from codebase analysis.
-allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, TeamCreate, TeamDelete,
-  SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, TeamCreate, TeamDelete,
+  SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, CronCreate, CronDelete, Skill]
 ---
 
 # /swarm — Full Agent Swarm Implementation

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -31,6 +31,8 @@ specialist agent.
 | 0 | Lead (YOU) | — | — | No | Orchestration, routing, judgment |
 | 2 | Architect | code-quality:architect | opus | No | Design, decomposition, risk analysis |
 | 2.5 | Security Design | code-quality:security | opus | No | Pre-implementation threat surface review |
+| 2.7 | Speculative Competitors (×N) | general-purpose | sonnet | Yes | Competing implementations in isolated worktrees (conditional) |
+| 2.7 | Speculative Judge | general-purpose | opus | No | Evaluate competitors, select winner (conditional) |
 | 3 | Implementer | general-purpose | sonnet | Yes | Write code, component by component |
 | 3 | Reviewer | general-purpose | opus | No | Review each component before testing |
 | 3 | Test-Writer | general-purpose | sonnet | Yes | Write tests for reviewed components |
@@ -39,6 +41,7 @@ specialist agent.
 | 4 | QA | code-quality:qa | opus | No | Patterns, conventions, code quality |
 | 4 | Code-Reviewer | superpowers:code-reviewer | sonnet | No | Broader review, complements QA |
 | 4 | Performance | code-quality:performance | sonnet | No | Bottlenecks, N+1, memory issues |
+| 4.5 | Structural Analyst (×2) | general-purpose | opus | No | Adversarial structural design review |
 | 5 | Fixer | general-purpose | sonnet | Yes | Address critical/high review findings |
 | 5 | Code-Simplifier | code-simplifier:code-simplifier | sonnet | Yes | Post-fix simplification pass |
 | 6 | Docs | general-purpose | haiku | Yes | Update repo docs and hack/ memory |
@@ -138,18 +141,54 @@ Output: SecurityDesignReview JSON written to `{run_dir}/security-design-review.j
 - If 2 iterations exhausted with unresolved Critical findings → Escalate to human via
   AskUserQuestion.
 
+### Phase 2.7: Speculative Fork (conditional)
+
+Skip this phase unless the architect's plan signals genuine implementation uncertainty — multiple
+viable approaches with real trade-offs where "try both and compare" beats guessing. The trigger
+is the architect explicitly flagging `speculative_fork_recommended: true` in
+`architect-plan.json`, OR the Lead identifying 2+ incompatible design choices in the plan that
+would significantly affect outcomes.
+
+When triggered, invoke the `/speculative` skill as a sub-orchestration for the contested
+component(s) only. The swarm Lead acts as the speculative orchestrator:
+
+1. Extract the contested component(s) from `architect-plan.json`
+2. Define evaluation criteria based on the architect's stated trade-offs
+3. Run `/speculative` Phases 1–3 (competitors fork in isolated worktrees, judge selects winner)
+4. The winning approach is written back into `architect-plan.json` as the implementation spec
+   for that component, replacing the ambiguous description
+5. Proceed to Phase 3 with the now-resolved plan
+
+**Scope:** Only the contested component(s) go through the speculative fork. Uncontested
+components proceed directly to Phase 3 without waiting (if pipeline-feasible).
+
+**Escalation:** If the judge recommends hybrid AND the Lead agrees it's genuinely better,
+run Phase 3.5 of the speculative skill (synthesis agent) before continuing to swarm Phase 3.
+Note it in the audit trail.
+
+When the architect classifies the domain as Complex AND competing approaches exist, proactively recommend /speculative even if `speculative_fork_recommended` is not explicitly set — Complex-domain tasks benefit most from speculative execution.
+
+**Never trigger Phase 2.7 for:**
+- Clear-domain tasks where the architect chose one approach without hesitation
+- Tasks with a single component and no stated approach trade-offs
+- Tasks where the user specified an explicit implementation approach in Phase 1
+
 ### Phase 3: Pipelined Implementation
 
-Spawn the full pipeline team at once: Implementer, Reviewer, Test-Writer, and Test-Runner. The
-Lead routes work through the pipeline using structured JSON messages — components flow from
-Implementer to Reviewer to Test-Writer to Test-Runner, with the Implementer moving to the next
-component while earlier ones advance through the pipeline. Each handoff uses a typed JSON message
-(see `references/communication-schema.md`). If the Reviewer rejects a component, the Lead routes
-specific feedback back to the Implementer for targeted fixes and re-submission (max 3 iterations
-per component). If Test-Runner reports failures, the Lead routes the failure details back to the
-Implementer for fixes, then re-submits through Review and Test stages. See
-`references/pipeline-model.md` for full parallelism rules, backpressure handling, and fallback
-to sequential mode.
+Before spawning pipeline agents, the Lead creates a CronCreate watchdog (60-second interval) to
+monitor agent idle status. The watchdog reports to the Lead — it never intervenes directly. The
+Lead then spawns the full pipeline team at once: Implementer, Reviewer, Test-Writer, and
+Test-Runner. The Lead routes work through the pipeline using structured JSON messages — components
+flow from Implementer to Reviewer to Test-Writer to Test-Runner, with the Implementer moving to
+the next component while earlier ones advance through the pipeline. Each agent sends a
+ContextAcknowledgment immediately upon receiving an assignment (see
+`references/communication-schema.md`). Each handoff uses a typed JSON message. If the Reviewer
+rejects a component, the Lead routes specific feedback back to the Implementer for targeted fixes
+and re-submission (max 3 iterations per component). If Test-Runner reports failures, the Lead
+routes the failure details back to the Implementer for fixes, then re-submits through Review and
+Test stages. The watchdog is torn down (CronDelete) when Phase 3 completes or on any abort path.
+See `references/pipeline-model.md` for full parallelism rules, backpressure handling, and
+fallback to sequential mode.
 
 ### Phase 4: Parallel Review
 
@@ -178,11 +217,42 @@ findings, escalate to the human via AskUserQuestion rather than re-running again
 Phase 3 re-implementations at 2 regardless of escalation type.
 
 All escalation events are recorded in `{run_dir}/escalations.json`
-(see schema in `references/orchestration-playbook.md` Step 4.5).
+(see schema in `references/communication-schema.md` under "Escalation Events Schema").
+
+### Phase 4.5: Structural Design Review
+
+This phase always runs after Phase 4 escalation routing completes. It is not conditional on
+whether Phase 4 found issues — it is a mandatory adversarial pass that reviews the full
+implementation as a system.
+
+Spawn 2 adversarial structural analysts simultaneously (both `general-purpose`, opus model):
+
+- **Analyst 1: Concurrency & State** — race conditions, state management gaps, error propagation
+  across component boundaries, dependency ordering issues, shared mutable state
+- **Analyst 2: Integration & Contract** — API contract violations, cross-component assumptions,
+  data flow integrity, failure cascading between components, contract drift from architect plan
+
+Both analysts review the entire implementation as a system, not file-by-file. They look for
+structural problems that emerge from the *combination* of components, not issues within a single
+component (those are covered by Phase 4 reviewers).
+
+Findings use the existing `ReviewFindings` schema with the `STRUCT` prefix (STRUCT-001, etc.)
+and are written to `{run_dir}/reviews/structural-concurrency.json` and
+`{run_dir}/reviews/structural-integration.json`.
+
+**Routing:**
+- Critical/High STRUCT findings follow tuix's escalation routing rules (same as Phase 4)
+- STRUCT escalations count toward the cumulative `design_escalation_count` cap (max 2 total
+  re-implementations before human escalation)
+- STRUCT escalation events are logged to `{run_dir}/escalations.json`
+
+If Phase 4 escalation routing triggers a return to Phase 2, Phase 4.5 runs on the re-implemented version after the next Phase 4 completes — not on the current (superseded) implementation.
+
+Phase 5 receives findings from both Phase 4 AND Phase 4.5 in its consolidated findings list.
 
 ### Phase 5: Fix & Simplify (conditional)
 
-Skip this phase if ALL reviews report clean (zero critical or high findings). Otherwise, spawn
+Skip this phase if ALL reviews (Phases 4 and 4.5) report clean (zero critical or high findings). Otherwise, spawn
 the Fixer with the consolidated critical/high findings and full context of the implementation.
 The Fixer addresses each finding with targeted, minimal changes. After the Fixer completes,
 check its output for `deferred` items — findings it couldn't resolve. For each deferred item:
@@ -266,6 +336,16 @@ Phase 2.5: Security Design Review (conditional, opus)
   +-- Unresolved Critical after 2 iterations --> AskUserQuestion
      |
      v
+Phase 2.7: Speculative Fork (conditional)
+  +-- Triggered by speculative_fork_recommended: true in architect-plan.json
+  +-- OR Lead identifies 2+ incompatible design choices with real trade-offs
+  +-- Spawn N competitors (sonnet, isolated worktrees) for contested components
+  +-- CronCreate watchdog (60s interval)
+  +-- Spawn judge (opus) --> JudgmentResult selects winner
+  +-- Winning approach written back into architect-plan.json
+  +-- (optional) Phase 3.5 synthesis if hybrid recommended and approved
+     |
+     v
 Phase 3: Pipelined Implementation
   +-------------------------------------------------------+
   | Implementer --> Reviewer --> Test-Writer --> Test-Runner |
@@ -283,7 +363,12 @@ Phase 4: Parallel Review
   +-- Optional: UI / API / DB reviewers -------------+
      |
      v
-Phase 5: Fix & Simplify (if findings exist)
+Phase 4.5: Structural Design Review (always runs)
+  +-- Analyst 1: Concurrency & State (opus) ---------+
+  +-- Analyst 2: Integration & Contract (opus) -------+--> Lead merges STRUCT findings
+     |
+     v
+Phase 5: Fix & Simplify (if Phase 4 or 4.5 findings exist)
   +-- Fixer: critical/high findings
   +-- Code-Simplifier: post-fix pass
      |
@@ -331,6 +416,14 @@ blocker or a pre-existing issue. Lean toward escalation for ambiguous decisions.
 Monitor the pipeline flow actively. Route handoff messages between agents using the schemas in
 `references/communication-schema.md`. Detect backpressure (see `references/pipeline-model.md`)
 and throttle the Implementer when the Reviewer queue is full.
+
+### Watchdog Monitoring
+
+Create a CronCreate watchdog (60-second interval) in Phase 3 Step 3.0 before spawning pipeline
+agents. On each tick, check `TaskList` for `in_progress` tasks and cross-reference with agent
+message timestamps. If any agent has been idle for 2+ consecutive checks, alert yourself and
+trigger Silent Failure Detection (Step 3.6). Always CronDelete the watchdog when Phase 3 ends
+or on any abort path — do not leave orphaned cron jobs.
 
 ### Context Health Monitoring
 
@@ -382,9 +475,10 @@ After escalation, wait for user input before proceeding.
 | Phase / Agent | Skip When |
 |---------------|-----------|
 | Phase 2.5: Security Design Review | Config-only, docs-only, or test-only changes that don't touch auth/data/network/API surfaces. Clear-domain tasks without auth/data/network/API involvement. |
+| Phase 2.7: Speculative Fork | Architect did NOT flag `speculative_fork_recommended: true` AND Lead does not identify 2+ incompatible approach choices. Skip for single-component tasks and tasks where the user specified an approach. |
 | Test-Writer | `--skip-tests` flag provided, or changes are purely config/docs with no logic |
 | Domain Reviewers (UI/API/DB) | Not auto-detected from codebase analysis |
-| Phase 5: Fix | ALL review agents report zero critical or high findings |
+| Phase 5: Fix | ALL Phase 4 AND Phase 4.5 review agents report zero critical or high findings |
 | Code-Simplifier | Fixer made no changes in Phase 5 |
 | Phase 6: Docs | Purely internal refactor with no public API or documented behavior changes |
 | /unfuck sweep | Fewer than 20 files modified and not an architectural change |
@@ -408,6 +502,9 @@ specific skills directly.
 | Codebase-wide cleanup | `/unfuck` |
 | Security audit only | `code-quality:security` directly |
 | Test coverage only | `dev-essentials:test-runner` directly |
+| Codebase-wide analysis or bulk transformation (20+ files) | `/map-reduce` |
+| Multiple viable approaches, need to compare | `/speculative` |
+| Architectural analysis (cross-cutting concerns) | Single agent (NOT /map-reduce) |
 
 ### Model Cost Hierarchy
 

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   checkpoint. Use when asked to "swarm this", "full team", "agent team",
   "full send", or when maximum rigor is needed on an implementation task.
   Auto-detects optional domain reviewers (UI, API, DB) from codebase analysis.
-allowed-tools: [Read, Write, Edit, Glob, Grep, Task, Bash, AskUserQuestion, TeamCreate, TeamDelete,
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, TeamCreate, TeamDelete,
   SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, Skill]
 ---
 
@@ -149,15 +149,21 @@ is the architect explicitly flagging `speculative_fork_recommended: true` in
 `architect-plan.json`, OR the Lead identifying 2+ incompatible design choices in the plan that
 would significantly affect outcomes.
 
-When triggered, invoke the `/speculative` skill as a sub-orchestration for the contested
-component(s) only. The swarm Lead acts as the speculative orchestrator:
+When triggered, the Lead presents the competing approaches to the user via `AskUserQuestion`:
+"The architect identified N competing approaches for [component] (all vetted by security review).
+Want to run /speculative to compare them, or pick one directly?"
+
+If the user chooses `/speculative`, the Lead acts as the speculative orchestrator:
 
 1. Extract the contested component(s) from `architect-plan.json`
 2. Define evaluation criteria based on the architect's stated trade-offs
-3. Run `/speculative` Phases 1–3 (competitors fork in isolated worktrees, judge selects winner)
+3. Run `/speculative` Phases 1–3 (competitors fork in isolated worktrees, judge evaluates,
+   winning approach merged back)
 4. The winning approach is written back into `architect-plan.json` as the implementation spec
    for that component, replacing the ambiguous description
 5. Proceed to Phase 3 with the now-resolved plan
+
+If the user picks one approach directly, skip /speculative and continue to Phase 3 as normal.
 
 **Scope:** Only the contested component(s) go through the speculative fork. Uncontested
 components proceed directly to Phase 3 without waiting (if pipeline-feasible).
@@ -166,7 +172,9 @@ components proceed directly to Phase 3 without waiting (if pipeline-feasible).
 run Phase 3.5 of the speculative skill (synthesis agent) before continuing to swarm Phase 3.
 Note it in the audit trail.
 
-When the architect classifies the domain as Complex AND competing approaches exist, proactively recommend /speculative even if `speculative_fork_recommended` is not explicitly set — Complex-domain tasks benefit most from speculative execution.
+When the architect classifies the domain as Complex AND competing approaches exist,
+proactively recommend /speculative even if `speculative_fork_recommended` is not explicitly
+set — Complex-domain tasks benefit most from speculative execution.
 
 **Never trigger Phase 2.7 for:**
 - Clear-domain tasks where the architect chose one approach without hesitation

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -186,10 +186,19 @@ Write your plan to `{run_dir}/architect-plan.json` using the Architect Plan Sche
 `testing_strategy`, `risks`, `estimated_complexity`), `component_dependency_graph`,
 `pipeline_feasible`, `pipeline_notes`, `global_risks`, `data_model_changes`, `api_changes`.
 
-Additionally include this field for lead routing:
+Additionally include these fields for lead routing:
 - `questions`: array of strings — any open questions that need user input before implementation
+- `speculative_fork_recommended`: boolean (optional) — set to `true` if you identify multiple
+  genuinely viable implementation approaches for one or more components where the trade-offs
+  are significant and "try both and compare" would produce a meaningfully better outcome than
+  choosing one approach up front. Do NOT set this for stylistic preferences or trivial choices.
+- `speculative_components`: array of component IDs (required if `speculative_fork_recommended`
+  is true) — list only the component(s) that are genuinely contested. Do NOT include components
+  where the approach is clear.
 
 If `questions` is non-empty, the lead will present these to the user before implementation begins.
+If `speculative_fork_recommended` is true, the lead will run Phase 2.7 (speculative fork) for
+the specified components before proceeding to Phase 3.
 
 ## Communication
 
@@ -202,7 +211,8 @@ SendMessage(type="message", recipient="team-lead",
           "Components: N\n"
           "Pipeline feasible: yes/no\n\n"
           "Risks: [list any non-empty risks]\n"
-          "Questions for user: [list any questions]",
+          "Questions for user: [list any questions]\n"
+          "Speculative fork recommended: yes/no — [if yes: list contested component IDs]",
   summary="Architect: {domain}, N components, plan written")
 ```
 
@@ -264,6 +274,27 @@ about the security implications of the architecture, not about any specific code
 You have access to: Read, Glob, Grep.
 You do NOT modify any files except to write your output.
 You do NOT review implementation code (none exists yet at this phase).
+
+## Acknowledgment Protocol
+
+**IMMEDIATELY upon being spawned**, before reading any files, send a `ContextAcknowledgment`
+to the lead confirming you have received your assignment:
+
+```
+SendMessage(type="message", recipient="team-lead",
+  content='{
+    "schema": "ContextAcknowledgment",
+    "component_id": "security-design-review",
+    "agent_role": "security-design-reviewer",
+    "received": true,
+    "ready": true,
+    "clarifications_needed": []
+  }',
+  summary="Security Design Reviewer: ack — starting threat model")
+```
+
+If the scope of the review is unclear from the plan, include questions in `clarifications_needed`
+and wait for the lead to answer before proceeding with your analysis.
 
 ## Input
 
@@ -377,6 +408,28 @@ You have access to: Read, Write, Edit, Glob, Grep, Bash, LSP tools.
 You do NOT write tests (test-writer handles that).
 You do NOT commit code (the lead commits after test-runner confirms success).
 You do NOT write documentation (docs agent handles that).
+
+## Acknowledgment Protocol
+
+**IMMEDIATELY upon receiving a ComponentAssignment**, before doing any work, send a
+`ContextAcknowledgment` to the lead:
+
+```
+SendMessage(type="message", recipient="team-lead",
+  content='{
+    "schema": "ContextAcknowledgment",
+    "component_id": "<component_id from assignment>",
+    "agent_role": "implementer",
+    "received": true,
+    "ready": true,
+    "clarifications_needed": []
+  }',
+  summary="Implementer: ack <component_id>")
+```
+
+If you have questions or ambiguities about the assignment, list them in `clarifications_needed`
+and wait for the lead to answer before starting work. Do NOT start working until the lead
+responds to your clarifications (or `clarifications_needed` is empty).
 
 ## Pipeline Protocol
 
@@ -529,6 +582,27 @@ For each component, check:
 - Patterns that are unusual but work correctly
 - Anything that would be better handled in a separate refactor
 
+## Acknowledgment Protocol
+
+**IMMEDIATELY upon receiving a ComponentHandoff for review**, before reading any files, send a
+`ContextAcknowledgment` to the lead:
+
+```
+SendMessage(type="message", recipient="team-lead",
+  content='{
+    "schema": "ContextAcknowledgment",
+    "component_id": "<component_id from handoff>",
+    "agent_role": "reviewer",
+    "received": true,
+    "ready": true,
+    "clarifications_needed": []
+  }',
+  summary="Reviewer: ack <component_id>")
+```
+
+If anything about the component scope is ambiguous, list it in `clarifications_needed` and wait
+for the lead's response before beginning your review.
+
 ## Pipeline Protocol
 
 You receive a ComponentHandoff from the lead. Review the implementation, then send a ReviewResult.
@@ -610,6 +684,27 @@ coverage padding.
 
 You have access to: Read, Write, Edit, Glob, Grep, Bash (for reading test output, not running full suites).
 You do NOT run the test suite — test-runner handles that.
+
+## Acknowledgment Protocol
+
+**IMMEDIATELY upon receiving a TestRequest**, before reading any files, send a
+`ContextAcknowledgment` to the lead:
+
+```
+SendMessage(type="message", recipient="team-lead",
+  content='{
+    "schema": "ContextAcknowledgment",
+    "component_id": "<component_id from TestRequest>",
+    "agent_role": "test-writer",
+    "received": true,
+    "ready": true,
+    "clarifications_needed": []
+  }',
+  summary="Test-Writer: ack <component_id>")
+```
+
+If the testing strategy is unclear or you need clarification about test scope, list it in
+`clarifications_needed` and wait for the lead before writing any tests.
 
 ## Pipeline Protocol
 
@@ -1128,6 +1223,189 @@ Category values: `n-plus-one`, `unbounded-collection`, `memory`, `io-pattern`,
 `algorithm`, `resource-leak`.
 
 Send summary to lead when complete.
+```
+
+---
+
+## Agent 9.5a: Structural Analyst — Concurrency & State (Phase 4.5)
+
+**Type:** `general-purpose` | **Model:** opus | **Mode:** default (read-only)
+
+> **DISTINCT FROM Phase 4 reviewers.** Phase 4 reviewers assess individual components file-by-file.
+> This analyst reviews the full implementation as a system, looking for problems that emerge from
+> the *combination* and *interaction* of components.
+
+```markdown
+# Structural Analyst: Concurrency & State — Swarm Phase 4.5 Agent
+
+{context_bundle}
+
+## Your Role
+
+You are a Structural Analyst (Concurrency & State). You review the complete implementation as
+an integrated system, looking for structural defects in concurrency, state management, error
+propagation, and dependency ordering. You do NOT review individual files for code quality —
+that is the Phase 4 reviewers' job. You look for problems that only appear when you reason
+about all components together.
+
+You have access to: Read, Glob, Grep, LSP tools.
+You do NOT modify any code.
+
+## Files to Review
+
+Review ALL files modified or created during this swarm:
+{files_modified_list}
+
+Read them all before forming conclusions — structural issues span multiple files.
+
+## Analysis Focus
+
+### 1. Race Conditions
+- Shared mutable state accessed from multiple concurrent paths without synchronization
+- Read-modify-write cycles that are not atomic
+- Caches or singletons initialized lazily without thread safety
+- Event handlers or callbacks that can fire concurrently with mutation
+
+### 2. State Management Gaps
+- State that must be kept consistent across components but has no enforcement mechanism
+- State that is duplicated in multiple components — which is authoritative?
+- Missing state transitions: are all valid states reachable? Are invalid states preventable?
+- State that leaks across request boundaries (request-scoped data stored in module-level vars)
+
+### 3. Error Propagation
+- Errors swallowed in one component that should propagate to callers
+- Error recovery in one component that leaves other components in an inconsistent state
+- Missing cleanup when an operation partially succeeds across multiple components
+- Retry logic in one component that can cause duplicate side effects in another
+
+### 4. Dependency Ordering
+- Initialization order assumptions: does Component A assume Component B is initialized first?
+- Shutdown order: does teardown happen in the wrong order, leaving orphaned resources?
+- Circular dependencies that create deadlock risk (A waits for B which waits for A)
+
+## Perspective
+
+You are adversarial. Your job is to probe the system for weaknesses, not to affirm correctness.
+Reason about failure scenarios: What happens if two requests arrive simultaneously? What happens
+if Component A succeeds and Component B fails? What happens if the system restarts mid-operation?
+
+Only flag issues you can substantiate with evidence from the code. Do not speculate without grounding.
+
+## Output Format
+
+Write to `{run_dir}/reviews/structural-concurrency.json` using the `ReviewFindings` schema from
+`references/communication-schema.md`. Use `STRUCT` prefix for all finding IDs (STRUCT-001, etc.).
+Category values: `race-condition`, `state-gap`, `error-propagation`, `dependency-ordering`.
+
+Then send a summary to the lead:
+
+```
+SendMessage(type="message", recipient="team-lead",
+  content="Structural review (Concurrency & State) complete. "
+          "Results: {run_dir}/reviews/structural-concurrency.json\n\n"
+          "Findings: N (N critical, N high, N medium, N low)\n"
+          "[Brief summary of most significant structural issue found, if any]",
+  summary="Structural-Concurrency: N STRUCT findings")
+```
+
+## Boundaries
+
+- Do NOT flag issues that are already covered by Phase 4 reviewers (code-level bugs, injection,
+  naming, performance bottlenecks within a single file)
+- Do NOT propose refactors — describe the structural defect and its risk
+- Do NOT spawn other agents
+```
+
+---
+
+## Agent 9.5b: Structural Analyst — Integration & Contract (Phase 4.5)
+
+**Type:** `general-purpose` | **Model:** opus | **Mode:** default (read-only)
+
+> **DISTINCT FROM Phase 4 reviewers.** Phase 4 reviewers assess individual components file-by-file.
+> This analyst reviews the full implementation as a system, looking for problems that emerge from
+> the *combination* and *interaction* of components.
+
+```markdown
+# Structural Analyst: Integration & Contract — Swarm Phase 4.5 Agent
+
+{context_bundle}
+
+## Your Role
+
+You are a Structural Analyst (Integration & Contract). You review the complete implementation as
+an integrated system, looking for structural defects in API contracts, cross-component assumptions,
+data flow integrity, and failure cascading. You do NOT review individual files for code quality —
+that is the Phase 4 reviewers' job. You look for problems that only appear when you reason
+about all components together.
+
+You have access to: Read, Glob, Grep, LSP tools.
+You do NOT modify any code.
+
+## Files to Review
+
+Review ALL files modified or created during this swarm:
+{files_modified_list}
+
+Also read `{run_dir}/architect-plan.json` to understand the intended contracts between components.
+
+## Analysis Focus
+
+### 1. API Contract Violations
+- Does a component's actual interface match what the architect planned?
+- Does a consumer pass the correct types and values to a component's interface?
+- Does a component return the data its consumers expect (shape, nullability, error types)?
+- Are interface changes backwards-compatible with all known callers?
+
+### 2. Cross-Component Assumptions
+- Does Component A assume Component B will always return in a certain format, when B can return variants?
+- Does a component assume another component's internal state without reading it?
+- Are there hidden coupling points not expressed in the interface (shared global, implicit ordering)?
+
+### 3. Data Flow Integrity
+- Does data transformation happen correctly across component boundaries?
+- Is data validated at the correct boundary, or is invalid data allowed to flow deeper?
+- Are there data encoding/decoding mismatches (e.g., one component produces base64, another expects raw)?
+- Is sensitive data appropriately stripped before crossing trust boundaries?
+
+### 4. Failure Cascading
+- If Component A fails, does it correctly signal failure to components that depend on it?
+- Can a failure in one component leave other components stuck in an indefinite wait?
+- Are there missing circuit breakers or timeouts on cross-component calls?
+- Does a partial failure in one component leave the overall system in a consistent state?
+
+## Perspective
+
+You are adversarial. Your job is to probe the system for weaknesses, not to affirm correctness.
+Reason about the seams between components: Where do they touch? What must each assume about the
+other? What happens when those assumptions are violated?
+
+Only flag issues you can substantiate with evidence from the code. Do not speculate without grounding.
+
+## Output Format
+
+Write to `{run_dir}/reviews/structural-integration.json` using the `ReviewFindings` schema from
+`references/communication-schema.md`. Use `STRUCT` prefix for all finding IDs (STRUCT-001, etc.,
+continuing the sequence from the Concurrency & State analyst if both ran).
+Category values: `contract-violation`, `cross-component-assumption`, `data-flow`, `failure-cascade`.
+
+Then send a summary to the lead:
+
+```
+SendMessage(type="message", recipient="team-lead",
+  content="Structural review (Integration & Contract) complete. "
+          "Results: {run_dir}/reviews/structural-integration.json\n\n"
+          "Findings: N (N critical, N high, N medium, N low)\n"
+          "[Brief summary of most significant structural issue found, if any]",
+  summary="Structural-Integration: N STRUCT findings")
+```
+
+## Boundaries
+
+- Do NOT flag issues that are already covered by Phase 4 reviewers (code-level bugs, injection,
+  naming, performance bottlenecks within a single file)
+- Do NOT propose refactors — describe the structural defect and its risk
+- Do NOT spawn other agents
 ```
 
 ---

--- a/code-quality/skills/swarm/references/communication-schema.md
+++ b/code-quality/skills/swarm/references/communication-schema.md
@@ -70,9 +70,21 @@ reads the file and uses `components` to drive Phase 3 pipeline routing.
   "global_risks": ["string — risks affecting the whole implementation"],
   "data_model_changes": "string | null — description of schema/model changes, or null",
   "api_changes": "string | null — description of public API surface changes, or null",
-  "questions": ["string — open questions requiring user decision before implementation begins"]
+  "questions": ["string — open questions requiring user decision before implementation begins"],
+  "speculative_fork_recommended": "boolean | null — true if the architect identifies multiple viable approaches with real trade-offs for one or more components. Omit or null if not applicable.",
+  "speculative_components": ["string — component IDs the architect recommends for speculative fork (only present when speculative_fork_recommended is true)"],
+  "competing_approaches": [
+    {
+      "approach_id": "string",
+      "description": "string — what this approach does differently",
+      "trade_offs": "string — what it gains and sacrifices",
+      "recommended": "boolean — architect's preference"
+    }
+  ]
 }
 ```
+
+**Note:** `competing_approaches` is optional. When present, each entry provides structured metadata for speculative competitors. `speculative_fork_recommended` is the boolean trigger; `competing_approaches` provides the per-approach detail.
 
 **Note:** If `pipeline_feasible` is `false`, the Lead runs Phase 3 in sequential mode using the
 same agents and protocol — just no parallelism. See `references/pipeline-model.md`.
@@ -128,6 +140,31 @@ Written by the Phase 2.5 security-design agent to `{run_dir}/security-design-rev
 ## Pipeline Handoff Schemas
 
 These schemas cover every message exchanged during Phase 3 pipeline execution.
+
+### ContextAcknowledgment (Agent → Lead)
+
+Sent by a pipeline agent immediately upon receiving a ComponentAssignment. The Lead waits for
+this acknowledgment before marking the component as "in progress." This confirms the agent
+received its assignment and is ready to begin work.
+
+```json
+{
+  "schema": "ContextAcknowledgment",
+  "component_id": "string — matches the assigned component",
+  "agent_role": "string — implementer | reviewer | test-writer",
+  "received": true,
+  "ready": true,
+  "clarifications_needed": ["string — any ambiguities in the assignment (optional, empty if none)"]
+}
+```
+
+**Lead routing:**
+- `clarifications_needed` is empty → mark component as "in progress," agent begins work immediately.
+- `clarifications_needed` is non-empty → Lead answers all clarifications before the agent starts work.
+  Send answers back to the agent via SendMessage before proceeding.
+- No acknowledgment after agent appears idle (2+ minutes with no messages) → Lead re-sends the
+  assignment once. If second attempt also fails, log to `{run_dir}/errors.log` and spawn a
+  replacement agent with the same assignment.
 
 ### ComponentAssignment (Lead → Implementer)
 
@@ -318,6 +355,7 @@ and sends a summary to the Lead.
 | UI Reviewer | UI | UI-001 |
 | API Reviewer | API | API-001 |
 | DB Reviewer | DB | DB-001 |
+| Structural Analyst (Phase 4.5) | STRUCT | STRUCT-001 |
 
 IDs are sequential within each reviewer's output (SEC-001, SEC-002, etc.). The Lead uses these
 IDs when routing findings to the Fixer and when recording disposition in the audit trail.
@@ -558,7 +596,9 @@ hack/swarm/
         ├── performance.json        # Performance reviewer findings (ReviewFindings)
         ├── ui.json                 # UI reviewer findings (if triggered)
         ├── api.json                # API reviewer findings (if triggered)
-        └── db.json                 # DB reviewer findings (if triggered)
+        ├── db.json                 # DB reviewer findings (if triggered)
+        ├── structural-concurrency.json  # Phase 4.5 Concurrency & State analyst findings
+        └── structural-integration.json  # Phase 4.5 Integration & Contract analyst findings
 ```
 
 The Lead resolves `{run_dir}` once in Phase 0 and passes it to all agents in their context

--- a/code-quality/skills/swarm/references/communication-schema.md
+++ b/code-quality/skills/swarm/references/communication-schema.md
@@ -151,7 +151,7 @@ received its assignment and is ready to begin work.
 {
   "schema": "ContextAcknowledgment",
   "component_id": "string — matches the assigned component",
-  "agent_role": "string — implementer | reviewer | test-writer",
+  "agent_role": "string — implementer | reviewer | test-writer | security-design-reviewer",
   "received": true,
   "ready": true,
   "clarifications_needed": ["string — any ambiguities in the assignment (optional, empty if none)"]

--- a/code-quality/skills/swarm/references/cynefin-reference.md
+++ b/code-quality/skills/swarm/references/cynefin-reference.md
@@ -224,9 +224,11 @@ solvable as stated?
 | Phase 1: Clarify & Checkpoint | Yes | Confirm scope is truly bounded. |
 | Phase 2: Architect | Yes | Can be short. Single-pass decomposition. |
 | Phase 2.5: Security Design Review | Optional | Skip unless auth/data/external API is involved. |
+| Phase 2.7: Speculative Fork | Skip | Overhead exceeds value for Clear-domain tasks. |
 | Phase 3: Pipelined Implementation | Yes | Standard pipeline. |
 | Phase 4: Parallel Review | Yes | Standard. |
-| Phase 5: Fix & Simplify | Conditional | Only if Phase 4 finds critical/high issues. |
+| Phase 4.5: Structural Design Review | Yes | Always runs. |
+| Phase 5: Fix & Simplify | Conditional | Only if Phase 4/4.5 finds critical/high issues. |
 | Phase 6: Docs & Memory | Yes | Standard. |
 | Phase 7: Verification & Completion | Yes | Standard. Quality-gate invoked here. |
 
@@ -238,9 +240,11 @@ solvable as stated?
 | Phase 1: Clarify & Checkpoint | Yes | Confirm scope and identify expert needs. |
 | Phase 2: Architect | Yes | Full decomposition with dependency graph. |
 | Phase 2.5: Security Design Review | Conditional | Mandatory if auth/data/external API involved. |
+| Phase 2.7: Speculative Fork | Conditional | Recommended when architect identifies competing approaches. |
 | Phase 3: Pipelined Implementation | Yes | Standard pipeline. Parallel where possible. |
 | Phase 4: Parallel Review | Yes | Standard. May require domain expert reviewer. |
-| Phase 5: Fix & Simplify | Conditional | Only if Phase 4 finds critical/high issues. |
+| Phase 4.5: Structural Design Review | Yes | Always runs. |
+| Phase 5: Fix & Simplify | Conditional | Only if Phase 4/4.5 finds critical/high issues. |
 | Phase 6: Docs & Memory | Yes | Standard. |
 | Phase 7: Verification & Completion | Yes | Standard. Quality-gate invoked here. |
 
@@ -252,9 +256,11 @@ solvable as stated?
 | Phase 1: Clarify & Checkpoint | Yes | Flag complexity. Set probe objectives. |
 | Phase 2: Architect | Yes | Probe design output, not full plan. Define signals. |
 | Phase 2.5: Security Design Review | Yes | Always mandatory for Complex tasks. |
+| Phase 2.7: Speculative Fork | Recommended | Complex-domain tasks benefit most from speculative execution. |
 | Phase 3: Pipelined Implementation | Yes | Smaller components. Explicit checkpoints between. |
 | Phase 4: Parallel Review | Yes | Reviewer assesses probe results, not just correctness. |
-| Phase 5: Fix & Simplify | Conditional | Only if Phase 4 finds critical/high issues. |
+| Phase 4.5: Structural Design Review | Yes | Always runs. Probe results may reveal structural issues. |
+| Phase 5: Fix & Simplify | Conditional | Only if Phase 4/4.5 finds critical/high issues. |
 | Phase 6: Docs & Memory | Yes | Standard. |
 | Phase 7: Verification & Completion | Yes | Quality-gate invoked here. Include re-classification assessment. |
 
@@ -266,8 +272,10 @@ solvable as stated?
 | Phase 1: Clarify & Checkpoint | Yes | Identify stabilization target. |
 | Phase 2: Architect | Yes | Stabilization brief only. No full decomposition. |
 | Phase 2.5: Security Design Review | Deferred | Resume after stabilization. |
+| Phase 2.7: Speculative Fork | Skip | Crisis mode — no time for competing implementations. |
 | Phase 3: Pipelined Implementation | Yes | Single implementer. Stabilization action only. |
 | Phase 4: Parallel Review | Yes | Lightweight. Verify stabilization works. |
+| Phase 4.5: Structural Design Review | Yes | Always runs. Stabilization may introduce structural issues. |
 | Phase 5: Fix & Simplify | Conditional | Standard. |
 | Phase 6: Docs & Memory | Yes | Standard. |
 | Phase 7: Verification & Completion | Yes | Quality-gate invoked here. Must re-classify domain after stabilization. |
@@ -280,7 +288,8 @@ solvable as stated?
 | Phase 1: Clarify & Checkpoint | Yes | Identify what information is missing. |
 | Phase 2: Architect | Yes | Investigation plan, not implementation plan. |
 | Phase 2.5: Security Design Review | Deferred | Re-evaluate after classification. |
-| Phase 3-7 | Conditional | Only after domain is determined. Follow phase map for determined domain. |
+| Phase 2.7: Speculative Fork | Deferred | Re-evaluate after classification. |
+| Phase 3-7 (incl. 4.5) | Conditional | Only after domain is determined. Follow phase map for determined domain. |
 
 ---
 

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -374,7 +374,7 @@ Do NOT interrupt the user for:
 ### Step 2.1: Spawn Architect
 
 ```
-Task(
+Agent(
   name="architect",
   subagent_type="code-quality:architect",
   model="opus",
@@ -480,7 +480,7 @@ If skipping: note the reason in the audit trail and proceed to Phase 3. Do NOT s
 ### Step 2.5.1: Spawn Security Design Agent
 
 ```
-Task(
+Agent(
   name="security-design",
   subagent_type="code-quality:security",
   model="opus",
@@ -644,12 +644,12 @@ Maximum 3 competitors in the swarm context (cost constraint).
 For each contested component, spawn competitor agents simultaneously:
 
 ```
-Task(name="competitor-1", subagent_type="general-purpose", model="sonnet",
+Agent(name="competitor-1", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl", mode="bypassPermissions",
      isolation="worktree",
      prompt="[speculative context bundle]\n\n[competitor prompt — see below]")
 
-Task(name="competitor-2", subagent_type="general-purpose", model="sonnet",
+Agent(name="competitor-2", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl", mode="bypassPermissions",
      isolation="worktree",
      prompt="[speculative context bundle]\n\n[competitor prompt — see below]")
@@ -694,7 +694,7 @@ finished:
 Spawn a single judge agent after all competitors have submitted:
 
 ```
-Task(name="speculative-judge", subagent_type="general-purpose", model="opus",
+Agent(name="speculative-judge", subagent_type="general-purpose", model="opus",
      team_name="swarm-impl",
      prompt="[speculative context bundle]\n\n[judge prompt from speculative skill agent-prompts.md]")
 ```
@@ -812,19 +812,19 @@ components — do NOT shut them down between components. Also spawn the Architec
 (it was already running from Phase 2, remaining on standby).
 
 ```
-Task(name="implementer", subagent_type="general-purpose", model="sonnet",
+Agent(name="implementer", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl", mode="bypassPermissions",
      prompt="[context bundle]\n\n[implementer prompt from agent-prompts.md]")
 
-Task(name="reviewer", subagent_type="general-purpose", model="opus",
+Agent(name="reviewer", subagent_type="general-purpose", model="opus",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[reviewer prompt from agent-prompts.md]")
 
-Task(name="test-writer", subagent_type="general-purpose", model="sonnet",
+Agent(name="test-writer", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl", mode="bypassPermissions",
      prompt="[context bundle]\n\n[test-writer prompt from agent-prompts.md]")
 
-Task(name="test-runner", subagent_type="dev-essentials:test-runner", model="haiku",
+Agent(name="test-runner", subagent_type="dev-essentials:test-runner", model="haiku",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[test-runner prompt from agent-prompts.md]")
 ```
@@ -1002,7 +1002,7 @@ When an agent's `turn_count` exceeds its threshold AND it is between components 
 
 4. **Spawn replacement** with the same name, type, model, and mode:
    ```
-   Task(name="implementer", subagent_type="general-purpose", model="sonnet",
+   Agent(name="implementer", subagent_type="general-purpose", model="sonnet",
         team_name="swarm-impl", mode="bypassPermissions",
         prompt="[context bundle]\n\n[implementer prompt from agent-prompts.md]\n\n"
                "=== CONTINUATION FROM PREVIOUS AGENT ===\n"
@@ -1092,42 +1092,42 @@ Spawn ALL reviewers simultaneously in a SINGLE message. Do not spawn them sequen
 
 **Core reviewers (always spawn):**
 ```
-Task(name="security-reviewer", subagent_type="code-quality:security", model="opus",
+Agent(name="security-reviewer", subagent_type="code-quality:security", model="opus",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[security-reviewer prompt from agent-prompts.md]")
 
-Task(name="qa-reviewer", subagent_type="code-quality:qa", model="opus",
+Agent(name="qa-reviewer", subagent_type="code-quality:qa", model="opus",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[qa-reviewer prompt from agent-prompts.md]")
 
-Task(name="code-reviewer", subagent_type="superpowers:code-reviewer", model="sonnet",
+Agent(name="code-reviewer", subagent_type="superpowers:code-reviewer", model="sonnet",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[code-reviewer prompt from agent-prompts.md]")
 
-Task(name="performance-reviewer", subagent_type="code-quality:performance", model="sonnet",
+Agent(name="performance-reviewer", subagent_type="code-quality:performance", model="sonnet",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[performance-reviewer prompt from agent-prompts.md]")
 ```
 
 **Optional reviewers (spawn if auto-detected or user-requested in Phase 1):**
 ```
-Task(name="ui-reviewer", subagent_type="general-purpose", model="sonnet",
+Agent(name="ui-reviewer", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[ui-reviewer prompt from agent-prompts.md]")
 
-Task(name="api-reviewer", subagent_type="general-purpose", model="sonnet",
+Agent(name="api-reviewer", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[api-reviewer prompt from agent-prompts.md]")
 
-Task(name="db-reviewer", subagent_type="general-purpose", model="sonnet",
+Agent(name="db-reviewer", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[db-reviewer prompt from agent-prompts.md]")
 
-Task(name="plugin-validator", subagent_type="general-purpose", model="sonnet",
+Agent(name="plugin-validator", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[plugin-validator prompt — include plugin validation checklist]")
 
-Task(name="skill-reviewer", subagent_type="general-purpose", model="sonnet",
+Agent(name="skill-reviewer", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[skill-reviewer prompt — include skill validation checklist]")
 ```
@@ -1208,7 +1208,7 @@ If any finding is classified as **design-level** AND `design_escalation_count < 
 3. Shut down all Phase 4 reviewers
 4. Respawn Architect with the findings:
    ```
-   Task(name="architect", subagent_type="code-quality:architect", model="opus",
+   Agent(name="architect", subagent_type="code-quality:architect", model="opus",
         team_name="swarm-impl",
         prompt="[context bundle]\n\n[architect prompt from agent-prompts.md]\n\n"
                "=== DESIGN ESCALATION FROM PHASE 4 ===\n"
@@ -1304,11 +1304,11 @@ that individual file-by-file reviews miss.
 Spawn both analysts simultaneously after Phase 4 escalation routing completes:
 
 ```
-Task(name="structural-concurrency", subagent_type="general-purpose", model="opus",
+Agent(name="structural-concurrency", subagent_type="general-purpose", model="opus",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[structural-concurrency analyst prompt from agent-prompts.md]")
 
-Task(name="structural-integration", subagent_type="general-purpose", model="opus",
+Agent(name="structural-integration", subagent_type="general-purpose", model="opus",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[structural-integration analyst prompt from agent-prompts.md]")
 ```
@@ -1371,7 +1371,7 @@ Phase 5 task as completed with note "No findings — skipped." Proceed to Phase 
 ### Step 5.2: Spawn Fixer
 
 ```
-Task(name="fixer", subagent_type="general-purpose", model="sonnet",
+Agent(name="fixer", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl", mode="bypassPermissions",
      prompt="[context bundle]\n\n[fixer prompt from agent-prompts.md]\n\n"
             "CONSOLIDATED FINDINGS:\n<JSON findings from synthesis>")
@@ -1397,7 +1397,7 @@ If no deferred items exist, skip this step.
 After fixer completes (and deferrals are handled), spawn code-simplifier:
 
 ```
-Task(name="code-simplifier", subagent_type="code-simplifier:code-simplifier", model="sonnet",
+Agent(name="code-simplifier", subagent_type="code-simplifier:code-simplifier", model="sonnet",
      team_name="swarm-impl", mode="bypassPermissions",
      prompt="[context bundle]\n\n[code-simplifier prompt from agent-prompts.md]")
 ```
@@ -1448,7 +1448,7 @@ SendMessage(type="shutdown_request", recipient="code-simplifier", content="Simpl
 ### Step 6.1: Spawn Docs Agent
 
 ```
-Task(name="docs", subagent_type="general-purpose", model="haiku",
+Agent(name="docs", subagent_type="general-purpose", model="haiku",
      team_name="swarm-impl", mode="bypassPermissions",
      prompt="[context bundle]\n\n[docs prompt from agent-prompts.md]\n\n"
             "FILES MODIFIED THIS SWARM:\n<git diff --name-only from branch start>")
@@ -1512,7 +1512,7 @@ SendMessage(type="shutdown_request", recipient="docs", content="Documentation ph
 After Docs agent is shut down, spawn the Lessons Extractor:
 
 ```
-Task(name="lessons-extractor", subagent_type="general-purpose", model="sonnet",
+Agent(name="lessons-extractor", subagent_type="general-purpose", model="sonnet",
      team_name="swarm-impl", mode="bypassPermissions",
      prompt="[context bundle]\n\n[lessons-extractor prompt from agent-prompts.md]\n\n"
             "Run directory: {run_dir}\n"
@@ -1538,7 +1538,7 @@ SendMessage(type="shutdown_request", recipient="lessons-extractor",
 ### Step 7.1: Spawn Verifier
 
 ```
-Task(name="verifier", subagent_type="dev-essentials:test-runner", model="haiku",
+Agent(name="verifier", subagent_type="dev-essentials:test-runner", model="haiku",
      team_name="swarm-impl",
      prompt="[context bundle]\n\n[verifier prompt from agent-prompts.md]\n\n"
             "BASELINE: {baseline from Phase 0.1}")

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -562,6 +562,17 @@ Evaluate whether this phase applies before spawning any agents:
 
 If skipping: note the reason in the audit trail (`.swarm-run` entry) and proceed to Phase 3.
 
+### Step 2.7.0.5: User Checkpoint
+
+Present the competing approaches to the user via `AskUserQuestion`:
+
+"The architect identified N competing approaches for [component(s)] (all vetted by security
+review in Phase 2.5). Want to run /speculative to compare them, or pick one directly?"
+
+- If user chooses `/speculative`: proceed to Step 2.7.1.
+- If user picks one approach directly: update `architect-plan.json` with the chosen approach,
+  skip the rest of Phase 2.7, and proceed to Phase 3.
+
 ### Step 2.7.1: Identify Contested Components
 
 Read `architect-plan.json`. Extract the component(s) that are contested:

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1812,8 +1812,8 @@ TeamCreate:
 
 Only agents that need Write/Edit access use `bypassPermissions`. Read-only agents use default mode.
 
-Maximum agent count: 20 (15 core + 5 optional domain reviewers).
-Minimum agent count: 15 (all domain reviewers skipped).
+Maximum agent count: 22 (17 core + 5 optional domain reviewers).
+Minimum agent count: 17 (all domain reviewers skipped, all conditional phases run).
 
 Agents are spawned and shut down per-phase to manage resource usage. The pipeline team (Phase 3)
 and reviewer team (Phase 4) are never active simultaneously.

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -14,8 +14,10 @@ point is documented here.
 | 1 | Clarify & Checkpoint | Lead direct | None (AskUserQuestion) |
 | 2 | Architect | Single agent | architect (opus) |
 | 2.5 | Security Design Review | Single agent (conditional) | security-design (opus) |
+| 2.7 | Speculative Fork | N competitors + judge (conditional) | competitor-N (sonnet, worktree), judge (opus) |
 | 3 | Pipelined Implementation | Persistent team | implementer, reviewer, test-writer, test-runner |
 | 4 | Parallel Review | All reviewers simultaneously | security, qa, code-reviewer, performance (+ optional) |
+| 4.5 | Structural Design Review | Adversarial pair | structural-concurrency (opus), structural-integration (opus) |
 | 5 | Fix & Simplify | Sequential pair | fixer, code-simplifier |
 | 6 | Docs & Memory | Sequential pair | docs (haiku), then lessons-extractor (sonnet) |
 | 7 | Verification & Completion | Single agent + lead | verifier (haiku) |
@@ -233,8 +235,10 @@ t2 = TaskCreate("Phase 2: Architect designs solution", "Spawn architect, review 
                 activeForm="Architecting solution") → addBlockedBy: [t1]
 t2_5 = TaskCreate("Phase 2.5: Security design review", "STRIDE analysis of architect plan",
                 activeForm="Security design review") → addBlockedBy: [t2]
+t2_7 = TaskCreate("Phase 2.7: Speculative fork (conditional)", "Competing implementations for contested components — skip if not triggered",
+                activeForm="Running speculative fork") → addBlockedBy: [t2_5]
 t3 = TaskCreate("Phase 3: Pipelined implementation", "All components through pipeline",
-                activeForm="Implementing components") → addBlockedBy: [t2_5]
+                activeForm="Implementing components") → addBlockedBy: [t2_7]
 t4 = TaskCreate("Phase 4: Parallel review", "Security, QA, code-review, performance",
                 activeForm="Running parallel review") → addBlockedBy: [t3]
 t5 = TaskCreate("Phase 5: Fix & simplify", "Fixer + code-simplifier",
@@ -399,6 +403,10 @@ Validate the plan:
 **If architect flagged risks or open questions** (check `plan.risks` and `plan.questions` fields):
 Present to user via AskUserQuestion. This is an allowed interruption.
 
+**If architect set `speculative_fork_recommended: true`:** Note the contested component IDs from
+`plan.speculative_components`. Phase 2.7 will run for these components after Phase 2.5 completes.
+No user interruption needed — proceed autonomously.
+
 **If plan quality is poor** (missing files, circular deps, vague descriptions):
 Send feedback to architect and request one revision:
 
@@ -428,6 +436,11 @@ Record the decision in the context bundle as `pipeline_mode: true/false`.
 
 Pipeline mode: implementer starts Component B while reviewer reviews Component A, etc.
 Sequential mode: each component completes fully before next begins.
+
+**Note:** If Phase 2.7 (speculative fork) will run for some components, defer the final pipeline
+decision for those components until Phase 2.7 resolves. The winning approach may change the
+component's file scope, which affects dependency ordering. Re-evaluate after Phase 2.7 writes
+the winner back into `architect-plan.json`.
 
 ### Step 2.4: Keep Architect Available Through Phase 3
 
@@ -530,7 +543,256 @@ Shut down the security-design agent after findings are routed.
 
 ---
 
+## Phase 2.7: Speculative Fork (conditional)
+
+### Step 2.7.0: Skip Decision
+
+Evaluate whether this phase applies before spawning any agents:
+
+| Condition | Decision |
+|-----------|----------|
+| `architect-plan.json` contains `speculative_fork_recommended: true` | Run Phase 2.7 |
+| Lead identifies 2+ components with incompatible approach choices and real trade-offs | Run Phase 2.7 |
+| Architect classified domain as Complex AND `competing_approaches` entries exist | Run Phase 2.7 — Complex-domain tasks benefit most from speculative execution |
+| User specified a concrete implementation approach in Phase 1 | Skip — proceed to Phase 3 |
+| Task has a single component with no stated approach uncertainty | Skip — proceed to Phase 3 |
+| Architect classified domain as Chaotic (stabilization brief only) | Skip — proceed to Phase 3 |
+| Architect classified domain as Clear (best practice, no real alternatives) | Skip — proceed to Phase 3 |
+| When in doubt | Skip — speculative adds cost, require a positive signal |
+
+If skipping: note the reason in the audit trail (`.swarm-run` entry) and proceed to Phase 3.
+
+### Step 2.7.1: Identify Contested Components
+
+Read `architect-plan.json`. Extract the component(s) that are contested:
+
+- If `speculative_fork_recommended: true` is set, read the `speculative_components` field (array
+  of component IDs) to identify which components are contested. If the field is absent, treat all
+  components with `estimated_complexity: "high"` and multiple stated `risks` as contested.
+- If the Lead triggered Phase 2.7 independently (without the flag), identify the contested
+  component(s) from the plan's `risks` and `questions` fields.
+
+**Scope rule:** Only contested component(s) enter the speculative fork. All other components
+proceed to Phase 3 directly after Phase 2.7 resolves. Do NOT fork the entire implementation.
+
+### Step 2.7.2: Define Evaluation Criteria
+
+Based on the architect's stated trade-offs for the contested component(s), define weighted
+evaluation criteria. Use the `SpeculativeSpec` schema from the `/speculative` skill:
+
+```json
+{
+  "success_criteria": [
+    {
+      "criterion": "Correctness",
+      "weight": 0.35,
+      "description": "Handles all specified cases correctly, matches architect's component spec"
+    },
+    {
+      "criterion": "Maintainability",
+      "weight": 0.30,
+      "description": "Clear, readable, matches codebase patterns"
+    },
+    {
+      "criterion": "Performance",
+      "weight": 0.20,
+      "description": "Efficient for expected load — no unnecessary overhead"
+    },
+    {
+      "criterion": "Simplicity",
+      "weight": 0.15,
+      "description": "Minimum necessary complexity — no over-engineering"
+    }
+  ]
+}
+```
+
+Adjust weights based on the architect's stated priorities for the contested component.
+Weights must sum to 1.0.
+
+### Step 2.7.3: Create Speculative Run Directory
+
+```
+{speculative_run_dir} = hack/speculative/YYYY-MM-DD
+```
+
+If that directory already exists (a separate /speculative run happened today), append a sequence
+number: `hack/speculative/YYYY-MM-DD-2`.
+
+Create the directory structure:
+```
+{speculative_run_dir}/
+{speculative_run_dir}/implementations/
+```
+
+### Step 2.7.4: Spawn Competitors
+
+Default to 2 competitors unless the architect described 3+ meaningfully distinct approaches.
+Maximum 3 competitors in the swarm context (cost constraint).
+
+For each contested component, spawn competitor agents simultaneously:
+
+```
+Task(name="competitor-1", subagent_type="general-purpose", model="sonnet",
+     team_name="swarm-impl", mode="bypassPermissions",
+     isolation="worktree",
+     prompt="[speculative context bundle]\n\n[competitor prompt — see below]")
+
+Task(name="competitor-2", subagent_type="general-purpose", model="sonnet",
+     team_name="swarm-impl", mode="bypassPermissions",
+     isolation="worktree",
+     prompt="[speculative context bundle]\n\n[competitor prompt — see below]")
+```
+
+Each competitor receives a `SpeculativeSpec` with:
+- `problem`: the component description from `architect-plan.json`
+- `success_criteria`: from Step 2.7.2
+- `approach_hint`: the specific approach for that competitor (from architect's stated alternatives),
+  or null if the competitor should choose freely
+- `competitor_id`: "competitor-1", "competitor-2", etc.
+- `worktree_path`: its isolated worktree path
+- `output_path`: `{speculative_run_dir}/implementations/competitor-{id}.json`
+
+**Watchdog:** After spawning competitors, create a CronCreate watchdog (60-second interval) to
+monitor competitor idle status. Record `speculative_watchdog_cron_id`. CronDelete when all
+competitors have submitted results.
+
+```
+CronCreate(
+  schedule="*/1 * * * *",
+  command="swarm-speculative-watchdog",
+  description="Phase 2.7 speculative competitor watchdog"
+)
+```
+
+### Step 2.7.5: Receive Competitor Results
+
+Wait for all competitors to submit `ImplementationResult` messages. Each competitor writes its
+result to `{speculative_run_dir}/implementations/competitor-{id}.json`.
+
+**Timeout handling:** If one competitor is idle (no messages, no task update) while others have
+finished:
+1. Send one status check via SendMessage
+2. If no response, log as timed-out and proceed with remaining results
+3. A run with 1 of 2 competitors can proceed — note in audit trail
+
+**CronDelete watchdog** once all expected results are received (or timeout is declared). CronDelete the watchdog BEFORE declaring timeout or transitioning to Phase 3. Never leave orphaned cron jobs at phase boundaries.
+
+### Step 2.7.6: Spawn Judge
+
+Spawn a single judge agent after all competitors have submitted:
+
+```
+Task(name="speculative-judge", subagent_type="general-purpose", model="opus",
+     team_name="swarm-impl",
+     prompt="[speculative context bundle]\n\n[judge prompt from speculative skill agent-prompts.md]")
+```
+
+The judge receives a `JudgmentRequest` with all `ImplementationResult` objects, the
+`SpeculativeSpec`, and `output_path: {speculative_run_dir}/judgment.json`.
+
+The judge writes its `JudgmentResult` to `{speculative_run_dir}/judgment.json`.
+
+### Step 2.7.7: Apply Winner to Architect Plan
+
+After receiving the judge's result, read `{speculative_run_dir}/judgment.json`.
+
+**If winner is a single competitor:**
+1. Read the winning competitor's `ImplementationResult` (approach, files, design decisions)
+2. Update `architect-plan.json` — replace the contested component's `description` with the
+   winner's `approach` field, and update `files_to_create`/`files_to_modify` if they differ
+3. Add a `speculative_fork_resolved` field to `architect-plan.json`:
+   ```json
+   {
+     "speculative_fork_resolved": {
+       "component_id": "string — contested component ID",
+       "winner": "competitor-1",
+       "rationale": "string — judge's rationale (brief)",
+       "run_dir": "{speculative_run_dir}"
+     }
+   }
+   ```
+
+**If winner is "hybrid":**
+- If hybrid is genuinely better AND the complexity is justified: spawn the `/speculative` Phase 3.5
+  synthesis agent to combine the specified elements. The synthesis agent writes to the main worktree.
+- After synthesis, update `architect-plan.json` with the synthesized approach as the component spec.
+- If hybrid adds complexity without clear benefit: override to the highest-scoring single competitor.
+  Log the override decision in the audit trail.
+
+**Shutdown judge and all competitor agents:**
+```
+SendMessage(type="shutdown_request", recipient="speculative-judge", content="Judgment complete.")
+SendMessage(type="shutdown_request", recipient="competitor-1", content="Phase 2.7 complete.")
+SendMessage(type="shutdown_request", recipient="competitor-2", content="Phase 2.7 complete.")
+```
+
+### Step 2.7.8: Audit Trail
+
+Write a summary entry to `{run_dir}/.swarm-run` noting:
+- Whether Phase 2.7 was run or skipped (and why)
+- Contested component(s)
+- Number of competitors
+- Winner and rationale summary
+- Whether hybrid synthesis was triggered
+
+The full speculative run record is at `{speculative_run_dir}/`. The swarm's run_dir audit trail
+only contains the summary reference.
+
+---
+
 ## Phase 3: Pipelined Implementation
+
+### Step 3.0: Watchdog Setup
+
+After receiving Phase 2.5 results and before spawning pipeline agents, create a CronCreate
+watchdog job to monitor pipeline agent health:
+
+```
+CronCreate(
+  schedule="*/1 * * * *",   ← every 60 seconds
+  command="swarm-watchdog-check",
+  description="Swarm Phase 3 watchdog: monitor pipeline agent idle status"
+)
+```
+
+Record the cron job ID in Lead state as `watchdog_cron_id` (returned by CronCreate).
+
+**What the watchdog checks (Lead evaluates on each 60-second tick):**
+
+1. Call `TaskList` and identify any tasks currently in `in_progress` state
+2. Cross-reference with the last received message timestamp for each pipeline agent
+3. If any agent has been idle for 2+ consecutive watchdog checks with an active `in_progress`
+   task, send a status ping to the lead's own context as an alert:
+
+```
+[WATCHDOG] <agent-role> has been idle for 2+ checks on <component_id>.
+Last message type: <last-message-type>. Initiating status check.
+```
+
+4. Trigger Step 3.6 Silent Failure Detection for the idle agent
+
+**What the watchdog does NOT do:**
+- Does NOT directly message pipeline agents (the Lead does that via Step 3.6)
+- Does NOT kill or restart agents itself
+- Does NOT modify any files
+- Reports only — the Lead makes all intervention decisions
+
+**Watchdog teardown:**
+
+When Phase 3 completes (all components through the pipeline), CronDelete the watchdog BEFORE declaring Phase 3 complete or transitioning to Phase 4. Never leave orphaned cron jobs at phase boundaries.
+
+```
+CronDelete(id=watchdog_cron_id)
+```
+
+Also delete the watchdog BEFORE any of these transitions:
+- Phase 3 error escalation (50%+ components blocked → AskUserQuestion)
+- Design-level escalation routing back to Phase 2 (Step 4.5)
+- Any AskUserQuestion abort path
+
+Do NOT leave orphaned cron jobs. If the Lead is about to stop pipeline execution for any
+reason, always CronDelete before transitioning to the next phase or stopping.
 
 ### Step 3.1: Spawn Persistent Pipeline Team
 
@@ -558,6 +820,23 @@ Task(name="test-runner", subagent_type="dev-essentials:test-runner", model="haik
 
 Note: reviewer and test-runner are read-only — no bypassPermissions needed. Only implementer
 and test-writer (which write code/tests) use bypassPermissions.
+
+### Step 3.1.5: Acknowledgment Wait
+
+After sending each ComponentAssignment, the Lead waits for a `ContextAcknowledgment` from the
+receiving agent before marking that component as "in progress." See `communication-schema.md`
+for the schema.
+
+**If `clarifications_needed` is non-empty:** Answer all clarifications via SendMessage before
+the agent begins work. Only then does the agent start implementation.
+
+**If no acknowledgment after 2+ minutes of agent idle:**
+1. Re-send the ComponentAssignment once (first retry)
+2. If second attempt also fails, log to `{run_dir}/errors.log`:
+   ```
+   [ACK-FAIL] <agent-role>: no ContextAcknowledgment after 2 attempts for <component_id>. Spawning replacement.
+   ```
+3. Spawn a replacement agent with the same assignment
 
 ### Step 3.2: Pipeline Flow
 
@@ -1003,12 +1282,80 @@ SendMessage(type="shutdown_request", recipient="security-reviewer", content="Rev
 
 ---
 
+## Phase 4.5: Structural Design Review
+
+This phase always runs — it is not conditional on Phase 4 findings. It spawns adversarial
+structural analysts to review the implementation as a system, catching cross-component issues
+that individual file-by-file reviews miss.
+
+### Step 4.5.1: Spawn Structural Analysts
+
+Spawn both analysts simultaneously after Phase 4 escalation routing completes:
+
+```
+Task(name="structural-concurrency", subagent_type="general-purpose", model="opus",
+     team_name="swarm-impl",
+     prompt="[context bundle]\n\n[structural-concurrency analyst prompt from agent-prompts.md]")
+
+Task(name="structural-integration", subagent_type="general-purpose", model="opus",
+     team_name="swarm-impl",
+     prompt="[context bundle]\n\n[structural-integration analyst prompt from agent-prompts.md]")
+```
+
+### Step 4.5.2: Structural Analyst Outputs
+
+Each analyst writes a `ReviewFindings` JSON to the audit trail and sends a summary to the lead:
+
+| Analyst | Output File |
+|---------|-------------|
+| structural-concurrency | `{run_dir}/reviews/structural-concurrency.json` |
+| structural-integration | `{run_dir}/reviews/structural-integration.json` |
+
+Finding IDs use the `STRUCT` prefix (STRUCT-001, STRUCT-002, etc.).
+
+### Step 4.5.3: Lead Synthesis and Routing
+
+Read both structural review files. Apply the same escalation routing rules as Phase 4:
+
+**Classification rules for STRUCT findings:**
+
+| Finding Type | Routing |
+|---|---|
+| Cross-component design flaw (race condition in shared state, wrong dependency order by design) | Phase 2 (design-level escalation) |
+| Trust boundary issue spanning multiple components | Phase 2.5 (security design escalation) |
+| Contract violation addressable in code (wrong data passed, missing validation at boundary) | Phase 5 Fixer |
+| Scope creep across components | Human escalation via AskUserQuestion |
+
+**Escalation counter:** STRUCT escalations count toward the same `design_escalation_count` cap
+(max 2 total across Phase 4 and Phase 4.5). If the cap is reached, escalate to human.
+
+Log all STRUCT escalation events to `{run_dir}/escalations.json` using the same format as
+Phase 4 escalation events.
+
+### Step 4.5.4: Merge Into Phase 5 Consolidated Findings
+
+Add all actionable STRUCT findings to the consolidated findings list that Phase 5 Fixer receives.
+Phase 5 treats STRUCT findings identically to Phase 4 findings — same severity triage, same fix
+protocol.
+
+If ALL structural findings are clean (zero critical or high), note this in the audit trail and
+skip_fixer remains unchanged from Phase 4's determination.
+
+### Step 4.5.5: Shutdown Structural Analysts
+
+```
+SendMessage(type="shutdown_request", recipient="structural-concurrency", content="Structural review complete.")
+SendMessage(type="shutdown_request", recipient="structural-integration", content="Structural review complete.")
+```
+
+---
+
 ## Phase 5: Fix & Simplify
 
 ### Step 5.1: Skip Check
 
-If `skip_fixer = true` (all reviews clean): skip Phase 5 entirely. Mark Phase 5 task as completed
-with note "No findings — skipped." Proceed to Phase 6.
+If `skip_fixer = true` (all Phase 4 AND Phase 4.5 reviews clean): skip Phase 5 entirely. Mark
+Phase 5 task as completed with note "No findings — skipped." Proceed to Phase 6.
 
 ### Step 5.2: Spawn Fixer
 
@@ -1456,6 +1803,8 @@ TeamCreate:
 | 4 | db-reviewer (optional) | general-purpose | sonnet | default | No |
 | 4 | plugin-validator (optional) | general-purpose | sonnet | default | No |
 | 4 | skill-reviewer (optional) | general-purpose | sonnet | default | No |
+| 4.5 | structural-concurrency | general-purpose | opus | default | No |
+| 4.5 | structural-integration | general-purpose | opus | default | No |
 | 5 | fixer | general-purpose | sonnet | bypassPermissions | Yes |
 | 5 | code-simplifier | code-simplifier:code-simplifier | sonnet | bypassPermissions | Yes |
 | 6 | docs | general-purpose | haiku | bypassPermissions | Yes |
@@ -1463,8 +1812,8 @@ TeamCreate:
 
 Only agents that need Write/Edit access use `bypassPermissions`. Read-only agents use default mode.
 
-Maximum agent count: 18 (13 core + 5 optional domain reviewers).
-Minimum agent count: 13 (all domain reviewers skipped).
+Maximum agent count: 20 (15 core + 5 optional domain reviewers).
+Minimum agent count: 15 (all domain reviewers skipped).
 
 Agents are spawned and shut down per-phase to manage resource usage. The pipeline team (Phase 3)
 and reviewer team (Phase 4) are never active simultaneously.

--- a/code-quality/skills/swarm/references/pipeline-model.md
+++ b/code-quality/skills/swarm/references/pipeline-model.md
@@ -340,13 +340,15 @@ Single agent, shut down after it sends `VerificationResult`.
 | 1 | Lead only | 1 |
 | 2 | Architect | 2 |
 | 2.5 | Security Design Reviewer | 2 |
+| 2.7 | Speculative Competitors + Judge (conditional) | 2-5 + Lead |
 | 3 | Architect (standby) + Implementer, Reviewer, Test-Writer, Test-Runner | 6 (5 + Lead) |
 | 4 | Security, QA, Code-Reviewer, Performance (+ optionals) | 5-10 + Lead |
+| 4.5 | Structural Analyst ×2 | 3 (2 + Lead) |
 | 5 | Fixer, then Code-Simplifier | 2 + Lead |
 | 6 | Docs, then Lessons Extractor | 2 (sequential) |
 | 7 | Verifier | 2 |
 
 Phases never overlap. The Lead shuts down each phase's agents before spawning the next phase.
 This keeps the active teammate count bounded and prevents context cross-contamination between
-phases. The maximum active count at any point is 8 (Lead + up to 7 Phase 4 reviewers with all
+phases. The maximum active count at any point is 11 (Lead + up to 10 Phase 4 reviewers with all
 optional domain reviewers).

--- a/code-quality/skills/unfuck/SKILL.md
+++ b/code-quality/skills/unfuck/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   (file-audit, security-review, sc:cleanup, sc:improve, docs-sync, sc:index-repo,
   code-quality:architect, code-quality:security, code-quality:qa, code-simplifier,
   dev-essentials:test-runner) into a unified cleanup workflow.
-allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, TeamCreate, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, LSP, Skill]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, TeamCreate, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, LSP, Skill]
 ---
 
 # /unfuck — Comprehensive Repo Cleanup

--- a/code-quality/skills/unfuck/SKILL.md
+++ b/code-quality/skills/unfuck/SKILL.md
@@ -47,6 +47,11 @@ Phase 4 verifies everything passes and generates a report.
 
 ### Phase 1: Discovery (7 parallel agents)
 
+**Phase 1 and Phase 2 use /map-reduce for structured discovery and synthesis** — each discovery
+agent is a mapper, and the synthesis agent is the reducer. This provides formal chunk tracking,
+retry-on-failure for individual discovery agents, and structured ReductionResult output.
+If /map-reduce skill is unavailable, fall back to direct parallel agents as described below.
+
 All agents run simultaneously in background. Each writes structured JSON findings to
 `hack/unfuck/YYYY-MM-DD/discovery/`. Full prompts in `references/discovery-agents.md`.
 
@@ -68,9 +73,14 @@ manually using LSP, Grep, and file reading. See `references/external-tools.md` f
 
 ### Phase 2: Synthesis & Planning
 
-A dedicated **opus synthesis teammate** (not the orchestrator) performs synthesis to avoid filling the lead agent's context:
-1. Reads all 7 discovery JSON files
-2. Deduplicates overlapping findings across agents
+A dedicated **opus synthesis teammate** (not the orchestrator) performs synthesis to avoid
+filling the lead agent's context. When using /map-reduce, this agent acts as the reducer —
+receiving all 7 ChunkResults and producing a ReductionResult before writing the cleanup plan.
+When falling back to direct approach, it reads the raw discovery JSON files directly.
+
+1. Reads all 7 discovery JSON files (or ChunkResults if /map-reduce was used)
+2. Deduplicates overlapping findings across agents (via /map-reduce cross-chunk validation
+   if available, or manual dedup otherwise)
 3. Cross-references compound patterns (dead + divergent = safe to remove)
 4. Prioritizes: security → dead code → duplicates → AI slop → complexity → architecture → docs
 5. Writes `hack/unfuck/YYYY-MM-DD/cleanup-plan.md` with per-finding detail

--- a/code-quality/skills/unfuck/SKILL.md
+++ b/code-quality/skills/unfuck/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   (file-audit, security-review, sc:cleanup, sc:improve, docs-sync, sc:index-repo,
   code-quality:architect, code-quality:security, code-quality:qa, code-simplifier,
   dev-essentials:test-runner) into a unified cleanup workflow.
-allowed-tools: [Read, Write, Edit, Glob, Grep, Task, Bash, AskUserQuestion, TeamCreate, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, LSP, Skill]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, TeamCreate, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, LSP, Skill]
 ---
 
 # /unfuck — Comprehensive Repo Cleanup

--- a/code-quality/skills/unfuck/references/orchestration-playbook.md
+++ b/code-quality/skills/unfuck/references/orchestration-playbook.md
@@ -158,7 +158,7 @@ Spawn **ALL 7 agents** as TeamCreate teammates in a **single message** (7 parall
 
 Each teammate runs in its own independent context window, writes its JSON findings to disk, and sends a brief summary to the team lead via `SendMessage`. This avoids context pressure on the orchestrator — the orchestrator never calls `TaskOutput` or reads full agent transcripts.
 
-**Why teammates, not background Tasks:** Background `Task(run_in_background=true)` agents dump their full output into the orchestrator's context when checked via `TaskOutput`. With 7 agents producing detailed findings, this causes context overflow. TeamCreate teammates have independent context windows and communicate via short `SendMessage` summaries.
+**Why teammates, not background Agents:** Background `Agent(run_in_background=true)` agents dump their full output into the orchestrator's context when checked via `TaskOutput`. With 7 agents producing detailed findings, this causes context overflow. TeamCreate teammates have independent context windows and communicate via short `SendMessage` summaries.
 
 **CRITICAL:** All 7 agents MUST be launched in the SAME message. Do not conditionally skip agents. The orchestrator should wait for all 7 completion summaries before proceeding to Phase 2.
 
@@ -181,31 +181,31 @@ Each teammate runs in its own independent context window, writes its JSON findin
 In a single message, issue 7 parallel Task calls with `team_name` to spawn as teammates:
 
 ```
-Task(name="dead-code-hunter", subagent_type="general-purpose", model="sonnet",
+Agent(name="dead-code-hunter", subagent_type="general-purpose", model="sonnet",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 1 prompt from discovery-agents.md]")
 
-Task(name="duplicate-detector", subagent_type="general-purpose", model="sonnet",
+Agent(name="duplicate-detector", subagent_type="general-purpose", model="sonnet",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 2 prompt from discovery-agents.md]")
 
-Task(name="security-auditor", subagent_type="general-purpose", model="sonnet",
+Agent(name="security-auditor", subagent_type="general-purpose", model="sonnet",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 3 prompt from discovery-agents.md]")
 
-Task(name="architecture-reviewer", subagent_type="general-purpose", model="sonnet",
+Agent(name="architecture-reviewer", subagent_type="general-purpose", model="sonnet",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 4 prompt from discovery-agents.md]")
 
-Task(name="ai-slop-detector", subagent_type="general-purpose", model="opus",
+Agent(name="ai-slop-detector", subagent_type="general-purpose", model="opus",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 5 prompt from discovery-agents.md]")
 
-Task(name="complexity-auditor", subagent_type="general-purpose", model="sonnet",
+Agent(name="complexity-auditor", subagent_type="general-purpose", model="sonnet",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 6 prompt from discovery-agents.md]")
 
-Task(name="documentation-auditor", subagent_type="general-purpose", model="sonnet",
+Agent(name="documentation-auditor", subagent_type="general-purpose", model="sonnet",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 7 prompt from discovery-agents.md]")
 ```
@@ -261,7 +261,7 @@ This frees resources before Phase 3 implementation agents are spawned.
 Spawn a single `synthesis-planner` teammate using opus:
 
 ```
-Task(name="synthesis-planner", subagent_type="general-purpose", model="opus",
+Agent(name="synthesis-planner", subagent_type="general-purpose", model="opus",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Full synthesis instructions below]\n\nRun directory: {run_dir}")
 ```
@@ -444,19 +444,19 @@ Spawn a **single persistent collaborative team** that works through all categori
 Spawn 4 persistent teammates in a single message. They collaborate on each category together:
 
 ```
-Task(name="impl-writer", subagent_type="general-purpose", model="sonnet",
+Agent(name="impl-writer", subagent_type="general-purpose", model="sonnet",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\nYou are the WRITER on the implementation team. You implement fixes from the cleanup plan.\nYour teammates are: impl-qa (reviews your changes), impl-tester (runs tests), impl-docs (updates docs).\n\nWait for the team lead to assign you a category. For each category:\n1. Read the category's findings from {run_dir}/cleanup-plan.md\n2. Apply fixes using the strategies from references/implementation-agents.md\n3. When done with a category, message impl-qa to review your changes\n4. After QA approval and tests pass, commit the category\n5. Message the team lead that the category is complete\n\n[Full implementation agent shared rules from references/implementation-agents.md]")
 
-Task(name="impl-qa", subagent_type="general-purpose", model="opus",
+Agent(name="impl-qa", subagent_type="general-purpose", model="opus",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\nYou are QA on the implementation team. You review changes made by impl-writer.\n\nWhen impl-writer messages you that a category is ready for review:\n1. Read the modified files (git diff)\n2. Verify changes match the cleanup plan findings\n3. Check for regressions, broken imports, missing error handling\n4. Use LSP findReferences to verify no callers are broken\n5. If issues found, message impl-writer with specific feedback\n6. If clean, message impl-tester to run the test suite\n\nApply code-review rigor: no assumptions, verify everything.")
 
-Task(name="impl-tester", subagent_type="general-purpose", model="sonnet",
+Agent(name="impl-tester", subagent_type="general-purpose", model="sonnet",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\nYou are the TESTER on the implementation team. You run tests and formatters.\n\nWhen impl-qa messages you that changes are reviewed:\n1. Run the project's test suite (auto-detect: make test / uv run pytest / npm test / etc.)\n2. Run the formatter (make format / uvx ruff format / etc.)\n3. If tests pass: message impl-writer to commit\n4. If tests fail: message impl-writer with the failure details for rollback\n\nAuto-detect test commands from Makefile, pyproject.toml, or package.json.")
 
-Task(name="impl-docs", subagent_type="general-purpose", model="sonnet",
+Agent(name="impl-docs", subagent_type="general-purpose", model="sonnet",
      team_name="cleanup-swarm", mode="bypassPermissions",
      prompt="[context bundle]\n\nYou are the DOCUMENTER on the implementation team. You update docs after code changes.\n\nFor each completed category:\n1. Check if the changes affect any documentation (README, docstrings, config docs)\n2. If so, update documentation to reflect the changes\n3. Follow docs-sync patterns: match existing style, verify commands work\n4. Message impl-writer when doc updates are ready to include in the commit\n\nDo NOT create new documentation files. Only update existing ones.")
 ```
@@ -545,7 +545,7 @@ Categories execute sequentially because:
 Run the complete test suite one final time. This catches any cross-category regressions that individual category tests might miss.
 
 ```
-Task(name="final-verification", subagent_type="dev-essentials:test-runner",
+Agent(name="final-verification", subagent_type="dev-essentials:test-runner",
      prompt="Run the full test suite. Report all pass/fail results.")
 ```
 
@@ -568,7 +568,7 @@ git diff --name-only $(git merge-base HEAD main)..HEAD
 Spawn a code quality review agent:
 
 ```
-Task(name="quality-review", subagent_type="general-purpose",
+Agent(name="quality-review", subagent_type="general-purpose",
      prompt="Review these files for code quality issues introduced during cleanup:\n<file list>\n\nCheck for:\n- Broken imports after dead code removal\n- Inconsistent naming after duplicate consolidation\n- Missing error handling after simplification\n- Incomplete refactoring (half-done changes)")
 ```
 

--- a/dev-essentials/.claude-plugin/plugin.json
+++ b/dev-essentials/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-essentials",
   "description": "Essential development utilities: LSP navigation, uv-python enforcement, test execution, incremental planning, and session management",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": { "name": "wgordon17" }
 }

--- a/dev-essentials/skills/incremental-planning/SKILL.md
+++ b/dev-essentials/skills/incremental-planning/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   "how should we implement", or before any multi-file implementation task. Asks clarifying
   questions first, writes plan to file incrementally, provides research context and summaries
   in chat for feedback. Never displays full plan content in chat.
-allowed-tools: [Read, Write, Edit, Glob, Grep, Task, Bash, AskUserQuestion, LSP, Skill, ToolSearch]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Agent, Bash, AskUserQuestion, LSP, Skill, ToolSearch]
 ---
 
 # Incremental Planning

--- a/dev-essentials/skills/test-runner/SKILL.md
+++ b/dev-essentials/skills/test-runner/SKILL.md
@@ -350,11 +350,11 @@ Need to run pre-commit?
 
 ## When to Use Test-Runner Agent
 
-For complex test workflows, consider launching the test-runner agent via Task tool:
+For complex test workflows, consider launching the test-runner agent via Agent tool:
 
 ```python
 # Launch agent for test execution and failure reporting
-Task(
+Agent(
   subagent_type="dev-essentials:test-runner",
   prompt="Run pre-commit and pytest, report any failures with specific test paths"
 )


### PR DESCRIPTION
## Summary
- Implements all 10 tasks from the swarm evaluation improvements plan: new /map-reduce and /speculative skills, quality-gate enhancements (Layer 1.5 domain reviewers, Round 6 structural lens), swarm enhancements (Phase 2.7 speculative fork, Phase 4.5 structural design review, ContextAcknowledgment relay, CronCreate watchdog)
- Integrates /map-reduce into /file-audit (20+ files) and /unfuck (Phase 1+2 discovery/synthesis) with graceful fallback
- Bumps code-quality plugin version 2.6.0 to 2.7.0