### PR TITLE
feat(code-quality): adds stateful roadmap lifecycle management

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, LSP navigation, uv-python, incremental planning, roadmap sequencing, session management, file-audit, bug-investigation, unfuck, swarm, quality-gate, map-reduce, and speculative",
       "category": "quality",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, LSP navigation, uv-python, incremental planning, roadmap sequencing, session management, file-audit, bug-investigation, unfuck, swarm, quality-gate, map-reduce, and speculative",
       "category": "quality",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,9 +77,9 @@
     },
     {
       "name": "code-quality",
-      "version": "3.2.1",
+      "version": "3.2.0",
       "source": "./code-quality",
-      "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, LSP navigation, uv-python, incremental planning, roadmap sequencing, session management, file-audit, bug-investigation, unfuck, swarm, quality-gate, map-reduce, and speculative",
+      "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, file-audit, bug-investigation, unfuck, swarm, quality-gate, map-reduce, and speculative",
       "category": "quality",
       "tags": ["agents", "architecture", "security", "qa", "performance", "audit", "lsp", "python", "testing", "planning", "roadmap", "session"],
       "author": {

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Personal Claude Code plugins: LSP servers, code quality agents, development util
 - `/map-reduce` - Parallelized workload processing with chunking, mapper agents, and reducer synthesis
 - `/speculative` - Competing implementations in isolated worktrees with judge selection
 - `/incremental-planning` - Incremental planning workflow with per-task review and assumption surfacing
-- `/roadmap` - Multi-plan phase sequencing and dependency analysis
+- `/roadmap` - Stateful multi-plan phase sequencing with roadmap lifecycle management (update, cleanup, status/drift, fresh creation)
 - `/lsp-navigation` - PROACTIVE semantic code navigation
 - `/uv-python` - PROACTIVE Python tooling enforcement (uv over pip)
 - `/test-runner` - Efficient test execution patterns

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, LSP navigation, uv-python, incremental planning, roadmap sequencing, session management, file-audit, bug-investigation, unfuck, swarm, quality-gate, map-reduce, and speculative",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
-  "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, LSP navigation, uv-python, incremental planning, roadmap sequencing, session management, file-audit, bug-investigation, unfuck, swarm, quality-gate, map-reduce, and speculative",
-  "version": "3.2.1",
+  "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, file-audit, bug-investigation, unfuck, swarm, quality-gate, map-reduce, and speculative",
+  "version": "3.2.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, LSP navigation, uv-python, incremental planning, roadmap sequencing, session management, file-audit, bug-investigation, unfuck, swarm, quality-gate, map-reduce, and speculative",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/README.md
+++ b/code-quality/README.md
@@ -26,7 +26,7 @@ Code quality agents, development utilities, and orchestration skills: architectu
 | `/map-reduce` | Parallelized workload processing with chunking, mapper agents, and reducer synthesis | Manual |
 | `/speculative` | Competing implementations in isolated worktrees with judge selection | Manual |
 | `/incremental-planning` | Planning workflow with per-task review and assumption surfacing | Manual |
-| `/roadmap` | Multi-plan phase sequencing and dependency analysis | Manual |
+| `/roadmap` | Stateful multi-plan phase sequencing with roadmap lifecycle management: detect existing roadmaps, update, cleanup completed work, status/drift report, or fresh creation | Manual |
 | `/lsp-navigation` | Semantic code navigation via LSP | PROACTIVE |
 | `/uv-python` | Python tooling enforcement (uv over pip) | PROACTIVE |
 | `/test-runner` | Efficient test execution patterns | Manual |

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -338,6 +338,14 @@ Pass 2 resumes the Pass 1 agent via `SendMessage` using the **agent ID** (not th
 This preserves the agent's full conversation history from Pass 1. You MUST use the agent
 ID returned in the Pass 1 result — using the agent name routes to a team inbox instead.
 
+**CRITICAL — Pass 2 synchronization:** `SendMessage` is asynchronous — it returns immediately
+but the agent's response arrives later as a teammate notification. You MUST wait for each
+Pass 2 response before proceeding. Do NOT move to Memory Gate or any subsequent gate until
+BOTH Pass 2 responses are received and all findings are fixed. "Message sent" is not
+"response received." If the agent does not respond within 2 minutes, re-do the Pass 2 check
+yourself: re-read the files you fixed and verify the fixes are semantically correct (not just
+syntactically applied). A self-performed Pass 2 is better than a skipped one.
+
 **Subagent A: Completeness Reviewer (opus)**
 
 ```
@@ -352,12 +360,13 @@ PASS 1:
 
 PASS 2 (MANDATORY — do not skip):
   SendMessage(
-    to=<agentId from Pass 1>,
+    to=<agentId from Pass 1>,    ← MUST be agentId, not agent name
     message="Here are the fixes I made: {summary_of_fixes}.
              Review them. Also: what did YOU miss on your first pass?
              You had fresh eyes but still have blind spots. Look again.",
     summary="Pass 2 completeness re-review"
   )
+  → WAIT for response (do not proceed to gates)
   → Fix ALL findings from Pass 2
 ```
 
@@ -375,11 +384,12 @@ PASS 1:
 
 PASS 2 (MANDATORY — do not skip):
   SendMessage(
-    to=<agentId from Pass 1>,
+    to=<agentId from Pass 1>,    ← MUST be agentId, not agent name
     message="Here are the fixes: {summary_of_fixes}.
              Verify they're correct. What else breaks in production?",
     summary="Pass 2 adversarial re-review"
   )
+  → WAIT for response (do not proceed to gates)
   → Fix ALL findings from Pass 2
 ```
 

--- a/code-quality/skills/roadmap/SKILL.md
+++ b/code-quality/skills/roadmap/SKILL.md
@@ -549,7 +549,7 @@ Phase 0: Detect & Route (HITL, requires project memory dir) →
   [Update]  Completion Check → Phase 1-5 (re-ingest, completed phases preserved)
   [Status]  Completion Check → Drift Detection → Report → offer Update/Cleanup/Exit
   [Cleanup] Completion Check → Archive plans → Delete branches → Update roadmap doc
-  [No memory dir] → skip Phase 0, go directly to Phase 1
+  [No memory dir] → skip Phase 0, go to Phase 1 (lifecycle requests get AskUserQuestion first)
 ```
 
 ### What Goes Where

--- a/code-quality/skills/roadmap/SKILL.md
+++ b/code-quality/skills/roadmap/SKILL.md
@@ -39,15 +39,24 @@ Before ingesting any plans, check whether an existing roadmap document already e
 Check for `hack/`, `.local/`, `scratch/`, `.dev/` in the project root (in this order).
 
 - **If found:** Plan directory is `{memory-dir}/plans/`
-- **If none found:** **Skip Phase 0 entirely** — proceed to Phase 1. Stateful roadmap
-  management requires a project-local memory directory. `~/.claude/plans/` is shared across
-  all projects and globbing it would surface cross-project roadmaps, leading to false positives
-  and unintended mutations.
+- **If none found:** **Skip Phase 0** — proceed to Phase 1. Stateful roadmap management
+  requires a project-local memory directory. `~/.claude/plans/` is shared across all projects
+  and globbing it would surface cross-project roadmaps, leading to false positives and
+  unintended mutations.
+
+  **Exception:** If the user's request matches a lifecycle trigger phrase (`roadmap status`,
+  `update roadmap`, `roadmap cleanup`, `roadmap drift`, or similar), do NOT silently fall
+  through to Phase 1. Instead, surface via `AskUserQuestion`:
+  > "Roadmap lifecycle management (update, cleanup, status/drift) requires a project-local
+  > memory directory (hack/, .local/, scratch/, or .dev/). This project doesn't have one.
+  > Options:
+  > 1. Create a new roadmap via Phase 1 (fresh creation only — no lifecycle features)
+  > 2. Abort"
+
+### Step 2: Glob and verify
 
 **Scope the glob strictly to the determined plan directory** — do not glob the project root
 or any other location. This prevents false positives from unrelated files.
-
-### Step 2: Glob and verify
 
 Glob for `*roadmap*.md` within the plan directory only.
 

--- a/code-quality/skills/roadmap/SKILL.md
+++ b/code-quality/skills/roadmap/SKILL.md
@@ -175,6 +175,8 @@ Executes when user selects "Clean up completed work."
 - If all phases are complete: add `**Status:** Completed` to the document header (not just
   per-phase blocks), then offer to archive the entire roadmap file itself:
   > "All phases are complete. Archive the roadmap file to {plan-dir}/done/ as well?"
+  If the user confirms, update the document header `**Status:**` to `Archived` before
+  moving the file to `{plan-dir}/done/`.
 
 **Branch deletion scoping:** Only delete branches matching `roadmap/phase-N/` for the
 specific completed phase numbers. Do NOT delete branches for in-progress or not-started
@@ -228,8 +230,9 @@ never mutates files or branches.**
 **Follow-up actions:**
 
 After presenting the report, offer via `AskUserQuestion`:
-- "Update roadmap to incorporate changes" → Route to Phase 0.U
-- "Clean up completed work" → Route to Phase 0.C
+- "Update roadmap to incorporate changes" → Route to Phase 0.U (re-run from step 1; reuse
+  the completion tracking results already gathered — do not re-run completion tracking)
+- "Clean up completed work" → Route to Phase 0.C (reuse completion tracking results)
 - "No action needed" → Exit
 
 ---

--- a/code-quality/skills/roadmap/SKILL.md
+++ b/code-quality/skills/roadmap/SKILL.md
@@ -36,11 +36,13 @@ Before ingesting any plans, check whether an existing roadmap document already e
 
 ### Step 1: Locate plan directory
 
-Use the same location logic as Phase 4:
+Check for `hack/`, `.local/`, `scratch/`, `.dev/` in the project root (in this order).
 
-1. Check for `hack/`, `.local/`, `scratch/`, `.dev/` in the project root (in this order)
-2. **If found:** Plan directory is `{memory-dir}/plans/`
-3. **If none found:** Plan directory is `~/.claude/plans/`
+- **If found:** Plan directory is `{memory-dir}/plans/`
+- **If none found:** **Skip Phase 0 entirely** — proceed to Phase 1. Stateful roadmap
+  management requires a project-local memory directory. `~/.claude/plans/` is shared across
+  all projects and globbing it would surface cross-project roadmaps, leading to false positives
+  and unintended mutations.
 
 **Scope the glob strictly to the determined plan directory** — do not glob the project root
 or any other location. This prevents false positives from unrelated files.
@@ -209,8 +211,8 @@ never mutates files or branches.**
 - **Modified plans:** Determine the roadmap's generation timestamp: if the roadmap contains a
   `**Last updated:**` field, parse its ISO timestamp as the reference time. Otherwise, use
   the roadmap file's mtime via
-  `Bash(python3 -c "import os; print(os.path.getmtime('[file]'))")` (portable across macOS
-  and Linux). For each source plan, compare its mtime against the reference time. If a source
+  `Bash(uv run python3 -c "import os; print(os.path.getmtime('[file]'))")` (portable across
+  macOS and Linux). For each source plan, compare its mtime against the reference time. If a source
   plan is newer, flag: "Plan [path] was modified after this roadmap was generated."
   On mtime anomaly (plan appears newer but changes unclear), fall back to content comparison:
   read both the plan and the roadmap's corresponding plan reference and diff to confirm
@@ -219,7 +221,7 @@ never mutates files or branches.**
   roadmap's source plans list AND are not the roadmap file itself. Flag only files that:
   (a) appear to be incremental-planning output (contain `**Goal:**` and `## Task N:` markers)
   AND (b) were created after the roadmap was generated (mtime comparison). This filtering
-  prevents false positives from unrelated files in `~/.claude/plans/` or old completed plans.
+  prevents false positives from old completed plans or non-plan files.
   Flag: "New plan [path] not included in this roadmap."
 - **Deleted plans:** For each source plan path, verify it still exists. Flag any missing:
   "Plan [path] no longer exists."
@@ -533,11 +535,12 @@ If a plan is missing `**Goal:**`, no `## Task N:` headings, or no `**Files:**` b
 ### Flow
 
 ```
-Phase 0: Detect & Route (HITL) →
+Phase 0: Detect & Route (HITL, requires project memory dir) →
   [New]     Phase 1 → Phase 2 → Phase 3 (checkpoint) → Phase 4 (incremental) → Phase 5
   [Update]  Completion Check → Phase 1-5 (re-ingest, completed phases preserved)
   [Status]  Completion Check → Drift Detection → Report → offer Update/Cleanup/Exit
   [Cleanup] Completion Check → Archive plans → Delete branches → Update roadmap doc
+  [No memory dir] → skip Phase 0, go directly to Phase 1
 ```
 
 ### What Goes Where
@@ -549,12 +552,15 @@ FILE: Full roadmap document (header + phase blocks, optional Status/Last updated
 NEVER IN CHAT: Full roadmap content, raw table data, raw diff content from subagent validators
 ```
 
-### Roadmap File Location
+### Roadmap File Location (Phase 4 — document generation)
 
 ```
 1. hack/plans/ (or .local/plans/, scratch/plans/, .dev/plans/) → if memory dir exists
 2. ~/.claude/plans/ → fallback for all other cases
 ```
+
+**Phase 0 detection** only runs when a project memory dir exists (option 1 above).
+Projects using `~/.claude/plans/` skip Phase 0 and go straight to Phase 1.
 
 ### Schema Reference
 

--- a/code-quality/skills/roadmap/SKILL.md
+++ b/code-quality/skills/roadmap/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: roadmap
 description: >-
-  Multi-plan phase sequencing and dependency analysis. Use when coordinating
-  multiple implementation plans into parallel/sequential workstreams. Takes
-  existing plan files as input, analyzes cross-plan dependencies, re-organizes
-  tasks across phases, and produces a structured roadmap document optimized
-  for AI orchestrator consumption. Use when asked to "roadmap", "sequence plans",
-  "coordinate multiple plans", "plan execution order", or when 2+ plans need
-  ordering.
+  Stateful multi-plan phase sequencing, dependency analysis, and roadmap lifecycle
+  management. Detects existing roadmaps and routes to update, cleanup, status/drift,
+  or fresh creation. Use when coordinating multiple implementation plans into
+  parallel/sequential workstreams, or when managing an existing roadmap.
+  Trigger phrases: "roadmap", "sequence plans", "coordinate multiple plans",
+  "plan execution order", "roadmap status", "roadmap cleanup", "update roadmap",
+  "roadmap drift", or when 2+ plans need ordering.
 allowed-tools: [Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, Bash, ToolSearch]
 ---
 
@@ -25,6 +25,203 @@ This skill activates when:
 - After `/incremental-planning` generates a plan that references other planned work
 
 **Announce at start:** "Using roadmap to sequence [N] plans into phases."
+
+---
+
+## Phase 0: Detect & Route
+
+Before ingesting any plans, check whether an existing roadmap document already exists.
+
+### Step 1: Locate plan directory
+
+Use the same location logic as Phase 4:
+
+1. Check for `hack/`, `.local/`, `scratch/`, `.dev/` in the project root (in this order)
+2. **If found:** Plan directory is `{memory-dir}/plans/`
+3. **If none found:** Plan directory is `~/.claude/plans/`
+
+**Scope the glob strictly to the determined plan directory** — do not glob the project root
+or any other location. This prevents false positives from unrelated files.
+
+### Step 2: Glob and verify
+
+Glob for `*roadmap*.md` within the plan directory only.
+
+For each match, verify it is an actual roadmap document by checking for **both**:
+- A `# Roadmap:` header (first-level heading starting with "Roadmap:")
+- A `**Source plans:**` field in the document header block
+
+Discard any matches that lack either marker (e.g., a plan file about improving the roadmap
+skill). If no verified roadmaps remain → **skip to Phase 1** (existing flow, unchanged).
+
+### Step 3: Handle multiple roadmaps
+
+If more than one verified roadmap is found, first ask which one to operate on:
+
+```
+AskUserQuestion: "I found [N] roadmap files in [plan-dir]:
+  1. [filename-1] — [title from # Roadmap: header]
+  2. [filename-2] — [title from # Roadmap: header]
+Which roadmap do you want to work with?"
+```
+
+Proceed with the selected roadmap for the remainder of Phase 0.
+
+### Step 4: Parse roadmap header
+
+From the selected roadmap, extract:
+- **Title** — from the `# Roadmap:` heading
+- **Source plans** — from the `**Source plans:**` field (list of plan file paths)
+- **Total phases** — from the `**Total phases:**` field
+
+### Step 5: HITL mode menu
+
+Present a `AskUserQuestion` with four options:
+
+```
+AskUserQuestion: "Found existing roadmap: [title]
+  Source plans: [N] plans | Total phases: [M]
+
+  What would you like to do?
+  1. Update existing roadmap — re-ingest all plans (including any new ones) and regenerate
+  2. Clean up completed work — archive done plans and remove merged branches
+  3. Show status / drift report — see per-phase completion and drift detection (read-only)
+  4. Create new roadmap (ignore existing) — start fresh with Phase 1"
+```
+
+### Routing
+
+Based on the user's selection:
+
+| Choice | Routes to |
+|--------|-----------|
+| Update existing roadmap | **Phase 0.U** (below) — re-ingest with completion awareness |
+| Clean up completed work | **Phase 0.C** (below) — archive and branch removal |
+| Show status / drift report | **Phase 0.S** (below) — read-only status and drift report |
+| Create new roadmap | **Phase 1** — existing flow, existing roadmap is left untouched |
+
+---
+
+### Phase 0.U — Update Mode
+
+Executes when user selects "Update existing roadmap."
+
+1. Parse the existing roadmap's `**Source plans:**` list to get all already-ingested plan paths.
+2. Ask for additional plan paths via `AskUserQuestion`:
+   > "The existing roadmap covers [N] source plans. Do you have new plan files to add?
+   > Provide paths, or press Enter to re-sequence existing plans only."
+3. Combine: existing source plans + any new plans provided → full plan list.
+4. Run completion tracking (see **Completion Tracking** section) to identify which phases
+   are fully complete.
+5. **Preserve completed phases** — do not re-sequence work already done. Only re-analyze
+   incomplete and not-started phases.
+6. **Backup before overwrite:** Copy the existing roadmap to
+   `{plan-dir}/done/{filename}.YYYY-MM-DDTHH-MM-SS.pre-update` (timestamped, unique per run)
+   before writing the regenerated version. Create `{plan-dir}/done/` if it doesn't exist.
+   The `hack/` directory is gitignored — an explicit backup is the only recovery path.
+7. Proceed to Phase 1 with the combined plan list, skipping tasks from completed phases.
+   The regenerated roadmap MUST include `**Last updated:**` with the current ISO timestamp
+   (e.g., `2026-03-20T14:30:00`) in the document header.
+
+**Edge cases:**
+- **Deleted plan:** If a source plan path no longer exists, surface via `AskUserQuestion`:
+  "Plan [path] no longer exists. Remove from roadmap, or provide an updated path?"
+- **All phases complete, no new plans:** Suggest cleanup instead:
+  "All phases are complete. Did you mean to clean up? (Route to Cleanup mode, or continue
+  with update anyway?)"
+- **In-progress phase restructuring:** If re-analysis changes phase numbering and an
+  in-progress branch (e.g., `roadmap/phase-2/plan-x`) would be affected, surface via
+  `AskUserQuestion`:
+  "Phase restructuring would affect in-progress branch [roadmap/phase-2/plan-x]. Options:
+  (1) Rename the branch to match the new structure, (2) Keep current phase structure for
+  in-progress work and only re-sequence not-started phases, (3) Abandon in-progress branch
+  and start fresh."
+  Default to option 2 (least disruptive).
+
+---
+
+### Phase 0.C — Cleanup Mode
+
+Executes when user selects "Clean up completed work."
+
+1. Run completion tracking (see **Completion Tracking** section) to determine which phases
+   are fully complete.
+2. Present a summary in chat:
+   > "Phases 1-2 complete. Phase 3 in progress. Cleanup actions available for completed phases."
+3. Before any mutations, present all planned actions via `AskUserQuestion` and require
+   explicit confirmation:
+   > "Cleanup will:
+   > - Archive source plans for Phase 1: [plan-a.md, plan-b.md] → {plan-dir}/done/
+   > - Archive source plans for Phase 2: [plan-c.md] → {plan-dir}/done/
+   > - Delete local branches: roadmap/phase-1/plan-a, roadmap/phase-1/plan-b,
+   >   roadmap/phase-2/plan-c
+   > - Add 'Status: Completed' to Phase 1 and Phase 2 blocks in the roadmap document
+   > Proceed?"
+4. **Remote branch deletion is a separate opt-in** (never default, never cached):
+   > "Also delete these branches from origin? (This affects shared state — confirm per session)"
+5. Execute cleanup actions **sequentially**: archive files first → delete local branches →
+   delete remote branches (if opted in) → update roadmap document. If any step fails (e.g.,
+   permission error, branch checked out elsewhere), **stop immediately** and surface the
+   error in chat. Do not continue to remaining steps — inconsistent state is better diagnosed
+   with a clear stopping point.
+6. Update the roadmap document: append `**Status:** Completed` to each cleaned-up phase
+   block (non-destructive — preserves phase content for reference).
+
+**Partial cleanup guidance:**
+- Plans that appear in tasks spanning multiple phases (task splitting) are NOT archived
+  until ALL their phases are complete.
+- If all phases are complete, offer to archive the entire roadmap file itself:
+  > "All phases are complete. Archive the roadmap file to {plan-dir}/done/ as well?"
+
+**Branch deletion scoping:** Only delete branches matching `roadmap/phase-N/` for the
+specific completed phase numbers. Do NOT delete branches for in-progress or not-started
+phases — filter by exact phase number, not a broad `roadmap/*` pattern.
+
+---
+
+### Phase 0.S — Status & Drift Report Mode
+
+Executes when user selects "Show status / drift report." **This mode is read-only — it
+never mutates files or branches.**
+
+**Status report:**
+
+1. Run completion tracking (see **Completion Tracking** section) for all phases.
+2. Present per-phase summary in chat:
+   ```
+   Phase 1: Complete (2/2 tracks merged, all tasks validated)
+   Phase 2: In Progress (Track A merged, Track B in-progress)
+   Phase 3: Not Started (blocked by Phase 2)
+   ```
+3. For any phase with `partial` or `deferred` tasks, list the specific tasks and their status.
+
+**Drift detection (shown alongside status):**
+
+- **Modified plans:** For each source plan, check mtime via
+  `Bash(python3 -c "import os; print(os.path.getmtime('[file]'))")` (portable across macOS
+  and Linux). Compare against the roadmap file's mtime. If a source plan is newer, flag:
+  "Plan [path] was modified after this roadmap was generated."
+  On mtime anomaly (plan appears newer but changes unclear), fall back to content comparison:
+  read both the plan and the roadmap's corresponding plan reference and diff to confirm
+  whether real changes exist.
+- **New untracked plans:** Glob for `*.md` in the plan directory that are NOT in the
+  roadmap's source plans list AND are not the roadmap file itself. Flag only files that:
+  (a) appear to be incremental-planning output (contain `**Goal:**` and `## Task N:` markers)
+  AND (b) were created after the roadmap was generated (mtime comparison). This filtering
+  prevents false positives from unrelated files in `~/.claude/plans/` or old completed plans.
+  Flag: "New plan [path] not included in this roadmap."
+- **Deleted plans:** For each source plan path, verify it still exists. Flag any missing:
+  "Plan [path] no longer exists."
+- **Orphaned branches:** Check `git branch | grep roadmap/` for any `roadmap/phase-*`
+  branches that don't match any track in the current roadmap. Flag:
+  "Orphaned branch [name] not in current roadmap (may be from a previous or renamed roadmap)."
+
+**Follow-up actions:**
+
+After presenting the report, offer via `AskUserQuestion`:
+- "Update roadmap to incorporate changes" → Route to Phase 0.U
+- "Clean up completed work" → Route to Phase 0.C
+- "No action needed" → Exit
 
 ---
 
@@ -187,6 +384,95 @@ After all phases are written:
 
 ---
 
+## Completion Tracking
+
+Used by Phase 0.U (update), Phase 0.C (cleanup), and Phase 0.S (status/drift) to determine
+the completion state of each phase and track. Run this logic whenever any mode needs phase
+status before acting.
+
+### Track status determination
+
+For each track in each phase, determine status using the following strategy. Try the primary
+method first; fall back if gh is unavailable or unauthenticated.
+
+**Primary method (requires `gh` auth and network access):**
+
+```bash
+gh pr list --state merged --head roadmap/phase-N/plan-name --json number,mergedAt
+```
+
+Works regardless of merge strategy (merge commit, squash, or rebase). If this returns a
+result, the track is `merged`.
+
+**Fallback method (no network / no gh auth):**
+
+```bash
+# True merges
+git branch --merged main | grep roadmap/phase-N/plan-name
+
+# Squash merges (only works if PR title or commit message contains the branch path)
+git log --oneline main | grep 'roadmap/phase-N/plan-name'
+```
+
+**Caveat:** GitHub's default squash commit message uses the PR title, not the branch name.
+The `git log` grep only works if the PR title or commit message contains the branch path.
+If neither fallback detects a merge, surface via `AskUserQuestion`:
+
+> "Cannot determine if [branch] was merged. Was this PR squash-merged with a different
+> commit message? Provide the PR number or commit SHA to confirm."
+
+**Track status enum:**
+
+| Status | Condition |
+|--------|-----------|
+| `not-started` | Branch `roadmap/phase-N/plan-name` does not exist locally or remotely |
+| `in-progress` | Branch exists but no merged PR found |
+| `merged` | PR merged (via gh) or branch content detected on main (via git fallback) |
+
+### Subagent validation
+
+For each track with `merged` status, spawn a **general-purpose** agent (not Explore — the
+validator needs Bash for git commands, Read, and Grep) with this prompt:
+
+> "Read the plan at [plan-path], tasks [task-range]. Find what the branch changed:
+> First try `gh pr list --state merged --head roadmap/phase-N/plan-name --json number`
+> to get the PR number, then `gh pr diff <number>` for the full diff. If gh is unavailable,
+> find the merge/squash commit via `git log --oneline main | grep 'phase-N/plan-name'` and
+> diff with `git diff <sha>~1..<sha>`. For each task, verify: (1) the files listed in
+> **Files:** exist on main, (2) the diff shows changes consistent with the task's described
+> steps (not just the file existing from before), (3) no task requirements were silently
+> deferred or left as TODOs in the merged code. Report for each task: task number, status
+> (implemented / partial / deferred), and a one-sentence evidence summary citing specific
+> file paths or code locations — do NOT echo raw diff content."
+
+**Important:** The subagent MUST NOT echo raw diff content to chat output (security
+constraint — diffs may contain sensitive content). The validator returns structured verdicts
+only: task number, status, evidence summary.
+
+**Parallel spawning:** Spawn subagent validators for all merged tracks in a phase
+simultaneously — they perform independent reads and can run in parallel.
+
+### Phase status derivation
+
+A phase is `complete` only when:
+1. ALL tracks in the phase have `merged` status, AND
+2. ALL subagent validations report `implemented` for every task
+
+If any track is `in-progress` or `not-started` → phase is `in-progress` or `not-started`.
+If any task is `partial` or `deferred` → phase is `incomplete` (distinct from `in-progress`).
+
+### Handling validation gaps
+
+When subagent validation finds `partial` or `deferred` tasks, surface via `AskUserQuestion`:
+
+> "Phase [N] track [name]: Task [M] is [partial/deferred]. Evidence: [one-sentence summary].
+> Options:
+> 1. Create a follow-up plan for the deferred work
+> 2. Mark as intentionally deferred (acknowledge and proceed)
+> 3. Re-open the phase for remediation"
+
+---
+
 ## Edge Case Guidance
 
 ### Single plan input
@@ -233,17 +519,20 @@ If a plan is missing `**Goal:**`, no `## Task N:` headings, or no `**Files:**` b
 ### Flow
 
 ```
-Phase 1: Ingest Plans → Phase 2: Dependency Analysis →
-Phase 3: Phase Construction (checkpoint) → Phase 4: Document Generation (incremental) →
-Phase 5: Validation and Completion
+Phase 0: Detect & Route (HITL) →
+  [New]     Phase 1 → Phase 2 → Phase 3 (checkpoint) → Phase 4 (incremental) → Phase 5
+  [Update]  Completion Check → Phase 1-5 (re-ingest, completed phases preserved)
+  [Status]  Completion Check → Drift Detection → Report → offer Update/Cleanup/Exit
+  [Cleanup] Completion Check → Archive plans → Delete branches → Update roadmap doc
 ```
 
 ### What Goes Where
 
 ```
-CHAT: Ingest summary, dependency edges found, checkpoint questions, per-phase write confirmations
-FILE: Full roadmap document (header + phase blocks)
-NEVER IN CHAT: Full roadmap content, raw table data
+CHAT: Mode routing, ingest summary, dependency edges, checkpoint questions,
+      per-phase write confirmations, status/drift report, completion validation verdicts
+FILE: Full roadmap document (header + phase blocks, optional Status/Last updated fields)
+NEVER IN CHAT: Full roadmap content, raw table data, raw diff content from subagent validators
 ```
 
 ### Roadmap File Location

--- a/code-quality/skills/roadmap/SKILL.md
+++ b/code-quality/skills/roadmap/SKILL.md
@@ -471,8 +471,9 @@ A phase is `Completed` only when:
 2. ALL subagent validations report `implemented` for every task
 
 If any track is `in-progress` or `not-started` → phase is `In Progress` or `Not Started`.
-If all tracks are `merged` but any task is `partial` or `deferred` → phase is `In Progress`
-(all branches merged but work is incomplete — distinct from branches still open).
+If all tracks are `merged` but any task is `partial` or `deferred` → phase is `Incomplete`
+(all branches merged but not all tasks fully implemented — distinct from `In Progress` where
+branches are still open).
 
 ### Handling validation gaps
 

--- a/code-quality/skills/roadmap/SKILL.md
+++ b/code-quality/skills/roadmap/SKILL.md
@@ -13,8 +13,10 @@ allowed-tools: [Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, Bash, Too
 
 # Roadmap
 
-Multi-plan phase sequencing and dependency analysis. Takes existing plan files as input,
-produces a structured roadmap document consumable by `/swarm` and other orchestrators.
+Stateful multi-plan phase sequencing with roadmap lifecycle management. Takes existing plan
+files as input, produces a structured roadmap document consumable by `/swarm` and other
+orchestrators. Detects existing roadmaps and routes to update, cleanup, status/drift, or
+fresh creation.
 
 ## Activation
 
@@ -170,12 +172,17 @@ Executes when user selects "Clean up completed work."
 **Partial cleanup guidance:**
 - Plans that appear in tasks spanning multiple phases (task splitting) are NOT archived
   until ALL their phases are complete.
-- If all phases are complete, offer to archive the entire roadmap file itself:
+- If all phases are complete: add `**Status:** Completed` to the document header (not just
+  per-phase blocks), then offer to archive the entire roadmap file itself:
   > "All phases are complete. Archive the roadmap file to {plan-dir}/done/ as well?"
 
 **Branch deletion scoping:** Only delete branches matching `roadmap/phase-N/` for the
 specific completed phase numbers. Do NOT delete branches for in-progress or not-started
 phases — filter by exact phase number, not a broad `roadmap/*` pattern.
+
+**After cleanup completes**, announce: "Cleanup complete. [N] plans archived, [M] branches
+deleted, [P] phase blocks marked Completed." If not all phases were cleaned up, note which
+phases remain active.
 
 ---
 
@@ -189,7 +196,7 @@ never mutates files or branches.**
 1. Run completion tracking (see **Completion Tracking** section) for all phases.
 2. Present per-phase summary in chat:
    ```
-   Phase 1: Complete (2/2 tracks merged, all tasks validated)
+   Phase 1: Completed (2/2 tracks merged, all tasks validated)
    Phase 2: In Progress (Track A merged, Track B in-progress)
    Phase 3: Not Started (blocked by Phase 2)
    ```
@@ -197,10 +204,12 @@ never mutates files or branches.**
 
 **Drift detection (shown alongside status):**
 
-- **Modified plans:** For each source plan, check mtime via
+- **Modified plans:** Determine the roadmap's generation timestamp: if the roadmap contains a
+  `**Last updated:**` field, parse its ISO timestamp as the reference time. Otherwise, use
+  the roadmap file's mtime via
   `Bash(python3 -c "import os; print(os.path.getmtime('[file]'))")` (portable across macOS
-  and Linux). Compare against the roadmap file's mtime. If a source plan is newer, flag:
-  "Plan [path] was modified after this roadmap was generated."
+  and Linux). For each source plan, compare its mtime against the reference time. If a source
+  plan is newer, flag: "Plan [path] was modified after this roadmap was generated."
   On mtime anomaly (plan appears newer but changes unclear), fall back to content comparison:
   read both the plan and the roadmap's corresponding plan reference and diff to confirm
   whether real changes exist.
@@ -454,12 +463,13 @@ simultaneously — they perform independent reads and can run in parallel.
 
 ### Phase status derivation
 
-A phase is `complete` only when:
+A phase is `Completed` only when:
 1. ALL tracks in the phase have `merged` status, AND
 2. ALL subagent validations report `implemented` for every task
 
-If any track is `in-progress` or `not-started` → phase is `in-progress` or `not-started`.
-If any task is `partial` or `deferred` → phase is `incomplete` (distinct from `in-progress`).
+If any track is `in-progress` or `not-started` → phase is `In Progress` or `Not Started`.
+If all tracks are `merged` but any task is `partial` or `deferred` → phase is `In Progress`
+(all branches merged but work is incomplete — distinct from branches still open).
 
 ### Handling validation gaps
 

--- a/code-quality/skills/roadmap/references/phase-schema.md
+++ b/code-quality/skills/roadmap/references/phase-schema.md
@@ -108,15 +108,17 @@ A `**Status:**` line may appear in a phase block after cleanup mode marks it com
 | Track | ...
 ```
 
-Values: `Not Started` | `In Progress` | `Completed`
+Values: `Not Started` | `In Progress` | `Incomplete` | `Completed`
 
 - `Not Started` — default; branch does not exist
 - `In Progress` — branch exists but no merged PR found
+- `Incomplete` — all tracks merged but subagent validation found `partial` or `deferred` tasks
 - `Completed` — written explicitly by cleanup mode after all tracks merged and validated
 
-Note: `Not Started` and `In Progress` are runtime-derived states (from branch checks) and are
-**not written to the roadmap file**. Only `Completed` is persisted. Absence of a `**Status:**`
-field means the phase has not been explicitly marked complete.
+Note: `Not Started`, `In Progress`, and `Incomplete` are runtime-derived states (from branch
+checks and subagent validation) and are **not written to the roadmap file**. Only `Completed`
+is persisted. Absence of a `**Status:**` field means the phase has not been explicitly marked
+complete.
 
 ### Per-track validation result format
 

--- a/code-quality/skills/roadmap/references/phase-schema.md
+++ b/code-quality/skills/roadmap/references/phase-schema.md
@@ -140,8 +140,11 @@ Cleanup mode archives completed work to prevent plan directory clutter.
 
 ### Archive location
 
-`{plan-dir}/done/` — a subdirectory of the plan directory (`hack/plans/done/`,
-`~/.claude/plans/done/`, etc.). Created if it doesn't exist.
+`{plan-dir}/done/` — a subdirectory of the plan directory (e.g., `hack/plans/done/`).
+Created if it doesn't exist.
+
+Note: Cleanup mode (Phase 0.C) is only available for project-local memory directories.
+Roadmaps in `~/.claude/plans/` do not support lifecycle operations (see SKILL.md Phase 0).
 
 ### What gets archived (and when)
 

--- a/code-quality/skills/roadmap/references/phase-schema.md
+++ b/code-quality/skills/roadmap/references/phase-schema.md
@@ -26,7 +26,7 @@ Every roadmap document begins with a header block:
 | Source plans | Yes | Absolute paths to all plan files ingested |
 | Total phases | Yes | Count of sequential phases |
 | Critical path | Yes | Which plans/tracks gate the overall schedule, and why |
-| Status | No | Overall roadmap lifecycle status: `Active`, `Completed`, or `Archived`. Written by cleanup mode when all phases are complete. Absent in freshly generated roadmaps (absence = Active). |
+| Status | No | Overall roadmap lifecycle status: `Active` (default, absence = Active), `Completed` (written by cleanup mode when all phases are complete), or `Archived` (written by cleanup mode before moving the roadmap file to `done/`). |
 | Last updated | No | ISO timestamp (e.g., `2026-03-20T14:30:00`) written by update mode when regenerating the roadmap. Provides provenance for distinguishing fresh vs. updated roadmaps and prevents drift detection false negatives after updates. |
 
 ---
@@ -154,7 +154,7 @@ references them is complete. The roadmap document is always the last thing archi
 ### Naming
 
 Files keep their original names when moved to `done/`. No renaming on archive.
-Backup files created by update mode use the pattern:
+Backup files created by update mode are written to `{plan-dir}/done/` using the pattern:
 `{original-filename}.YYYY-MM-DDTHH-MM-SS.pre-update` (timestamped, unique per run).
 
 ---

--- a/code-quality/skills/roadmap/references/phase-schema.md
+++ b/code-quality/skills/roadmap/references/phase-schema.md
@@ -26,6 +26,8 @@ Every roadmap document begins with a header block:
 | Source plans | Yes | Absolute paths to all plan files ingested |
 | Total phases | Yes | Count of sequential phases |
 | Critical path | Yes | Which plans/tracks gate the overall schedule, and why |
+| Status | No | Overall roadmap lifecycle status: `Active`, `Completed`, or `Archived`. Written by cleanup mode when all phases are complete. Absent in freshly generated roadmaps (absence = Active). |
+| Last updated | No | ISO timestamp (e.g., `2026-03-20T14:30:00`) written by update mode when regenerating the roadmap. Provides provenance for distinguishing fresh vs. updated roadmaps and prevents drift detection false negatives after updates. |
 
 ---
 
@@ -84,6 +86,92 @@ must appear as columns — do not add per-track metadata outside the table.
 4. **Task splitting across phases** is allowed when a single plan has tasks that depend on
    another plan's output. In this case, the same plan file appears in multiple phases with
    non-overlapping task ranges (e.g., "Tasks 1-3" in Phase 1, "Tasks 4-7" in Phase 2).
+
+---
+
+## Completion Status Fields
+
+These fields are written and read by the stateful roadmap skill modes (update, cleanup, status).
+They are optional additions — freshly generated roadmaps do not contain them.
+
+### Per-phase status
+
+A `**Status:**` line may appear in a phase block after cleanup mode marks it complete:
+
+```markdown
+## Phase 1: Foundation
+
+**Prerequisites:** None
+**Parallel tracks:** 2 plans execute concurrently in this phase
+**Status:** Completed
+
+| Track | ...
+```
+
+Values: `Not Started` | `In Progress` | `Completed`
+
+- `Not Started` — default; branch does not exist
+- `In Progress` — branch exists but no merged PR found
+- `Completed` — written explicitly by cleanup mode after all tracks merged and validated
+
+Note: `Not Started` and `In Progress` are runtime-derived states (from branch checks) and are
+**not written to the roadmap file**. Only `Completed` is persisted. Absence of a `**Status:**`
+field means the phase has not been explicitly marked complete.
+
+### Per-track validation result format
+
+When subagent validators run (see Completion Tracking in SKILL.md), they return structured
+verdicts — never raw diff content. The format is ephemeral (shown in chat, not persisted to
+the roadmap file unless the user requests it):
+
+```
+Task N: implemented — [one-sentence evidence citing specific file path or code location]
+Task N: partial — [one-sentence description of what was implemented vs. what was skipped]
+Task N: deferred — [one-sentence description of deferred work, e.g., "TODO left in auth.py:42"]
+```
+
+---
+
+## Archival
+
+Cleanup mode archives completed work to prevent plan directory clutter.
+
+### Archive location
+
+`{plan-dir}/done/` — a subdirectory of the plan directory (`hack/plans/done/`,
+`~/.claude/plans/done/`, etc.). Created if it doesn't exist.
+
+### What gets archived (and when)
+
+| Item | Archived when |
+|------|---------------|
+| Source plan file | All phases that reference this plan are `Completed` |
+| Roadmap document itself | ALL phases in the roadmap are `Completed` |
+
+Plans that span multiple phases (task splitting) are NOT archived until every phase that
+references them is complete. The roadmap document is always the last thing archived.
+
+### Naming
+
+Files keep their original names when moved to `done/`. No renaming on archive.
+Backup files created by update mode use the pattern:
+`{original-filename}.YYYY-MM-DDTHH-MM-SS.pre-update` (timestamped, unique per run).
+
+---
+
+## Backward Compatibility
+
+The `**Status:**` and `**Last updated:**` document header fields and the per-phase
+`**Status:**` field are **optional additions**. Existing roadmap documents without them
+are valid and fully functional.
+
+Consumers (e.g., `/swarm`) that parse roadmap documents MUST tolerate unknown fields
+gracefully. The `/swarm` orchestration-playbook.md has been verified: its "phase block"
+references are about its own internal pipeline phases (Phase 0-7 of swarm execution),
+not roadmap document structure. Encountering `**Status:**` or `**Last updated:**` lines
+in a roadmap document will not break `/swarm`'s parsing — it reads the per-track table
+rows and fixed fields (Prerequisites, Parallel tracks, Sync point, Merge order) and
+ignores unrecognized fields.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Phase 0 detect/route with HITL modal routing (update/cleanup/status-drift/new) to the roadmap skill
- Adds completion tracking via gh PR queries (primary) with git fallback for squash merges, plus subagent validation
- Adds phase-schema completion status, archival, and backward compatibility sections
- Restricts Phase 0 detection to project memory dirs only (skip for ~/.claude/plans/)
- Fixes quality-gate Pass 2 async sync gap; bumps code-quality to 3.2.0