### PR TITLE
fix(dev-guard): replaces delta parsing with tail-read context

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.42.0",
+      "version": "1.43.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -11,9 +11,10 @@ a pass/fail decision JSON on stdout.
 
 Stdin schema (from stop-hook.py):
   {
-    "first_user_message": str | null,
-    "new_tool_calls": list[str],
+    "recent_user_messages": list[str],
+    "last_assistant_message": str,
     "recent_assistant_messages": list[str],
+    "new_tool_calls": list[str],
     "git_diff_stat": str | null,
     "trigger_reasons": list[str],
     "work_type": "code_config | planning | research | question | conversation | mixed"
@@ -44,7 +45,7 @@ import re
 import sys
 from typing import NoReturn
 
-_MAX_INPUT = 1 * 1024 * 1024  # 1 MB — context is small
+_MAX_INPUT = 2 * 1024 * 1024  # 2 MB — includes recent message history
 # Strip Claude Code context-window suffixes like [1m] — Vertex AI doesn't accept them
 _RAW_MODEL = os.environ.get("ANTHROPIC_DEFAULT_SONNET_MODEL", "claude-sonnet-4-6")
 _MODEL = re.sub(r"\[.*\]$", "", _RAW_MODEL)
@@ -82,60 +83,92 @@ def _parse_stdin() -> dict:
 
 def _build_prompt(ctx: dict) -> str:
     """Build an adaptive evaluation prompt based on trigger reasons and work type."""
-    first_user_msg = ctx.get("first_user_message") or "(not available)"
+    recent_user_msgs = ctx.get("recent_user_messages") or []
+    last_assistant_msg = (ctx.get("last_assistant_message") or "").strip()
+    recent_assistant_msgs = ctx.get("recent_assistant_messages") or []
     tool_calls = ctx.get("new_tool_calls") or []
-    recent_msgs = ctx.get("recent_assistant_messages") or []
     diff_stat = ctx.get("git_diff_stat")
     trigger_reasons = ctx.get("trigger_reasons") or []
     work_type = ctx.get("work_type", "conversation")
-    # Build context section
+
     lines = [
         "You are a quality gate for a Claude Code session. "
-        "Evaluate whether the work is complete and correct.",
+        "Evaluate whether the work is complete and correct based on the evidence below.",
         "",
-        "## Session Context",
-        f"**Original user request:** {first_user_msg}",
+    ]
+
+    # ── Section 1: Conversation Arc ───────────────────────────────────────────
+    lines += ["## 1. Conversation Arc (recent user messages)"]
+    if recent_user_msgs:
+        for i, msg in enumerate(recent_user_msgs, 1):
+            label = (
+                f"**User message {i} (Most recent — current task):**"
+                if i == len(recent_user_msgs)
+                else f"**User message {i}:**"
+            )
+            lines += [label, msg, ""]
+    else:
+        lines += ["(no user messages available)", ""]
+
+    # ── Section 2: Work Evidence ──────────────────────────────────────────────
+    lines += ["## 2. Work Evidence"]
+    lines += [
         f"**Work type:** {work_type}",
         f"**Trigger reasons:** {', '.join(trigger_reasons) if trigger_reasons else 'none'}",
         f"**Tools used this turn:** {', '.join(tool_calls) if tool_calls else 'none'}",
     ]
-
     if diff_stat:
         lines += [
             "",
-            "## Git Changes",
+            "**Git diff stat:**",
             "```",
             diff_stat,
             "```",
         ]
+    lines.append("")
 
-    if recent_msgs:
-        lines += ["", "## Recent Assistant Messages"]
-        for i, msg in enumerate(recent_msgs, 1):
+    # ── Section 3: Final Message ──────────────────────────────────────────────
+    lines += [
+        "## 3. Final Assistant Message (the response being evaluated)",
+        "This is what the user will see. Evaluate this.",
+    ]
+    lines += [last_assistant_msg if last_assistant_msg else "(empty)", ""]
+
+    # ── Section 4: Supporting Context ────────────────────────────────────────
+    if recent_assistant_msgs:
+        lines += ["## 4. Supporting Context (earlier assistant messages)"]
+        for i, msg in enumerate(recent_assistant_msgs, 1):
             lines += [f"**Message {i}:**", msg, ""]
 
-    # Add work-type-specific evaluation criteria
-    lines += ["", "## Evaluation Criteria"]
+    # ── Section 5: Evaluation Criteria ───────────────────────────────────────
+    lines += ["## 5. Evaluation Criteria"]
+    lines += [
+        "Evaluate the final message in the context of the conversation arc. "
+        "Use the work evidence and supporting context to inform your judgment.",
+        "",
+    ]
 
     criteria: list[str] = []
 
     # Universal criteria
     criteria.append(
-        "COMPLETENESS: Was every part of the original user request addressed? "
-        "Not partially, not deferred without explicit user agreement."
+        "CLAIM ACCURACY: Do the claims in the final message match the work evidence? "
+        "Check that tools listed as used appear in the tools list, that git changes "
+        "described match the diff stat, and that completion claims are supported by evidence."
     )
     criteria.append(
-        "IDENTIFIED-BUT-UNFIXED: Did the assistant mention issues ('could be improved', "
-        "'consider', 'potential issue', 'follow-up', 'out of scope') without fixing them? "
-        "If yes, that is incomplete work. "
-        "DEFERRAL-TO-USER is the same failure: phrases like 'should be verified', "
-        "'needs to be confirmed', 'you should check', 'verify against your', "
-        "'please verify', 'you may want to update' mean the assistant identified "
-        "work that needs doing and punted it. The assistant has tools (Read, Grep, "
-        "WebSearch, LSP, MCP servers) to verify things itself — saying 'should be "
-        "verified' when it could verify is confessing to incomplete work, not "
-        "flagging a genuine limitation. If it should be verified, verify it. "
-        "If it needs checking, check it. Do not defer work to the user."
+        "COMPLETENESS: Does the final message address the MOST RECENT user request "
+        "(the last message in the conversation arc)? Not an earlier one, not partially, "
+        "not deferred without explicit user agreement."
+    )
+    criteria.append(
+        "DEFERRED WORK: Does the final message punt work to the user that Claude should "
+        "have done itself? Phrases like 'should be verified', 'needs to be confirmed', "
+        "'you should check', 'verify against your', 'please verify', "
+        "'you may want to update' — when the assistant has tools (Read, Grep, "
+        "WebSearch, LSP, MCP servers) to do that verification — mean the assistant "
+        "identified work that needs doing and punted it. That is incomplete work. "
+        "If it should be verified, verify it. If it needs checking, check it."
     )
 
     if work_type in ("code_config", "mixed"):
@@ -191,9 +224,10 @@ def _build_prompt(ctx: dict) -> str:
     for i, criterion in enumerate(criteria, 1):
         lines.append(f"{i}. {criterion}")
 
+    # ── Section 6: Decision ───────────────────────────────────────────────────
     lines += [
         "",
-        "## Decision",
+        "## 6. Decision",
         "Respond with ONLY a JSON object — no prose, no markdown fences:",
         (
             '{"decision": "pass" | "fail", "reasoning": "brief explanation", '

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -786,8 +786,10 @@ def main() -> None:
     latest_user_message = recent_user_messages[-1] if recent_user_messages else None
 
     # ── Tool-call dedup via count ────────────────────────────────────────────
-    if evaluated_count > len(all_tool_calls):
-        evaluated_count = 0  # transcript compacted, re-evaluate all
+    # When the 512KB tail window shifts (large transcripts), the count refers to a
+    # different window base — reset to 0 to avoid silently skipping tools.
+    if evaluated_count > len(all_tool_calls) or file_size > _MAX_PARSE_BYTES:
+        evaluated_count = 0
     new_tool_calls = all_tool_calls[evaluated_count:]
 
     # Create name-deduped list for LLM context

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -5,7 +5,7 @@
 """Stop Hook Main -- zero-dependency fast triage for Claude Code Stop events.
 
 Reads Stop hook stdin JSON, manages per-session state in ~/.claude, performs
-deterministic triage (loop guard, transcript delta, git diff, signal detection,
+deterministic triage (loop guard, transcript parsing, git diff, signal detection,
 question classification, work-type determination), and either exits 0 (allow
 stop) or delegates to stop-hook-llm.py for LLM evaluation.
 
@@ -35,6 +35,7 @@ from mcp_constants import MCP_READ_ONLY, MCP_THINK_PREFIX, mcp_key  # noqa: E402
 # ── Constants ────────────────────────────────────────────────────────────────
 
 _MAX_INPUT = 10 * 1024 * 1024  # 10 MB
+_MAX_PARSE_BYTES = 512 * 1024  # 512 KB tail window for transcript parsing
 _STATE_PATH = Path(
     os.environ.get("STOP_HOOK_STATE_PATH", str(Path.home() / ".claude" / "stop-hook-state.json"))
 )
@@ -42,7 +43,6 @@ _STATE_TTL_SECONDS = 24 * 3600  # 24 hours
 _GIT_TIMEOUT = 5  # seconds
 _LLM_TIMEOUT = 60  # seconds
 _SHORT_RESPONSE_CHARS = 200
-_RECENT_MESSAGES_LIMIT = 10
 _HACK_RECENT_SECONDS = 300  # 5 minutes
 _DB_PATH = Path(
     os.environ.get("GUARD_DB_PATH", str(Path.home() / ".claude" / "logs" / "dev-guard.db"))
@@ -186,15 +186,15 @@ def _update_session_state(
     state: dict,
     session_id: str,
     diff_hash: str,
-    transcript_byte_offset: int,
-    first_user_message: str | None = None,
+    evaluated_tool_count: int,
+    last_file_size: int,
 ) -> dict:
     """Write updated session state and return the full state dict."""
     state[session_id] = {
         "last_diff_hash": diff_hash,
         "last_fire_timestamp": time.time(),
-        "last_transcript_byte_offset": transcript_byte_offset,
-        "first_user_message": first_user_message,
+        "evaluated_tool_count": evaluated_tool_count,
+        "last_file_size": last_file_size,
     }
     return state
 
@@ -224,42 +224,28 @@ def _parse_hook_input() -> dict:
 
 def _parse_transcript(
     transcript_path: str,
-    start_byte_offset: int,
-    cached_first_user_message: str | None,
-) -> tuple[list[str], list[str], str | None, str | None, int]:
-    """Parse JSONL transcript, reading only new bytes from start_byte_offset.
-
-    Uses byte offsets instead of line counts for efficient seeking.
-    Caches first_user_message in caller's state to avoid re-scanning.
-
-    Returns:
-        (new_tool_calls, recent_assistant_messages, latest_user_message,
-         first_user_message, end_byte_offset)
+    recent_user_limit: int = 5,
+    recent_assistant_limit: int = 10,
+) -> tuple[list[str], list[str], list[str]]:
+    """Parse JSONL transcript, reading tail of file.
+    Returns: (all_tool_calls, recent_user_messages, recent_assistant_messages)
     """
-    new_tool_calls: list[str] = []
+    all_tool_calls: list[str] = []
+    user_messages: list[str] = []
     assistant_messages: list[str] = []
-    latest_user_message: str | None = None
-    first_user_message = cached_first_user_message
 
     try:
         path = Path(transcript_path)
         if not path.exists():
-            return [], [], None, first_user_message, 0
+            return [], [], []
 
         file_size = path.stat().st_size
-
-        # No new content since last check
-        if file_size <= start_byte_offset:
-            return [], [], None, first_user_message, start_byte_offset
-
-        # If first_user_message is not cached, read from beginning to find it;
-        # otherwise seek directly to new content
-        need_first_user = first_user_message is None
-        read_from = 0 if need_first_user else start_byte_offset
+        seek_to = max(0, file_size - _MAX_PARSE_BYTES)
 
         with open(path, encoding="utf-8", errors="replace") as f:
-            if read_from > 0:
-                f.seek(read_from)
+            if seek_to > 0:
+                f.seek(seek_to)
+                f.readline()  # discard partial first line after seek
 
             while True:
                 line = f.readline()
@@ -292,23 +278,11 @@ def _parse_transcript(
                 is_user = msg_type == "user" or role == "user"
                 is_assistant = msg_type == "assistant" or role == "assistant"
 
-                # First user message (only when not cached)
-                if need_first_user and is_user and first_user_message is None:
-                    if isinstance(content, str) and content.strip():
-                        first_user_message = content.strip()
-                    elif isinstance(content, list):
-                        for block in content:
-                            if isinstance(block, dict) and block.get("type") == "text":
-                                text = block.get("text", "")
-                                if text.strip():
-                                    first_user_message = text.strip()
-                                    break
-
                 # Tool use entries (flat format: top-level type == "tool_use")
                 if msg_type == "tool_use":
                     tool_name = entry.get("name", "")
                     if tool_name:
-                        new_tool_calls.append(tool_name)
+                        all_tool_calls.append(tool_name)
 
                 # Assistant messages — extract text and tool_use from content blocks
                 if is_assistant:
@@ -323,40 +297,30 @@ def _parse_transcript(
                             elif isinstance(block, dict) and block.get("type") == "tool_use":
                                 name = block.get("name", "")
                                 if name:
-                                    new_tool_calls.append(name)
+                                    all_tool_calls.append(name)
 
-                # User messages (track latest)
+                # User messages — skip pure tool_result entries (no text blocks)
                 if is_user:
                     if isinstance(content, str) and content.strip():
-                        latest_user_message = content.strip()
+                        user_messages.append(content.strip())
                     elif isinstance(content, list):
-                        for block in content:
-                            if isinstance(block, dict) and block.get("type") == "text":
-                                text = block.get("text", "")
-                                if text.strip():
-                                    latest_user_message = text.strip()
-                                    break
-
-            end_offset = f.tell()
-
-        # After a full scan, if first_user_message was never found (e.g. image-only
-        # first message), use "" sentinel so we don't re-scan the entire file next time
-        if need_first_user and first_user_message is None:
-            first_user_message = ""
+                        text_blocks = [
+                            block.get("text", "").strip()
+                            for block in content
+                            if isinstance(block, dict) and block.get("type") == "text"
+                        ]
+                        text_blocks = [t for t in text_blocks if t]
+                        if text_blocks:
+                            user_messages.append(text_blocks[0])
 
     except (OSError, UnicodeDecodeError):
-        return [], [], None, first_user_message, start_byte_offset
+        return [], [], []
 
-    # Deduplicate tool calls while preserving order
-    seen: set[str] = set()
-    deduped_tool_calls: list[str] = []
-    for tc in new_tool_calls:
-        if tc not in seen:
-            seen.add(tc)
-            deduped_tool_calls.append(tc)
-
-    recent = assistant_messages[-_RECENT_MESSAGES_LIMIT:]
-    return deduped_tool_calls, recent, latest_user_message, first_user_message, end_offset
+    return (
+        all_tool_calls,
+        user_messages[-recent_user_limit:],
+        assistant_messages[-recent_assistant_limit:],
+    )
 
 
 # ── Git Checks ───────────────────────────────────────────────────────────────
@@ -790,32 +754,49 @@ def main() -> None:
     # ── Fast-exit 2: First fire — initialize state ───────────────────────────
     if session_state is None:
         diff_hash = _git_diff_hash(cwd)
-        # Set byte_offset to 0 — next invocation will parse from byte 0, catching everything
-        state = _update_session_state(state, session_id, diff_hash, 0, None)
-        _save_state(state)
-        _exit_pass()
-
-    last_byte_offset = session_state.get("last_transcript_byte_offset", 0)
-    last_diff_hash = session_state.get("last_diff_hash", "")
-    cached_first_user_message = session_state.get("first_user_message")
-
-    # ── Parse transcript delta ───────────────────────────────────────────────
-    (
-        new_tool_calls,
-        recent_assistant_messages,
-        latest_user_message,
-        first_user_message,
-        end_byte_offset,
-    ) = _parse_transcript(transcript_path, last_byte_offset, cached_first_user_message)
-
-    # ── Fast-exit 3: No new transcript content ───────────────────────────────
-    if end_byte_offset <= last_byte_offset:
-        # No new content — nothing changed, reuse last_diff_hash to avoid git subprocess
         state = _update_session_state(
-            state, session_id, last_diff_hash, end_byte_offset, first_user_message
+            state, session_id, diff_hash, evaluated_tool_count=0, last_file_size=0
         )
         _save_state(state)
         _exit_pass()
+
+    evaluated_count = session_state.get("evaluated_tool_count", 0)
+    last_file_size = session_state.get("last_file_size", 0)
+    last_diff_hash = session_state.get("last_diff_hash", "")
+
+    # ── Stat transcript file ─────────────────────────────────────────────────
+    try:
+        file_size = Path(transcript_path).stat().st_size
+    except OSError:
+        file_size = 0
+
+    # ── Fast-exit 3: File size unchanged ────────────────────────────────────
+    if file_size > 0 and file_size == last_file_size:
+        state = _update_session_state(
+            state, session_id, last_diff_hash, evaluated_count, last_file_size
+        )
+        _save_state(state)
+        _exit_pass()
+
+    # ── Parse transcript ─────────────────────────────────────────────────────
+    all_tool_calls, recent_user_messages, recent_assistant_messages = _parse_transcript(
+        transcript_path
+    )
+
+    latest_user_message = recent_user_messages[-1] if recent_user_messages else None
+
+    # ── Tool-call dedup via count ────────────────────────────────────────────
+    if evaluated_count > len(all_tool_calls):
+        evaluated_count = 0  # transcript compacted, re-evaluate all
+    new_tool_calls = all_tool_calls[evaluated_count:]
+
+    # Create name-deduped list for LLM context
+    seen: set[str] = set()
+    llm_tool_calls: list[str] = []
+    for tc in new_tool_calls:
+        if tc not in seen:
+            seen.add(tc)
+            llm_tool_calls.append(tc)
 
     # ── Git diff check ───────────────────────────────────────────────────────
     current_diff_hash = _git_diff_hash(cwd)
@@ -833,7 +814,7 @@ def main() -> None:
     # ── Fast-exit 4: META question ───────────────────────────────────────────
     if question_type == "meta" and not write_signals and not diff_changed:
         state = _update_session_state(
-            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+            state, session_id, current_diff_hash, len(all_tool_calls), file_size
         )
         _save_state(state)
         _exit_pass()
@@ -841,7 +822,7 @@ def main() -> None:
     # ── Fast-exit 5: OPINION question ────────────────────────────────────────
     if question_type == "opinion" and not write_signals and not diff_changed:
         state = _update_session_state(
-            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+            state, session_id, current_diff_hash, len(all_tool_calls), file_size
         )
         _save_state(state)
         _exit_pass()
@@ -859,7 +840,7 @@ def main() -> None:
         and not user_requested_action
     ):
         state = _update_session_state(
-            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+            state, session_id, current_diff_hash, len(all_tool_calls), file_size
         )
         _save_state(state)
         _exit_pass()
@@ -867,7 +848,7 @@ def main() -> None:
     # ── Exit-with-guidance: Research + short response ────────────────────────
     if research_used and response_is_short and not write_signals and not diff_changed:
         state = _update_session_state(
-            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+            state, session_id, current_diff_hash, len(all_tool_calls), file_size
         )
         _save_state(state)
         _exit_pass("Research done, verify external claims if any.")
@@ -882,7 +863,7 @@ def main() -> None:
         and has_question_in_message
     ):
         state = _update_session_state(
-            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+            state, session_id, current_diff_hash, len(all_tool_calls), file_size
         )
         _save_state(state)
         _exit_pass("Answer based on code exploration.")
@@ -910,7 +891,7 @@ def main() -> None:
     # ── Fast-exit 7: No triggers at all ─────────────────────────────────────
     if not trigger_reasons:
         state = _update_session_state(
-            state, session_id, current_diff_hash, end_byte_offset, first_user_message
+            state, session_id, current_diff_hash, len(all_tool_calls), file_size
         )
         _save_state(state)
         _exit_pass()
@@ -924,9 +905,10 @@ def main() -> None:
     diff_stat = _git_diff_stat(cwd) if diff_changed else None
 
     llm_context = {
-        "first_user_message": first_user_message,
-        "new_tool_calls": new_tool_calls,
+        "recent_user_messages": recent_user_messages,
+        "last_assistant_message": last_assistant_message,
         "recent_assistant_messages": recent_assistant_messages,
+        "new_tool_calls": llm_tool_calls,
         "git_diff_stat": diff_stat,
         "trigger_reasons": trigger_reasons,
         "work_type": work_type,
@@ -959,7 +941,7 @@ def main() -> None:
 
     # ── Update state regardless of decision ─────────────────────────────────
     state = _update_session_state(
-        state, session_id, current_diff_hash, end_byte_offset, first_user_message
+        state, session_id, current_diff_hash, len(all_tool_calls), file_size
     )
     _save_state(state)
 

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -70,26 +70,21 @@ def write_transcript(path: Path, entries: list[dict]) -> None:
     path.write_text("\n".join(lines) + "\n")
 
 
-def transcript_offset(entries: list[dict], seen: int) -> int:
-    """Byte offset after `seen` JSONL entries (matches write_transcript format)."""
-    return sum(len(json.dumps(e)) + 1 for e in entries[:seen])
-
-
 def seed_state(
     state_path: Path,
     session_id: str,
     *,
-    byte_offset: int = 0,
+    evaluated_tool_count: int = 0,
+    last_file_size: int = 0,
     diff_hash: str = "",
-    first_user_message: str | None = None,
 ) -> None:
     """Write initial state so the hook treats this as a second fire."""
     state = {
         session_id: {
             "last_diff_hash": diff_hash,
             "last_fire_timestamp": time.time(),
-            "last_transcript_byte_offset": byte_offset,
-            "first_user_message": first_user_message,
+            "evaluated_tool_count": evaluated_tool_count,
+            "last_file_size": last_file_size,
         }
     }
     state_path.write_text(json.dumps(state))
@@ -161,7 +156,8 @@ class TestFirstFire:
         entry = state[session_id]
         assert "last_diff_hash" in entry
         assert "last_fire_timestamp" in entry
-        assert "last_transcript_byte_offset" in entry
+        assert "evaluated_tool_count" in entry
+        assert "last_file_size" in entry
 
     def test_first_fire_with_corrupt_state_exits_0(self, tmp_path):
         state_path = tmp_path / "state.json"
@@ -183,11 +179,11 @@ class TestZeroNewContent:
             {"role": "assistant", "content": "hi"},
         ]
         write_transcript(transcript, entries)
-        # Seed state at end of file — no new content since last fire
+        # Seed state with the actual file size — triggers file-size-unchanged fast-exit
         seed_state(
             tmp_path / "state.json",
             session_id,
-            byte_offset=transcript_offset(entries, len(entries)),
+            last_file_size=transcript.stat().st_size,
         )
 
         payload = make_payload(session_id=session_id, transcript_path=str(transcript))
@@ -207,7 +203,7 @@ class TestShortResponseFastExit:
             {"role": "assistant", "content": "It is 3pm."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
 
         payload = make_payload(
             session_id=session_id,
@@ -227,7 +223,7 @@ class TestShortResponseFastExit:
             {"role": "assistant", "content": long_msg},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
 
         # No plugin root → LLM fails open → still exits 0, but didn't short-circuit
         payload = make_payload(
@@ -257,7 +253,7 @@ class TestQuestionClassification:
             {"role": "assistant", "content": assistant_msg},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
         payload = make_payload(
             session_id=session_id,
             transcript_path=str(transcript),
@@ -306,7 +302,7 @@ class TestExitWithGuidance:
             {"role": "assistant", "content": "Here is a summary."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
 
         # Pass cwd=tmp_path (non-git dir) so git diff returns empty string,
         # matching the seeded empty diff_hash — otherwise diff_changed=True blocks this path.
@@ -333,7 +329,7 @@ class TestExitWithGuidance:
             {"role": "assistant", "content": "Here are the docs."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
 
         payload = make_payload(
             session_id=session_id,
@@ -358,7 +354,7 @@ class TestExitWithGuidance:
             {"role": "assistant", "content": "Found the pattern."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
 
         payload = make_payload(
             session_id=session_id,
@@ -383,7 +379,7 @@ class TestExitWithGuidance:
             {"role": "assistant", "content": "You have 3 open issues."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
 
         payload = make_payload(
             session_id=session_id,
@@ -406,7 +402,7 @@ class TestExitWithGuidance:
             {"role": "assistant", "content": "It reads files."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
 
         payload = make_payload(
             session_id=session_id,
@@ -432,7 +428,7 @@ class TestWriteToolSignals:
             {"role": "assistant", "content": "I've completed the fix. The changes are ready."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
         return session_id, transcript, "I've completed the fix. The changes are ready."
 
     def test_edit_tool_triggers_llm_path(self, tmp_path):
@@ -517,7 +513,7 @@ class TestMCPWriteToolSignals:
             {"role": "assistant", "content": assistant_msg},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
         return session_id, transcript
 
     def test_mcp_read_only_tool_does_not_trigger(self, tmp_path):
@@ -586,7 +582,7 @@ class TestCompletionClaims:
             {"role": "assistant", "content": assistant_msg},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
         payload = make_payload(
             session_id=session_id,
             transcript_path=str(transcript),
@@ -640,7 +636,7 @@ class TestLLMSubprocess:
         ]
         write_transcript(transcript, entries)
         state_path = tmp_path / "state.json"
-        seed_state(state_path, session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(state_path, session_id)
         payload = make_payload(
             session_id=session_id,
             transcript_path=str(transcript),
@@ -693,7 +689,7 @@ class TestLLMSubprocess:
 
 class TestStateManagement:
     def test_state_updated_after_pass(self, tmp_path):
-        """State file reflects new byte offset after a passing run."""
+        """State file reflects updated evaluated_tool_count and last_file_size after pass."""
         transcript = tmp_path / "transcript.jsonl"
         session_id = "sess-state-update"
         entries = [
@@ -704,7 +700,7 @@ class TestStateManagement:
         ]
         write_transcript(transcript, entries)
         state_path = tmp_path / "state.json"
-        seed_state(state_path, session_id, byte_offset=transcript_offset(entries, 2))
+        seed_state(state_path, session_id)
 
         payload = make_payload(
             session_id=session_id,
@@ -716,9 +712,9 @@ class TestStateManagement:
 
         state = json.loads(state_path.read_text())
         assert session_id in state
-        assert state[session_id]["last_transcript_byte_offset"] == transcript_offset(
-            entries, len(entries)
-        )
+        assert "evaluated_tool_count" in state[session_id]
+        assert "last_file_size" in state[session_id]
+        assert state[session_id]["last_file_size"] == transcript.stat().st_size
 
     def test_stale_sessions_pruned(self, tmp_path):
         """Sessions older than 24h are removed from state on next run."""
@@ -731,7 +727,8 @@ class TestStateManagement:
             old_session: {
                 "last_diff_hash": "",
                 "last_fire_timestamp": old_time,
-                "last_transcript_byte_offset": 0,
+                "evaluated_tool_count": 0,
+                "last_file_size": 0,
             },
         }
         state_path.write_text(json.dumps(state))
@@ -786,7 +783,7 @@ class TestNonGitDirectory:
             {"role": "assistant", "content": "Hi there."},
         ]
         write_transcript(transcript, entries)
-        seed_state(tmp_path / "state.json", session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(tmp_path / "state.json", session_id)
 
         payload = make_payload(
             session_id=session_id,
@@ -800,7 +797,7 @@ class TestNonGitDirectory:
     def test_missing_transcript_exits_0(self, tmp_path):
         """Missing transcript file → graceful fast exit."""
         session_id = str(uuid.uuid4())
-        seed_state(tmp_path / "state.json", session_id, byte_offset=0)
+        seed_state(tmp_path / "state.json", session_id)
         payload = make_payload(
             session_id=session_id,
             transcript_path="/nonexistent/path/transcript.jsonl",
@@ -825,7 +822,7 @@ class TestAgentToolSignals:
         ]
         write_transcript(transcript, entries)
         state_path = tmp_path / "state.json"
-        seed_state(state_path, session_id, byte_offset=transcript_offset(entries, 1))
+        seed_state(state_path, session_id)
 
         payload = make_payload(
             session_id=session_id,
@@ -896,7 +893,6 @@ class TestHackDirModified:
         seed_state(
             tmp_path / "state.json",
             session_id,
-            byte_offset=transcript_offset(entries, 1),
         )
 
         payload = make_payload(
@@ -941,7 +937,6 @@ class TestHackDirModified:
         seed_state(
             tmp_path / "state.json",
             session_id,
-            byte_offset=transcript_offset(entries, 1),
         )
 
         payload = make_payload(
@@ -978,7 +973,6 @@ class TestHackDirModified:
         seed_state(
             tmp_path / "state.json",
             session_id,
-            byte_offset=transcript_offset(entries, 1),
         )
 
         payload = make_payload(
@@ -1003,7 +997,6 @@ class TestHackDirModified:
         seed_state(
             tmp_path / "state.json",
             session_id,
-            byte_offset=transcript_offset(entries, 1),
         )
 
         payload = make_payload(
@@ -1020,16 +1013,17 @@ class TestHackDirModified:
 
 
 class TestStateMigration:
-    def test_old_line_count_state_degrades_gracefully(self, tmp_path):
-        """Old state with last_transcript_line_count is handled via .get() defaults."""
+    def test_old_byte_offset_state_degrades_gracefully(self, tmp_path):
+        """Old state with last_transcript_byte_offset is handled via .get() defaults."""
         state_path = tmp_path / "state.json"
         session_id = "sess-migration"
-        # Write old-format state (pre-byte-offset migration)
+        # Write old-format state (pre-count migration)
         old_state = {
             session_id: {
                 "last_diff_hash": "",
                 "last_fire_timestamp": time.time(),
-                "last_transcript_line_count": 5,  # old key name
+                "last_transcript_byte_offset": 42,  # old key name
+                "first_user_message": "Hello.",  # old key name
             }
         }
         state_path.write_text(json.dumps(old_state))
@@ -1047,13 +1041,15 @@ class TestStateMigration:
             last_assistant_message="Hi.",
         )
         result = run_hook(payload, state_path=state_path)
-        # Old key is ignored, byte_offset defaults to 0 → full re-scan → exit 0
+        # Old keys ignored, evaluated_tool_count defaults to 0 → full parse → exit 0
         assert result.returncode == 0
 
         # Verify state was rewritten with new schema
         new_state = json.loads(state_path.read_text())
-        assert "last_transcript_byte_offset" in new_state[session_id]
-        assert "last_transcript_line_count" not in new_state[session_id]
+        assert "evaluated_tool_count" in new_state[session_id]
+        assert "last_file_size" in new_state[session_id]
+        assert "last_transcript_byte_offset" not in new_state[session_id]
+        assert "first_user_message" not in new_state[session_id]
 
 
 # ── Multi-fire integration ────────────────────────────────────────────────────
@@ -1061,7 +1057,7 @@ class TestStateMigration:
 
 class TestMultiFireIntegration:
     def test_three_sequential_fires_with_transcript_growth(self, tmp_path):
-        """Fire hook 3 times as transcript grows — verifies byte offset tracking."""
+        """Fire hook 3 times as transcript grows — verifies file size and count tracking."""
         transcript = tmp_path / "transcript.jsonl"
         state_path = tmp_path / "state.json"
         session_id = "sess-multi-fire"
@@ -1079,7 +1075,9 @@ class TestMultiFireIntegration:
         result = run_hook(payload, state_path=state_path)
         assert result.returncode == 0
         state = json.loads(state_path.read_text())
-        assert state[session_id]["last_transcript_byte_offset"] == 0  # first fire sets 0
+        # First fire initializes evaluated_tool_count=0 and last_file_size=0
+        assert state[session_id]["evaluated_tool_count"] == 0
+        assert state[session_id]["last_file_size"] == 0
 
         # Fire 2: transcript has grown, hook parses new content
         entries_v2 = entries_v1 + [
@@ -1094,12 +1092,11 @@ class TestMultiFireIntegration:
         result = run_hook(payload, state_path=state_path)
         assert result.returncode == 0
         state = json.loads(state_path.read_text())
-        fire2_offset = state[session_id]["last_transcript_byte_offset"]
-        assert fire2_offset > 0
-        # first_user_message should now be cached
-        assert state[session_id]["first_user_message"] == "Fix the bug."
+        fire2_size = state[session_id]["last_file_size"]
+        assert fire2_size > 0
+        assert fire2_size == transcript.stat().st_size
 
-        # Fire 3: transcript grows again, only new bytes parsed
+        # Fire 3: transcript grows again
         entries_v3 = entries_v2 + [
             {"role": "user", "content": "Is it done yet?"},
             {"role": "assistant", "content": "Almost."},
@@ -1113,10 +1110,9 @@ class TestMultiFireIntegration:
         result = run_hook(payload, state_path=state_path)
         assert result.returncode == 0
         state = json.loads(state_path.read_text())
-        fire3_offset = state[session_id]["last_transcript_byte_offset"]
-        assert fire3_offset > fire2_offset
-        # first_user_message stays cached
-        assert state[session_id]["first_user_message"] == "Fix the bug."
+        fire3_size = state[session_id]["last_file_size"]
+        assert fire3_size > fire2_size
+        assert fire3_size == transcript.stat().st_size
 
 
 # ── Unit tests for _detect_doc_gap ───────────────────────────────────────────
@@ -1188,3 +1184,322 @@ class TestDetectDocGap:
     def test_cargo_toml_counts_as_docs(self):
         """Cargo.toml is a manifest -> counts as docs (case-insensitive)."""
         assert self.mod._detect_doc_gap(["src/main.rs", "Cargo.toml"]) is False
+
+
+# ── Unit tests for _parse_transcript ─────────────────────────────────────────
+
+
+class TestParseTranscript:
+    """Unit tests for _parse_transcript (tail-read, user filtering, slicing)."""
+
+    def setup_method(self):
+        self.mod = _load_stop_hook_module()
+
+    def test_recent_user_messages_window(self, tmp_path):
+        """8 user messages → only last 5 returned (recent_user_limit=5)."""
+        transcript = tmp_path / "t.jsonl"
+        entries = [
+            {"role": "user", "content": f"message {i}"}
+            for i in range(1, 9)  # 8 user messages
+        ]
+        write_transcript(transcript, entries)
+        all_tools, user_msgs, _ = self.mod._parse_transcript(str(transcript))
+        assert len(user_msgs) == 5
+        assert user_msgs[0] == "message 4"
+        assert user_msgs[-1] == "message 8"
+
+    def test_tool_result_user_entries_filtered(self, tmp_path):
+        """User entries whose content is a list of only tool_result blocks are skipped."""
+        transcript = tmp_path / "t.jsonl"
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            # Pure tool_result — no text blocks, should be filtered
+            {
+                "role": "user",
+                "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}],
+            },
+            {"role": "assistant", "content": "Done."},
+        ]
+        write_transcript(transcript, entries)
+        _, user_msgs, _ = self.mod._parse_transcript(str(transcript))
+        assert user_msgs == ["Fix the bug."]
+
+    def test_user_entry_with_text_and_tool_result_blocks_kept(self, tmp_path):
+        """User entry with mixed text+tool_result blocks: text blocks are extracted."""
+        transcript = tmp_path / "t.jsonl"
+        entries = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "ok"},
+                    {"type": "text", "text": "Here is my follow-up."},
+                ],
+            },
+        ]
+        write_transcript(transcript, entries)
+        _, user_msgs, _ = self.mod._parse_transcript(str(transcript))
+        assert user_msgs == ["Here is my follow-up."]
+
+    def test_all_tool_calls_collected_undeduped(self, tmp_path):
+        """all_tool_calls returns every occurrence including duplicates."""
+        transcript = tmp_path / "t.jsonl"
+        entries = [
+            {"type": "tool_use", "name": "Read", "id": "t1"},
+            {"type": "tool_use", "name": "Read", "id": "t2"},
+            {"type": "tool_use", "name": "Edit", "id": "t3"},
+        ]
+        write_transcript(transcript, entries)
+        all_tools, _, _ = self.mod._parse_transcript(str(transcript))
+        assert all_tools == ["Read", "Read", "Edit"]
+
+    def test_missing_transcript_returns_empty_tuples(self, tmp_path):
+        """Non-existent transcript path → ([], [], [])."""
+        all_tools, user_msgs, asst_msgs = self.mod._parse_transcript(
+            str(tmp_path / "nonexistent.jsonl")
+        )
+        assert all_tools == []
+        assert user_msgs == []
+        assert asst_msgs == []
+
+    def test_recent_assistant_messages_limit(self, tmp_path):
+        """More than 10 assistant messages → only last 10 returned."""
+        transcript = tmp_path / "t.jsonl"
+        entries = [
+            {"role": "assistant", "content": f"reply {i}"}
+            for i in range(1, 13)  # 12 assistant messages
+        ]
+        write_transcript(transcript, entries)
+        _, _, asst_msgs = self.mod._parse_transcript(str(transcript))
+        assert len(asst_msgs) == 10
+        assert asst_msgs[0] == "reply 3"
+        assert asst_msgs[-1] == "reply 12"
+
+
+# ── Tool-count dedup and compacted transcript ─────────────────────────────────
+
+
+class TestToolCountDedup:
+    def test_evaluated_count_skips_already_seen_tool_calls(self, tmp_path):
+        """evaluated_tool_count from state skips those tools on next fire."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        # Transcript has Edit tool call — we seed as if we already evaluated it
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            {"type": "tool_use", "name": "Edit", "id": "t1"},
+            {"role": "assistant", "content": "Done."},
+        ]
+        write_transcript(transcript, entries)
+        # evaluated_tool_count=1 means we already counted the Edit call
+        seed_state(tmp_path / "state.json", session_id, evaluated_tool_count=1)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="Done.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        # No new tool calls after offset → short response fast exit → exit 0
+        assert result.returncode == 0
+
+    def test_compacted_transcript_resets_count(self, tmp_path):
+        """If evaluated_count > len(all_tool_calls), count resets to 0 (re-evaluate all)."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            {"type": "tool_use", "name": "Edit", "id": "t1"},
+            {"role": "assistant", "content": "I've completed the fix."},
+        ]
+        write_transcript(transcript, entries)
+        # Seed with a stale count higher than actual tool calls (simulates compaction)
+        seed_state(tmp_path / "state.json", session_id, evaluated_tool_count=99)
+
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="I've completed the fix.",
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        # Count reset to 0 → Edit seen → completion claim → LLM invoked → pass
+        assert result.returncode == 0
+        state = json.loads((tmp_path / "state.json").read_text())
+        assert state[session_id]["evaluated_tool_count"] == 1
+
+
+# ── File-size fast-exit ───────────────────────────────────────────────────────
+
+
+class TestFileSizeFastExit:
+    def test_same_file_size_exits_0_without_parsing(self, tmp_path):
+        """Seeding last_file_size == actual file size → fast exit 0."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix it."},
+            {"type": "tool_use", "name": "Edit", "id": "t1"},
+            {"role": "assistant", "content": "I've completed the fix."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(
+            tmp_path / "state.json",
+            session_id,
+            last_file_size=transcript.stat().st_size,
+        )
+        # Even with a write tool in transcript, file-size fast-exit fires first
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="I've completed the fix.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0
+
+    def test_grown_file_size_proceeds_to_parse(self, tmp_path):
+        """File size larger than seeded → proceeds past fast-exit to parse."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            {"type": "tool_use", "name": "Edit", "id": "t1"},
+            {"role": "assistant", "content": "I've completed the fix."},
+        ]
+        write_transcript(transcript, entries)
+        # Seed with a smaller size than actual → file has grown → parse proceeds
+        seed_state(tmp_path / "state.json", session_id, last_file_size=10)
+
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="I've completed the fix.",
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        # Parse proceeded, Edit seen, completion claim → LLM invoked → pass
+        assert result.returncode == 0
+
+
+# ── LLM context fields: last_assistant_message and recent_user_messages ───────
+
+
+class TestLLMContextFields:
+    def test_llm_receives_last_assistant_message(self, tmp_path):
+        """Mock LLM stub receives last_assistant_message in context JSON."""
+        # Write a stub that validates the context field and fails if missing
+        hooks_dir = tmp_path / "plugin" / "hooks"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        stub = textwrap.dedent("""\
+            #!/usr/bin/env -S uv run
+            # /// script
+            # requires-python = ">=3.10"
+            # ///
+            import json, sys
+            ctx = json.loads(sys.stdin.read())
+            if "last_assistant_message" not in ctx:
+                print(json.dumps({"decision": "fail", "reasoning": "missing field",
+                    "findings": ["last_assistant_message not in context"]}))
+                sys.exit(2)
+            print(json.dumps({"decision": "pass", "reasoning": "ok", "findings": None}))
+            sys.exit(0)
+        """)
+        (hooks_dir / "stop-hook-llm.py").write_text(stub)
+        (hooks_dir / "stop-hook-llm.py").chmod(0o755)
+
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            {"type": "tool_use", "name": "Edit", "id": "t1"},
+            {"role": "assistant", "content": "I've completed the fix."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="I've completed the fix.",
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        assert result.returncode == 0
+
+    def test_llm_receives_recent_user_messages(self, tmp_path):
+        """Mock LLM stub receives recent_user_messages list in context JSON."""
+        hooks_dir = tmp_path / "plugin" / "hooks"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        stub = textwrap.dedent("""\
+            #!/usr/bin/env -S uv run
+            # /// script
+            # requires-python = ">=3.10"
+            # ///
+            import json, sys
+            ctx = json.loads(sys.stdin.read())
+            if not isinstance(ctx.get("recent_user_messages"), list):
+                print(json.dumps({"decision": "fail", "reasoning": "missing field",
+                    "findings": ["recent_user_messages not a list"]}))
+                sys.exit(2)
+            print(json.dumps({"decision": "pass", "reasoning": "ok", "findings": None}))
+            sys.exit(0)
+        """)
+        (hooks_dir / "stop-hook-llm.py").write_text(stub)
+        (hooks_dir / "stop-hook-llm.py").chmod(0o755)
+
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            {"type": "tool_use", "name": "Edit", "id": "t1"},
+            {"role": "assistant", "content": "I've completed the fix."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="I've completed the fix.",
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        assert result.returncode == 0
+
+
+# ── latest_user_message semantic: comes from recent messages, not first ───────
+
+
+class TestLatestUserMessageSemantic:
+    def test_latest_user_message_is_last_not_first(self, tmp_path):
+        """latest_user_message is derived from recent_user_messages[-1], not first."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        # First message is an action word; last is a meta word (should fast-exit)
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            {"role": "assistant", "content": "Working on it."},
+            {"role": "user", "content": "Looks good, proceed."},  # meta — last message
+            {"role": "assistant", "content": "Sure."},
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id)
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="Sure.",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        # last user message is meta ("proceed") → fast-exit 4
+        assert result.returncode == 0


### PR DESCRIPTION
## Summary
- Replaces delta byte-offset transcript parsing with 512KB tail-read, eliminating stale first-message-only context that caused false 'earlier turns' findings
- Adds tool-count dedup with compaction safety clamp and file-size fast-exit for efficient re-triggering prevention
- Restructures LLM prompt to Strategy D (Claim vs Evidence) with conversation arc, work evidence, final message evaluation, and adaptive criteria