### PR TITLE
fix(dev-guard): adds git filter-repo guard rule

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.43.0",
+      "version": "1.44.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.43.0",
+  "version": "1.44.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/README.md
+++ b/dev-guard/README.md
@@ -377,7 +377,8 @@ Users can trust these built-in ask-type rules with `/dev-guard trust add <rule-n
 - `config-global-write` — Global git config modifications
 - `stash-drop` — Destructive stash operations
 - `checkout-dash-dash` — Destructive checkout with -- (deprecated, use git restore)
-- `filter-branch` — Dangerous git filter-branch (use git-filter-repo)
+- `filter-branch` — Dangerous git filter-branch (deprecated)
+- `filter-repo` — History-rewriting git filter-repo
 - `reflog-delete-expire` — Reflog delete/expire operations
 - `remote-remove` — Removing a git remote
 - `branch-from-local-main` — Branching from local main (may be stale)

--- a/dev-guard/README.md
+++ b/dev-guard/README.md
@@ -76,8 +76,8 @@ claude plugin install dev-guard@personal-claude-marketplace
 The guard includes approximately 70 built-in rules across several categories:
 - **Command rules** (~37): Native tool redirections, Python tooling, git safety, interactive commands, project conventions
 - **URL rules** (~10): GitHub, GitLab, Google, Atlassian, Slack authenticated URLs
-- **Git deny rules** (~13): Force push, branch deletion, unsafe operations (always enforced)
-- **Git ask rules** (~8): Stash drop, filter-branch, rebase, config modifications (can be trusted)
+- **Git deny rules** (~14): Force push, branch deletion, filter-branch, unsafe operations (always enforced)
+- **Git ask rules** (~8): Stash drop, filter-repo, rebase, config modifications (can be trusted)
 - **oc/kubectl introspection** (~4): Critical, high, medium, low risk assessments (dynamic)
 
 All rule names and guidance messages are defined in the source file `dev-guard/hooks/tool-selection-guard.py`.
@@ -377,7 +377,6 @@ Users can trust these built-in ask-type rules with `/dev-guard trust add <rule-n
 - `config-global-write` — Global git config modifications
 - `stash-drop` — Destructive stash operations
 - `checkout-dash-dash` — Destructive checkout with -- (deprecated, use git restore)
-- `filter-branch` — Dangerous git filter-branch (deprecated)
 - `filter-repo` — History-rewriting git filter-repo
 - `reflog-delete-expire` — Reflog delete/expire operations
 - `remote-remove` — Removing a git remote

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -1346,6 +1346,11 @@ GIT_DENY_RULES: list[GitRule] = [
         "--no-verify flag is FORBIDDEN. Git hooks must run for all commits and pushes.",
     ),
     GitRule(
+        "filter-branch",
+        lambda cmd: bool(re.search(r"git\s+filter-branch", cmd)),
+        "git filter-branch is FORBIDDEN. It is deprecated — use git-filter-repo instead.",
+    ),
+    GitRule(
         "add-force",
         lambda cmd: bool(re.search(r"git\s+add", cmd)) and _has_force_flag(cmd),
         "git add --force is FORBIDDEN. Files are gitignored for a reason.",
@@ -1401,11 +1406,6 @@ GIT_ASK_RULES: list[GitRule] = [
         "checkout-dash-dash",
         lambda cmd: bool(re.search(r"git\s+checkout\s+--", cmd)),
         "git checkout -- is destructive and deprecated. Consider using 'git restore' instead.",
-    ),
-    GitRule(
-        "filter-branch",
-        lambda cmd: bool(re.search(r"git\s+filter-branch", cmd)),
-        "git filter-branch is dangerous and deprecated. Confirm this is intentional.",
     ),
     GitRule(
         "filter-repo",

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -1405,7 +1405,12 @@ GIT_ASK_RULES: list[GitRule] = [
     GitRule(
         "filter-branch",
         lambda cmd: bool(re.search(r"git\s+filter-branch", cmd)),
-        "git filter-branch is dangerous and deprecated. Use git-filter-repo if truly needed.",
+        "git filter-branch is dangerous and deprecated. Confirm this is intentional.",
+    ),
+    GitRule(
+        "filter-repo",
+        lambda cmd: bool(re.search(r"git\s+filter-repo", cmd)),
+        "git filter-repo rewrites repository history permanently. Confirm this is intentional.",
     ),
     GitRule(
         "reflog-delete-expire",

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1156,6 +1156,8 @@ class TestGitSafetyDeny:
             # chain awareness
             ("git status && git reset --hard", 2, "FORBIDDEN"),
             ("git add . && git push -f origin main", 2, "FORBIDDEN"),
+            # filter-branch
+            ("git filter-branch --tree-filter 'rm -f x'", 2, "FORBIDDEN"),
         ],
         ids=[
             "reset-hard",
@@ -1187,6 +1189,7 @@ class TestGitSafetyDeny:
             "clean-df-allow",
             "reset-hard-in-chain",
             "force-push-in-chain",
+            "filter-branch",
         ],
     )
     def test_git_deny(self, command, expected_exit, expected_msg):
@@ -1205,7 +1208,6 @@ class TestGitSafetyAsk:
         [
             ("git stash drop", True, "permanently deletes"),
             ("git checkout -- file.py", True, "destructive"),
-            ("git filter-branch --tree-filter 'rm -f x'", True, "Confirm this is intentional"),
             ("git filter-repo --invert-paths --path secret.txt", True, "permanently"),
             ("git reflog delete HEAD@{2}", True, "recovery points"),
             ("git reflog expire --expire=now", True, "recovery points"),
@@ -1218,7 +1220,6 @@ class TestGitSafetyAsk:
         ids=[
             "stash-drop",
             "checkout-dash-dash",
-            "filter-branch",
             "filter-repo",
             "reflog-delete",
             "reflog-expire",

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1205,7 +1205,8 @@ class TestGitSafetyAsk:
         [
             ("git stash drop", True, "permanently deletes"),
             ("git checkout -- file.py", True, "destructive"),
-            ("git filter-branch --tree-filter 'rm -f x'", True, "deprecated"),
+            ("git filter-branch --tree-filter 'rm -f x'", True, "Confirm this is intentional"),
+            ("git filter-repo --invert-paths --path secret.txt", True, "permanently"),
             ("git reflog delete HEAD@{2}", True, "recovery points"),
             ("git reflog expire --expire=now", True, "recovery points"),
             ("git remote remove upstream", True, "break workflows"),
@@ -1218,6 +1219,7 @@ class TestGitSafetyAsk:
             "stash-drop",
             "checkout-dash-dash",
             "filter-branch",
+            "filter-repo",
             "reflog-delete",
             "reflog-expire",
             "remote-remove",


### PR DESCRIPTION
## Summary
- Adds a guard rule for `git filter-repo`, which rewrites repository history permanently but had no guard
- Updates the `git filter-branch` guard message to stop recommending `git-filter-repo` as a casual alternative
- Bumps dev-guard to 1.44.0