### PR TITLE
fix(code-quality): removes severity filtering, adds fidelity guards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research, business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, map-reduce, speculative, reflect, and index-repo",
       "category": "quality",

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Personal Claude Code plugins: LSP servers, code quality agents, development util
 - `/unfuck` - Comprehensive one-shot repo cleanup
 - `/swarm` - Full agent team implementation via TeamCreate
 - `/quality-gate` - PROACTIVE multi-pass review with adversarial lenses, fresh-context subagents, and blocking gates
-- `/pr-review` - Multi-agent PR review with confidence scoring
+- `/pr-review` - Multi-agent PR review with finding verification
 - `/map-reduce` - Parallelized workload processing with chunking, mapper agents, and reducer synthesis
 - `/speculative` - Competing implementations in isolated worktrees with judge selection
 - `/incremental-planning` - Incremental planning workflow with per-task review and assumption surfacing

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research, business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, map-reduce, speculative, reflect, and index-repo",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/README.md
+++ b/code-quality/README.md
@@ -25,7 +25,7 @@ Code quality agents, development utilities, and orchestration skills: architectu
 | `/unfuck` | Comprehensive one-shot repo cleanup | Manual |
 | `/swarm` | Full agent team implementation via TeamCreate | Manual |
 | `/quality-gate` | Multi-pass review with adversarial lenses, fresh-context subagents, and blocking gates | PROACTIVE |
-| `/pr-review` | Multi-agent PR review with confidence scoring | Manual |
+| `/pr-review` | Multi-agent PR review with finding verification | Manual |
 | `/map-reduce` | Parallelized workload processing with chunking, mapper agents, and reducer synthesis | Manual |
 | `/speculative` | Competing implementations in isolated worktrees with judge selection | Manual |
 | `/incremental-planning` | Planning workflow with per-task review and assumption surfacing | Manual |

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -175,6 +175,16 @@ LEAD (you)
 | Full implementation task | `/swarm` |
 | Codebase cleanup | `/unfuck` |
 
+### Work Completion Principle
+
+Never defer, skip, or reduce the scope of work to save tokens or reduce agent count.
+If the task requires a mapper, spawn the mapper. If a finding needs fixing, fix it.
+The only valid reasons to skip work are: (1) the user explicitly opted out,
+(2) the work is genuinely out of scope, or (3) the task shape genuinely doesn't match
+map-reduce (see table above).
+
+"It would be expensive" is NEVER a valid reason to skip work or reduce mapper count.
+
 ---
 
 ## Lead Responsibilities

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -162,7 +162,9 @@ LEAD (you)
 
 ---
 
-## When to Use /map-reduce vs. Alternatives
+## Scope Matching
+
+Match the tool to the task scope:
 
 | Scenario | Recommended Approach |
 |----------|----------------------|

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -322,8 +322,9 @@ The verifier assigns each finding to a category based on its nature (not its sev
 
 ### Filter
 
-Remove findings with verdict `false_positive`. Keep all `verified` and `needs_context`
-findings.
+Remove findings with verdict `false_positive`. Keep all `verified`, `needs_context`, and
+`unverified` findings. Treat `unverified` findings as `needs_context` for output purposes —
+they appear in the Needs Context section with the verification failure note.
 
 ---
 
@@ -392,7 +393,11 @@ Findings with verdict `needs_context` appear in a dedicated section at the botto
 are items the verifier could not confirm or deny and require human judgment. They are NOT
 hidden or filtered — they are surfaced transparently.
 
-### No Verified Findings
+### No Findings After Verification
+
+Use this path only when `verified_count == 0` AND `needs_context_count == 0` (all findings
+were false positives, or no findings were reported). If `needs_context_count > 0`, use the
+"Findings Exist" path — it has the Needs Context section for those items.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -407,7 +412,7 @@ No verified issues found.
 Checked for: security, test coverage, performance, code quality, correctness, historical consistency.
 
 Reviewed by: {reviewer_list}
-Total raw: {total_raw} | All resolved as false positives
+Total raw: {total_raw} | Verified: 0 | False positives removed: {false_positive_count} | Needs context: 0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -429,6 +434,7 @@ After output, return to the original branch or worktree recorded in Phase 0.
 | Lock/generated files only | Stop: "PR #N changes only lock/generated files. No review needed." |
 | Cannot checkout branch | Auto-stash and retry. If stash fails, stop: "Cannot checkout PR branch and stash failed." |
 | All findings false positive | Output "no findings" report format (not an error) |
+| Verification JSON parse fails | All findings get `unverified` verdict, treated as `needs_context` in output |
 
 ---
 

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: pr-review
 description: |
-  Multi-agent PR review with confidence scoring. Use when asked to "review PR",
+  Multi-agent PR review with finding verification. Use when asked to "review PR",
   "review this PR", "code review", or given a PR URL to review. Spawns 6 parallel specialized
   reviewers (security, QA, performance, code quality, correctness, git history),
-  scores findings for confidence via batched scoring, filters false positives, and prints a
+  verifies findings by investigating source code, categorizes by type, and prints a
   structured report to the terminal. Never comments on GitHub PRs.
 allowed-tools: [Read, Glob, Grep, Bash, Agent]
 ---
@@ -12,8 +12,10 @@ allowed-tools: [Read, Glob, Grep, Bash, Agent]
 # PR Review Skill
 
 Multi-agent pull request review. Spawns 6 parallel Sonnet reviewers (security, QA, performance,
-code quality, correctness, git history), scores all findings in a single batched Haiku call,
-filters by confidence threshold, and prints a structured terminal report.
+code quality, correctness, git history), each required to investigate and verify findings before
+reporting. A Sonnet verification agent then reads source files to confirm or disprove each
+finding. Results are categorized by type (testing gaps, correctness, security, architecture,
+decisions needed, etc.) and printed as a structured terminal report.
 
 **Never comments on GitHub PRs.** Output is terminal-only.
 
@@ -21,13 +23,9 @@ filters by confidence threshold, and prints a structured terminal report.
 
 ```
 /pr-review <PR-URL>
-/pr-review <PR-URL> --threshold 60
 ```
 
 - `<PR-URL>` — required. Full GitHub PR URL (e.g. `https://github.com/owner/repo/pull/123`).
-- `--threshold` — optional integer 0-100. Minimum confidence score for a finding to appear in
-  the report. Default: 50. Lower values include more findings (less filtering); higher values
-  include only high-certainty findings.
 
 ---
 
@@ -37,7 +35,6 @@ filters by confidence threshold, and prints a structured terminal report.
 
 Extract from `$ARGUMENTS`:
 - PR URL (first token — required; error if absent)
-- `--threshold N` (optional integer; default 50; error if not 0-100)
 
 ### Preflight Checks
 
@@ -255,14 +252,15 @@ severity, evidence, source reviewer.
 
 ---
 
-## Phase 3 — Confidence Scoring (batched)
+## Phase 3 — Verification (batched)
 
-Spawn a **single** Haiku agent with ALL findings in one call. Do NOT spawn one agent per finding —
-that pattern is catastrophically slow in Claude Code where each Agent() has significant startup
-overhead. A single batched call takes ~10 seconds; per-finding agents with 15-20 findings would
-take 2-5 minutes.
+If no findings were reported by any reviewer, skip verification and proceed directly to
+Phase 4 with the 'no findings' output path.
 
-If no findings were reported by any reviewer, skip the scorer entirely and proceed directly to Phase 4 with the 'no findings' output path.
+Spawn a **single** Sonnet agent with ALL findings in one call. Do NOT spawn one agent per
+finding — that pattern is catastrophically slow in Claude Code where each Agent() has
+significant startup overhead. A single batched call takes ~15 seconds; per-finding agents
+with 15-20 findings would take 2-5 minutes.
 
 Build the findings JSON array:
 ```json
@@ -281,30 +279,51 @@ Build the findings JSON array:
 ```
 
 For each finding, extract ±10 lines from the diff around the finding's file:line location and
-include it as the `diff_context` field. This gives the scorer surrounding context to distinguish
-real issues from false positives.
+include it as the `diff_context` field. This gives the verifier surrounding context to
+investigate each finding.
 
 ```
 Agent(
-  description="Confidence scoring for PR #{number} findings",
-  model="haiku",
-  prompt=<Confidence Scorer template from references/reviewer-prompts.md, placeholders substituted>
+  description="Finding verification for PR #{number}",
+  model="sonnet",
+  prompt=<Finding Verifier template from references/reviewer-prompts.md, placeholders substituted>
 )
 ```
 
-The scorer receives: `{findings_json}` (the array above), `{claude_md_rules}`, and `{contributing_md_rules}`.
+The verifier receives: `{findings_json}` (the array above), `{claude_md_rules}`,
+`{contributing_md_rules}`, and `{changed_files}`.
 
-It returns: `[{finding_id, score, justification}, ...]`
+The verifier **investigates each finding** — it reads the actual source files, traces call
+chains, and checks whether the finding is real. It does NOT just score confidence from the
+diff context. It returns a JSON array with a verdict for each finding:
+`[{finding_id, verdict, investigation_summary, category}, ...]`
 
-Parse the scorer's response as JSON. If parsing fails, extract JSON from between the first `[`
-and last `]` markers. If that also fails, skip scoring and include all findings with a default
-confidence of 50 and a note: "Confidence scoring failed — showing all findings unfiltered."
+Verdicts: `verified` (confirmed real), `false_positive` (investigated and disproven),
+`needs_context` (cannot confirm or deny — requires human judgment).
+
+Parse the verifier's response as JSON. If parsing fails, extract JSON from between the first
+`[` and last `]` markers. If that also fails, include all findings with verdict `unverified`
+and a note: "Verification failed — showing all findings unverified."
+
+### Categorize
+
+The verifier assigns each finding to a category based on its nature (not its severity):
+
+| Category | Examples |
+|----------|----------|
+| **Testing Gaps** | Missing tests, untested paths, coverage gaps |
+| **Correctness** | Logic errors, wrong behavior, contract violations |
+| **Security** | Vulnerabilities, auth issues, injection, secrets |
+| **Architecture** | Design issues, pattern violations, structural problems |
+| **Decisions Needed** | Ambiguous intent, trade-offs requiring human judgment |
+| **Performance** | Bottlenecks, N+1, memory issues |
+| **Style & Conventions** | CLAUDE.md violations, naming, code quality |
+| **Historical** | Pattern contradictions, churn, reverted patterns |
 
 ### Filter
 
-Apply the threshold (default 50). Keep findings where `score >= threshold`.
-
-If ALL findings are filtered out, proceed to Phase 4 with the "no findings" output path.
+Remove findings with verdict `false_positive`. Keep all `verified` and `needs_context`
+findings.
 
 ---
 
@@ -323,34 +342,57 @@ PR: {owner}/{repo}#{number} — "{title}"
 Branch: {head_branch} → {base_branch}
 Files changed: {changedFiles} | Additions: +{additions} | Deletions: -{deletions}
 
-Findings: {passing_count} (filtered from {total_raw} at confidence ≥{threshold})
+Findings: {verified_count} verified, {needs_context_count} needs context
+  (from {total_raw} raw findings — {false_positive_count} false positives removed)
 
-CRITICAL ({critical_count})
-  1. [{Reviewer}:{score}] {description}
+TESTING GAPS
+  1. [{Reviewer}] {description} [{severity}]
      {file}:{line}
      Evidence: {evidence}
 
-HIGH ({high_count})
+CORRECTNESS
   ...
 
-MEDIUM ({medium_count})
+SECURITY
   ...
 
-LOW ({low_count})
+ARCHITECTURE
   ...
+
+DECISIONS NEEDED
+  ...
+
+PERFORMANCE
+  ...
+
+STYLE & CONVENTIONS
+  ...
+
+HISTORICAL
+  ...
+
+─── Needs Context ({needs_context_count}) ───
+  1. [{Reviewer}] {description} [{severity}]
+     {file}:{line}
+     Investigation: {investigation_summary}
 
 Reviewed by: {reviewer_list}
-Confidence threshold: {threshold} | Total raw findings: {total_raw} | Filtered: {filtered_count}
+Total raw: {total_raw} | Verified: {verified_count} | False positives removed: {false_positive_count} | Needs context: {needs_context_count}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-Group findings by severity (CRITICAL → HIGH → MEDIUM → LOW). Within each severity group, sort by
-confidence score descending. For the `[Reviewer:score]` tag, use the short reviewer name:
-Security, QA, Performance, Code Quality, Correctness, Git History.
+Group findings by **category** (Testing Gaps → Correctness → Security → Architecture →
+Decisions Needed → Performance → Style & Conventions → Historical). Within each category,
+sort by severity (CRITICAL → HIGH → MEDIUM → LOW). For the `[Reviewer]` tag, use the short
+reviewer name: Security, QA, Performance, Code Quality, Correctness, Git History.
 
-Omit severity sections with zero findings.
+Omit category sections with zero findings.
 
-### No Findings Above Threshold
+Findings with verdict `needs_context` appear in a dedicated section at the bottom — these
+are items the verifier could not confirm or deny and require human judgment. They are NOT
+hidden or filtered — they are surfaced transparently.
+
+### No Verified Findings
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -361,11 +403,11 @@ PR: {owner}/{repo}#{number} — "{title}"
 Branch: {head_branch} → {base_branch}
 Files changed: {changedFiles} | Additions: +{additions} | Deletions: -{deletions}
 
-No issues found above confidence threshold (≥{threshold}).
+No verified issues found.
 Checked for: security, test coverage, performance, code quality, correctness, historical consistency.
 
 Reviewed by: {reviewer_list}
-Confidence threshold: {threshold} | Total raw findings: {total_raw} | All filtered
+Total raw: {total_raw} | All resolved as false positives
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -380,14 +422,13 @@ After output, return to the original branch or worktree recorded in Phase 0.
 | Condition | Action |
 |-----------|--------|
 | No `gh` CLI | Error: "gh CLI not found. Install it from https://cli.github.com and authenticate with `gh auth login`." |
-| PR URL missing | Error: "Usage: /pr-review <PR-URL> [--threshold N]" |
+| PR URL missing | Error: "Usage: /pr-review <PR-URL>" |
 | PR in wrong repo | Error: "PR is from {url_owner}/{url_repo} but CWD is in {local_repo}. cd to the correct repo first." |
 | PR is closed/merged | Stop: "PR #N is already {state}. Nothing to review." |
 | PR is draft | Warn and continue: "Note: PR #N is a draft. Proceeding anyway." |
 | Lock/generated files only | Stop: "PR #N changes only lock/generated files. No review needed." |
 | Cannot checkout branch | Auto-stash and retry. If stash fails, stop: "Cannot checkout PR branch and stash failed." |
-| --threshold out of range | Error: "--threshold must be between 0 and 100." |
-| All findings filtered | Output "no findings" report format (not an error) |
+| All findings false positive | Output "no findings" report format (not an error) |
 
 ---
 
@@ -402,11 +443,11 @@ runtime; this skill owns its own copies adapted for PR review context.
 
 | Placeholder | Value | Used by |
 |-------------|-------|---------|
-| `{pr_description}` | "PR #N: {title}\n\n{body}" | All reviewers (not Scorer) |
+| `{pr_description}` | "PR #N: {title}\n\n{body}" | All reviewers (not Verifier) |
 | `{diff}` | Local `git diff` against merge base | Security, QA, Performance, Code Quality, Correctness |
-| `{claude_md_rules}` | CLAUDE.md content or "No CLAUDE.md found." | All reviewers + Scorer |
-| `{contributing_md_rules}` | CONTRIBUTING.md content or "No CONTRIBUTING.md found." | All reviewers + Scorer |
-| `{changed_files}` | Newline-separated file paths (from `files` in PR metadata) | All reviewers (not Scorer) |
+| `{claude_md_rules}` | CLAUDE.md content or "No CLAUDE.md found." | All reviewers + Verifier |
+| `{contributing_md_rules}` | CONTRIBUTING.md content or "No CONTRIBUTING.md found." | All reviewers + Verifier |
+| `{changed_files}` | Newline-separated file paths (from `files` in PR metadata) | All reviewers + Verifier |
 | `{plan_content}` | Implementation plan content or "No implementation plan found." | Correctness Reviewer only |
 | `{git_history_context}` | Pre-collected blame/log output | Git History Reviewer only |
-| `{findings_json}` | JSON array of all findings | Confidence Scorer only |
+| `{findings_json}` | JSON array of all findings with diff_context | Finding Verifier only |

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -294,8 +294,8 @@ The verifier receives: `{findings_json}` (the array above), `{claude_md_rules}`,
 `{contributing_md_rules}`, and `{changed_files}`.
 
 The verifier **investigates each finding** — it reads the actual source files, traces call
-chains, and checks whether the finding is real. It does NOT just score confidence from the
-diff context. It returns a JSON array with a verdict for each finding:
+chains, and checks whether the finding is real. It returns a JSON array with a verdict for
+each finding:
 `[{finding_id, verdict, investigation_summary, category}, ...]`
 
 Verdicts: `verified` (confirmed real), `false_positive` (investigated and disproven),

--- a/code-quality/skills/pr-review/references/reviewer-prompts.md
+++ b/code-quality/skills/pr-review/references/reviewer-prompts.md
@@ -329,8 +329,7 @@ If the code is correct, say "No correctness findings." Do not fabricate issues.
 
 ```
 You are a finding verification agent. You INVESTIGATE each finding to determine if it is real.
-You do NOT just score confidence from the diff — you actively read source files, trace call
-chains, and verify or disprove each finding.
+You actively read source files, trace call chains, and verify or disprove each finding.
 
 PROJECT RULES (CLAUDE.md):
 {claude_md_rules}

--- a/code-quality/skills/pr-review/references/reviewer-prompts.md
+++ b/code-quality/skills/pr-review/references/reviewer-prompts.md
@@ -5,7 +5,8 @@ with actual values. Domain reviewers (Security, QA, Performance, Code Quality, C
 receive diff, PR description, project rules, and changed files. The Correctness Reviewer also
 receives `{plan_content}` for plan drift detection. The Git History Reviewer receives
 `{git_history_context}` instead of `{diff}` — pre-collected blame/log output from the
-orchestrator. The Confidence Scorer receives findings JSON, CLAUDE.md, and CONTRIBUTING.md.
+orchestrator. The Finding Verifier receives findings JSON, changed files, CLAUDE.md, and
+CONTRIBUTING.md, and actively investigates each finding by reading source files.
 
 ---
 
@@ -30,6 +31,11 @@ PROJECT RULES (CONTRIBUTING.md):
 {contributing_md_rules}
 
 FOCUS: Security vulnerabilities only — do not report style, performance, or completeness issues.
+
+INVESTIGATION REQUIREMENT: For every potential finding, VERIFY it before reporting. Read the
+actual source files (not just the diff) to confirm the issue exists. Trace call chains to verify
+exploitability. Do not report speculative issues — only report what you have confirmed by
+reading the code. A finding you investigated and verified is worth ten you guessed from the diff.
 
 CHECKLIST:
 1. Injection: command injection, SQL injection, path traversal, template injection?
@@ -74,6 +80,11 @@ PROJECT RULES (CONTRIBUTING.md):
 
 FOCUS: Test coverage, testability, and quality assurance concerns — not style or performance.
 
+INVESTIGATION REQUIREMENT: For every potential finding, VERIFY it before reporting. Read the
+actual test files to confirm coverage gaps exist. Check if tests for the changed code already
+exist in other test files. Do not report speculative gaps — only report what you have confirmed
+by reading both the implementation and test code.
+
 CHECKLIST:
 1. Coverage: what changed code paths have no corresponding test coverage?
 2. Test quality: are existing tests meaningful, or just asserting the implementation exists?
@@ -116,6 +127,11 @@ PROJECT RULES (CONTRIBUTING.md):
 {contributing_md_rules}
 
 FOCUS: Performance issues only — not correctness, style, or test coverage.
+
+INVESTIGATION REQUIREMENT: For every potential finding, VERIFY it before reporting. Read the
+actual source files to confirm the performance issue exists. Check input sizes, call frequency,
+and real-world data patterns before claiming an issue matters. Do not report theoretical
+performance concerns that would never manifest at the project's actual scale.
 
 CHECKLIST:
 1. Algorithmic complexity: O(N²) or worse where O(N) is achievable? Unbounded loops?
@@ -161,6 +177,11 @@ PROJECT RULES (CONTRIBUTING.md):
 
 FOCUS: Code quality, style, maintainability, and convention compliance — not correctness,
 security, or performance.
+
+INVESTIGATION REQUIREMENT: For every potential finding, VERIFY it before reporting. Read the
+actual source files and adjacent files to confirm pattern violations. Check the project's
+existing conventions before claiming something violates them. Do not report style preferences
+that contradict the project's established patterns.
 
 CHECKLIST:
 1. Clarity: is the intent of the code clear without needing to trace execution?
@@ -211,6 +232,10 @@ GIT HISTORY CONTEXT:
 FOCUS: Historical patterns, established decisions, and prior review feedback that the PR
 should respect. Do not duplicate findings that belong to security, QA, performance, correctness,
 or code quality reviews.
+
+INVESTIGATION REQUIREMENT: For every potential finding, VERIFY it from the git history context
+provided. Cite specific commit SHAs, blame entries, or log messages as evidence. Do not report
+speculative historical concerns — only report what the git history concretely demonstrates.
 
 ANALYSIS AREAS:
 1. Established patterns: does the PR contradict coding patterns consistently used in the
@@ -265,6 +290,11 @@ IMPLEMENTATION PLAN (if provided):
 
 FOCUS: Correctness — does the code do what it claims? Not style, security, or performance.
 
+INVESTIGATION REQUIREMENT: For every potential finding, VERIFY it before reporting. Read the
+actual source files, trace the execution path, and confirm the logic error exists. Check
+callers and test cases to understand intended behavior. Do not report speculative correctness
+issues — only report what you have confirmed by reading and tracing the code.
+
 CHECKLIST:
 1. Logic errors: wrong conditions, inverted comparisons, off-by-one, missing negation?
 2. Wrong behavior: does the code actually do what the PR description says it does?
@@ -295,12 +325,12 @@ If the code is correct, say "No correctness findings." Do not fabricate issues.
 
 ---
 
-## Confidence Scorer
+## Finding Verifier
 
 ```
-You are a triage agent. Score each finding's confidence that it represents a real, actionable
-issue — not a false positive or hallucination. Be strict: most findings from automated review
-are noise.
+You are a finding verification agent. You INVESTIGATE each finding to determine if it is real.
+You do NOT just score confidence from the diff — you actively read source files, trace call
+chains, and verify or disprove each finding.
 
 PROJECT RULES (CLAUDE.md):
 {claude_md_rules}
@@ -308,31 +338,69 @@ PROJECT RULES (CLAUDE.md):
 PROJECT RULES (CONTRIBUTING.md):
 {contributing_md_rules}
 
-FINDINGS TO SCORE:
+CHANGED FILES:
+{changed_files}
+
+FINDINGS TO VERIFY:
 {findings_json}
 
 The findings are a JSON array. Each finding has an "id" field and includes the finding
 description, location, severity, evidence, and a `diff_context` field with ±10 lines of
-surrounding diff. Use `diff_context` to verify whether the finding is real — it shows what
-the code actually does around the reported location.
+surrounding diff.
 
-For EACH finding, return a JSON object with:
-- finding_id: the id from the input
-- score: integer 0-100
-- justification: one sentence explaining the score
+## Investigation Protocol
 
-Score rubric:
-- 0: False positive — the code is actually fine, finding is wrong
-- 25: Possibly real — plausible concern but insufficient evidence in the diff
-- 50: Real but minor — genuine issue, low impact or easily caught in normal review
-- 75: Verified real, important — clear evidence in the diff, meaningful impact
-- 100: Certain, frequent impact — no ambiguity, exploitable or causes failures in normal use
+For EACH finding:
 
-Scores are continuous 0-100. Use intermediate values (e.g., 40, 60, 85) as appropriate.
+1. Read the `diff_context` to understand what the finding claims
+2. Read the ACTUAL source file at the reported location (use the Read tool)
+3. If the finding claims a missing check, trace the call chain to verify it's actually missing
+4. If the finding claims a vulnerability, verify the input reaches the vulnerable point
+5. If the finding claims a test gap, check the test directory for existing coverage
+6. Make a verdict based on your investigation — not on how plausible the finding sounds
+
+## Categories
+
+Assign each finding to the category that best describes its nature:
+
+| Category | When to use |
+|----------|-------------|
+| Testing Gaps | Missing tests, untested paths, coverage gaps |
+| Correctness | Logic errors, wrong behavior, contract violations |
+| Security | Vulnerabilities, auth issues, injection, secrets |
+| Architecture | Design issues, pattern violations, structural problems |
+| Decisions Needed | Ambiguous intent, trade-offs requiring human judgment |
+| Performance | Bottlenecks, N+1, memory issues |
+| Style & Conventions | CLAUDE.md violations, naming, code quality |
+| Historical | Pattern contradictions, churn, reverted patterns |
+
+## Output
 
 Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
 [
-  {"finding_id": "...", "score": 75, "justification": "..."},
-  ...
+  {
+    "finding_id": "sec-1",
+    "verdict": "verified",
+    "category": "Security",
+    "investigation_summary": "Confirmed: user input at line 42 reaches SQL query at line 58 without parameterization. Traced through handle_request -> process_query."
+  },
+  {
+    "finding_id": "qa-2",
+    "verdict": "false_positive",
+    "category": "Testing Gaps",
+    "investigation_summary": "Tests exist in tests/unit/test_auth.py:test_login_edge_cases covering this exact path."
+  },
+  {
+    "finding_id": "perf-1",
+    "verdict": "needs_context",
+    "category": "Decisions Needed",
+    "investigation_summary": "N+1 query exists but dataset size is unclear. Could be 10 rows or 10,000 — performance impact depends on production data volume."
+  }
 ]
+
+Verdicts:
+- "verified": You investigated and confirmed the finding is real and actionable
+- "false_positive": You investigated and disproved the finding — the code is actually correct
+- "needs_context": You investigated but cannot confirm or deny — requires human judgment or
+  production context you don't have access to
 ```

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -68,7 +68,7 @@ Select the lens set for the detected type (see `references/lens-rubrics.md`).
 
 ## Layer 1: Self-Review Loop
 
-**6 rounds maximum (Round 6: Structural applies to Code/Mixed only). Exit early if a round produces zero findings AND the action audit is clean.**
+**6 rounds (Round 6: Structural applies to Code/Mixed only). All rounds are mandatory — do not exit early.**
 
 Each round uses a different adversarial lens. Rotating lenses prevent anchoring fatigue and ensure
 comprehensive coverage from different angles.
@@ -206,18 +206,18 @@ Execute this protocol for EVERY round:
    If no → fix remaining items before proceeding to next round.
 ```
 
-### Early Exit
+### No Early Exit
 
-**Rounds 1-3 always run.** Correctness, Completeness, and Robustness are critical lenses that
-catch categorically different issues — a clean Round 1 says nothing about Round 2.
+**All 6 rounds are mandatory for Code and Mixed work types.** Each round uses a categorically
+different lens — a clean Round 3 says nothing about Round 4 (Simplicity catches AI slop and
+over-engineering), Round 5 (Adversarial catches what you rationalized away), and Round 6
+(Structural catches integration issues invisible to single-component review).
 
-Starting from Round 4: if a round produces zero findings AND the action audit is clean, skip
-remaining rounds. Do NOT exit early just because you "feel done" — the `think_about_whether_you_are_done`
-tool must confirm.
+For non-Code work types: Rounds 1-5 always run. Round 6 (Structural) is skipped since it
+targets code architecture integration.
 
-**Note on Round 6 (Structural):** Only applies to Code and Mixed work types. Skip for all
-other types. Structural lens focuses on integration architecture, not the current change in
-isolation — it may find issues even when Rounds 1-5 were clean.
+Do NOT exit early because a round "produced zero findings." Each lens catches categorically
+different issues. The next round will find what this round cannot see.
 
 ---
 

--- a/code-quality/skills/speculative/SKILL.md
+++ b/code-quality/skills/speculative/SKILL.md
@@ -231,13 +231,9 @@ Write all structured outputs to `hack/speculative/YYYY-MM-DD/`:
 
 ---
 
-## Cost Awareness
+## Scope Matching
 
-This skill spawns 2-4 competitor agents plus a judge. Each competitor runs a full implementation.
-Use it only when the choice between approaches has real consequences and "try both" is genuinely
-better than the architect choosing one.
-
-### When to Use /speculative vs. Alternatives
+This skill runs competing implementations in parallel. Match tool to task:
 
 | Scenario | Recommended Approach |
 |----------|----------------------|
@@ -249,13 +245,23 @@ better than the architect choosing one.
 | Simple feature (1-3 files, obvious approach) | Single targeted subagent |
 | Large feature needing full pipeline rigor | `/swarm` (optionally with Phase 2.7 speculative fork) |
 
-### Model Cost Hierarchy
+### Model Assignment
 
 | Role | Model | Rationale |
 |------|-------|-----------|
-| Competitors | sonnet | Implementation work — capable but cost-efficient |
-| Judge | opus | Judgment-heavy evaluation — worth the cost for fair comparison |
+| Competitors | sonnet | Implementation work |
+| Judge | opus | Judgment-heavy evaluation — fair comparison requires strong reasoning |
 | Synthesis (Phase 3.5) | sonnet | Mechanical combination of known elements |
+
+### Work Completion Principle
+
+Never defer, skip, or reduce the scope of work to save tokens or reduce agent count.
+If the task requires an agent, spawn the agent. If a finding needs fixing, fix it.
+The only valid reasons to skip work are: (1) the user explicitly opted out,
+(2) the skip condition in the phase table applies, or (3) the work is genuinely
+out of scope for the current task.
+
+"It would be expensive" is NEVER a valid reason to skip work.
 
 ---
 

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -42,7 +42,8 @@ specialist agent.
 | 4 | Code-Reviewer | code-quality:code-reviewer | sonnet | No | Broader review, complements QA |
 | 4 | Performance | code-quality:performance | sonnet | No | Bottlenecks, N+1, memory issues |
 | 4.5 | Structural Analyst (×2) | general-purpose | opus | No | Adversarial structural design review |
-| 5 | Fixer | general-purpose | sonnet | Yes | Address critical/high review findings |
+| 5 | Fixer | general-purpose | sonnet | Yes | Address ALL review findings |
+| 5 | Test Coverage Agent | general-purpose | sonnet | Yes | Write tests for coverage gaps from Phase 4 |
 | 5 | Code-Simplifier | code-quality:code-simplifier | sonnet | Yes | Post-fix simplification pass |
 | 6 | Docs | general-purpose | sonnet | Yes | Update repo docs and hack/ memory |
 | 6 | Docs Reviewer | general-purpose | sonnet | No | Verify Docs agent's work against architect's documentation_impact |
@@ -206,25 +207,50 @@ Test stages. The watchdog is torn down (CronDelete) when Phase 3 completes or on
 See `references/pipeline-model.md` for full parallelism rules, backpressure handling, and
 fallback to sequential mode.
 
+#### Parallel Mini-Pipelines (when applicable)
+
+If the architect's dependency graph contains 2+ independent component groups (no shared files,
+no dependency edges between groups), the Lead SHOULD spawn parallel mini-pipelines rather than
+serializing all components through one Implementer:
+
+- Each mini-pipeline: Implementer (sonnet, worktree) → Reviewer (opus) → Test-Writer (sonnet)
+  → Test-Runner (haiku)
+- The Lead coordinates merge order based on the architect's merge priority
+- Components with dependencies between them still flow through a single pipeline sequentially
+- Each mini-pipeline's Implementer stays within context limits — no lossy handoffs needed
+
+**Decision heuristic:**
+```
+IF architect.components.count > 3 AND architect.independent_groups.count > 1:
+    Fan out independent groups to parallel mini-pipelines
+ELSE:
+    Use single pipeline (current behavior)
+```
+
+This reduces context pressure on individual Implementers and improves output quality for large
+tasks. The Lead decides based on the dependency graph — never based on cost or token concerns.
+
 ### Phase 4: Parallel Review
 
 Spawn ALL review agents simultaneously: Security, QA, Code-Reviewer, Performance, and any
 auto-detected optional reviewers (UI, API, DB). All reviewers operate in read-only mode on the
 completed implementation. Each writes structured JSON findings to `hack/swarm/YYYY-MM-DD/reviews/`
-(see schema in `references/communication-schema.md`). The Lead collects all findings, filters by
-severity, and synthesizes into a consolidated view. Critical and high-severity findings go to the
-Fixer in Phase 5. Low/informational findings are recorded in the audit trail but not acted on.
+(see schema in `references/communication-schema.md`). The Lead collects ALL findings and
+synthesizes into a consolidated view. Every finding — regardless of severity — is routed to
+Phase 5 for action. No finding is silently dropped or left unactioned in the audit trail.
 
 **Escalation Routing (before proceeding to Phase 5):**
 
-After synthesizing findings, classify each critical/high finding by type and route accordingly:
+After synthesizing findings, classify each finding by type and route accordingly:
 
 | Finding Type | Examples | Routing |
 |---|---|---|
 | Design-level | Architecture mismatch, wrong abstraction, missing component entirely | Route back to Architect — respawn Phase 2, then re-run Phase 2.5, then re-implement Phase 3 |
 | Security design | Trust boundary violation in architecture, missing auth layer, new attack surface from design decision | Route to Phase 2.5 Security Design Review for design-level fix |
 | Scope creep | Feature implemented that was not in the plan, undiscussed behavior introduced | Escalate to human via AskUserQuestion — do not fix silently |
-| Implementation | Bugs, quality issues, code-level security vulnerabilities, performance bottlenecks | Route to Phase 5 Fixer (existing flow) |
+| Implementation | Bugs, quality issues, code-level security vulnerabilities, performance bottlenecks | Route to Phase 5 Fixer |
+| Test coverage | Missing tests, untested paths, coverage gaps for the deliverable | Route to Phase 5 Test Coverage Agent |
+| Documentation | Missing or incorrect documentation for implemented features | Route to Phase 6 Docs agent |
 
 **Escalation counter:** Track a `design_escalation_count` across the swarm run. Each time findings
 trigger a return to Phase 2 (design-level) or Phase 2.5 (security design), increment the counter.
@@ -266,21 +292,39 @@ If Phase 4 escalation routing triggers a return to Phase 2, Phase 4.5 runs on th
 
 Phase 5 receives findings from both Phase 4 AND Phase 4.5 in its consolidated findings list.
 
-### Phase 5: Fix & Simplify (conditional)
+### Phase 5: Fix, Test Coverage & Simplify
 
-Skip this phase if ALL reviews (Phases 4 and 4.5) report clean (zero critical or high findings). Otherwise, spawn
-the Fixer with the consolidated critical/high findings and full context of the implementation.
-The Fixer addresses each finding with targeted, minimal changes. After the Fixer completes,
-check its output for `deferred` items — findings it couldn't resolve. For each deferred item:
+Skip this phase only if ALL reviews (Phases 4 and 4.5) report zero findings of any severity.
+Otherwise, spawn agents in this order:
+
+**Step 5.1 — Fixer:** Spawn the Fixer with ALL consolidated findings (every severity level)
+and full context of the implementation. The Fixer addresses each finding with targeted, minimal
+changes — critical/high first, then medium, then low. After the Fixer completes, check its
+output for `deferred` items — findings it couldn't resolve. For each deferred item:
 1. Create a `TaskCreate` entry marked as blocked with the reason (visible in task list throughout)
 2. Add to the "Scope Accountability" section of `swarm-report.md` (permanent record)
 3. If any deferred item is critical or high severity, use `AskUserQuestion` to notify the user
    before proceeding — do NOT silently continue past critical unresolved findings
 
-Then spawn the Code-Simplifier
-for a post-fix pass — it looks for over-engineering, unnecessary abstractions, and complexity
-introduced during implementation or fixing. Skip Code-Simplifier if the Fixer made no changes.
-Re-run affected tests after any fixes to confirm nothing regressed.
+**Step 5.2 — Test Coverage Agent:** If ANY Phase 4 or 4.5 reviewer identified test coverage
+gaps, missing tests, or untested code paths, spawn the Test Coverage Agent (sonnet,
+bypassPermissions). This agent writes tests that Phase 3's Test-Writer could not have written —
+coverage gaps identified only after the full implementation was reviewed. The Test Coverage Agent
+receives:
+- All test-related findings from Phase 4/4.5 (coverage gaps, missing edge case tests, untested
+  components, untested error paths)
+- The full list of files modified by the swarm
+- The existing test suite location and testing conventions
+- The Phase 3 Test-Writer's TestHandoff summaries (what was already tested)
+
+The Test Coverage Agent writes the missing tests and reports a TestCoverageResult listing
+test files created, test count, and which findings were addressed. Run the test suite after
+to confirm all new tests pass.
+
+**Step 5.3 — Code-Simplifier:** Spawn the Code-Simplifier for a post-fix pass — it looks for
+over-engineering, unnecessary abstractions, and complexity introduced during implementation or
+fixing. Skip Code-Simplifier only if neither the Fixer nor the Test Coverage Agent made any
+changes. Re-run affected tests after any fixes to confirm nothing regressed.
 
 ### Phase 6: Docs & Memory
 
@@ -440,8 +484,9 @@ Phase 4.5: Structural Design Review (always runs)
   +-- Analyst 2: Integration & Contract (opus) -------+--> Lead merges STRUCT findings
      |
      v
-Phase 5: Fix & Simplify (if Phase 4 or 4.5 findings exist)
-  +-- Fixer: critical/high findings
+Phase 5: Fix, Test Coverage & Simplify (if any findings exist)
+  +-- Fixer: ALL findings (critical → high → medium → low)
+  +-- Test Coverage Agent: coverage gaps from Phase 4/4.5
   +-- Code-Simplifier: post-fix pass
      |
      v
@@ -550,21 +595,18 @@ After escalation, wait for user input before proceeding.
 | Phase 2.7: Speculative Fork | Architect did NOT flag `speculative_fork_recommended: true` AND Lead does not identify 2+ incompatible approach choices. Skip for single-component tasks and tasks where the user specified an approach. |
 | Test-Writer | `--skip-tests` flag provided, or changes are purely config/docs with no logic |
 | Domain Reviewers (UI/API/DB) | Not auto-detected from codebase analysis |
-| Phase 5: Fix | ALL Phase 4 AND Phase 4.5 review agents report zero critical or high findings |
-| Code-Simplifier | Fixer made no changes in Phase 5 |
+| Phase 5: Fix | ALL Phase 4 AND Phase 4.5 review agents report zero findings of any severity |
+| Test Coverage Agent | No Phase 4 or 4.5 reviewer identified any test coverage gaps |
+| Code-Simplifier | Neither Fixer nor Test Coverage Agent made any changes in Phase 5 |
 | Phase 6: Docs | Purely internal refactor with no public API or documented behavior changes |
 | /unfuck sweep | Fewer than 20 files modified and not an architectural change |
 | NEVER SKIP | Phases 0, 1, 2, core Phase 3 (Implementer + Reviewer), Phase 4, Phase 4.5, Phase 7 (Verifier) |
 
 ---
 
-## Cost Awareness
+## Scope Matching
 
-This skill spawns 15+ agents, each with their own context and API calls. Use it only when the
-task genuinely warrants maximum rigor. For smaller tasks, use a targeted subagent or invoke
-specific skills directly.
-
-### When to Use /swarm vs. Alternatives
+Match the tool to the task scope:
 
 | Scenario | Recommended Approach |
 |----------|----------------------|
@@ -578,15 +620,28 @@ specific skills directly.
 | Multiple viable approaches, need to compare | `/speculative` |
 | Architectural analysis (cross-cutting concerns) | Single agent (NOT /map-reduce) |
 
-### Model Cost Hierarchy
+### Model Assignment
 
-| Model | Cost | Used For |
-|-------|------|---------|
-| opus | Expensive | Architect, Reviewer, Security, QA — judgment-heavy tasks |
-| sonnet | Moderate | Implementer, Test-Writer, Code-Reviewer, Performance, Fixer, Code-Simplifier, Lessons Extractor, Docs |
-| haiku | Cheap | Test-Runner, Verifier — execution-only tasks |
+Use opus for any task requiring judgment, evaluation, or nuanced reasoning. Use sonnet for
+implementation and mechanical tasks. Use haiku for execution-only tasks. When in doubt,
+prefer opus — one strong pass beats multiple weaker passes.
 
-Minimize opus usage to the phases where nuanced judgment is genuinely required.
+| Model | Used For |
+|-------|---------|
+| opus | Architect, Reviewer, Security, QA, Structural Analysts — judgment-heavy tasks |
+| sonnet | Implementer, Test-Writer, Test Coverage Agent, Code-Reviewer, Performance, Fixer, Code-Simplifier, Docs, Lessons Extractor |
+| haiku | Test-Runner, Verifier — execution-only tasks |
+
+### Work Completion Principle
+
+Never defer, skip, or reduce the scope of work to save tokens or reduce agent count.
+If the task requires an agent, spawn the agent. If a finding needs fixing, fix it.
+If tests need writing, write them. The only valid reasons to skip work are:
+(1) the user explicitly opted out, (2) the skip condition in the phase table applies,
+or (3) the work is genuinely out of scope for the current task.
+
+"It would be expensive" is NEVER a valid reason to skip work. Prefer spawning one opus
+agent that does the job right over multiple sonnet agents that require rework.
 
 ---
 

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Full TeamCreate agent swarm for implementation tasks. Launches a pipelined team
   of 15+ specialized agents (Architect, Security Design Reviewer, Implementer,
   Reviewer, Test-Writer, Test-Runner, Security, QA, Code-Reviewer, Performance,
-  Fixer, Code-Simplifier, Docs, Lessons Extractor, Verifier) with structured JSON
+  Fixer, Test Coverage Agent, Code-Simplifier, Docs, Lessons Extractor, Verifier) with structured JSON
   communication, Cynefin domain classification, audit trails, and early user
   checkpoint. Use when asked to "swarm this", "full team", "agent team",
   "full send", or when maximum rigor is needed on an implementation task.

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -2,7 +2,7 @@
 name: swarm
 description: >-
   Full TeamCreate agent swarm for implementation tasks. Launches a pipelined team
-  of 15+ specialized agents (Architect, Security Design Reviewer, Implementer,
+  of 18+ specialized agents (Architect, Security Design Reviewer, Implementer,
   Reviewer, Test-Writer, Test-Runner, Security, QA, Code-Reviewer, Performance,
   Fixer, Test Coverage Agent, Code-Simplifier, Docs, Lessons Extractor, Verifier) with structured JSON
   communication, Cynefin domain classification, audit trails, and early user
@@ -492,6 +492,7 @@ Phase 5: Fix, Test Coverage & Simplify (if any findings exist)
      v
 Phase 6: Docs & Memory
   +-- Docs agent: repo docs + hack/ updates
+  +-- Docs Reviewer: verify Docs agent's work
   +-- Lessons Extractor: audit trail → hack/LESSONS.md
      |
      v

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -1064,9 +1064,9 @@ You do NOT modify any code.
 
 Use the shared severity scale from `references/communication-schema.md` (ReviewFindings):
 - **critical:** Bug or correctness issue that will cause incorrect behavior in production
-- **high:** Serious convention violation or error handling gap that must be addressed (maps to must-fix)
-- **medium:** Clear improvement, won't block merge but should be addressed (maps to should-fix)
-- **low:** Stylistic or preference — do not waste fixer time on these (maps to optional/nitpick)
+- **high:** Serious convention violation or error handling gap
+- **medium:** Clear improvement that should be addressed
+- **low:** Stylistic or minor — still report these, the Fixer addresses all severity levels
 
 ## Output Format
 

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -1428,8 +1428,9 @@ SendMessage(type="message", recipient="team-lead",
 
 ## Your Role
 
-You are the Fixer. You address review findings from the parallel review phase. You make targeted,
-precise fixes — you do NOT refactor, reorganize, or improve beyond what the findings require.
+You are the Fixer. You address ALL review findings from the parallel review phase. You make
+targeted, precise fixes — you do NOT refactor, reorganize, or improve beyond what the findings
+require. You fix every finding assigned to you, regardless of severity.
 
 You have access to: Read, Write, Edit, Glob, Grep, Bash.
 
@@ -1440,11 +1441,15 @@ You have access to: Read, Write, Edit, Glob, Grep, Bash.
 ## Fix Protocol
 
 ### Priority Order
-1. Critical/high security findings (must-fix)
-2. Must-fix QA findings
-3. Should-fix security findings
-4. Should-fix QA findings
-5. Performance findings (high severity first)
+1. Critical security findings
+2. High security findings
+3. Critical/high QA and correctness findings
+4. Medium findings (all categories)
+5. Performance findings
+6. Low findings
+7. Informational items — document as concrete follow-up with file:line references
+
+Fix ALL findings in this list. Every severity level is your responsibility.
 
 ### For Each Finding
 
@@ -1457,7 +1462,7 @@ Do NOT:
 - Refactor code beyond what the finding requires
 - Change variable names, formatting, or style unless the finding specifically requires it
 - Add abstraction layers to "improve" the design
-- Fix optional/low findings (those are in the report but not assigned to you)
+- Skip or defer findings because of their severity level — every finding gets addressed
 
 ### Test After Fixes
 
@@ -1490,6 +1495,87 @@ SendMessage(type="message", recipient="team-lead",
     ]
   }',
   summary="Fixer: 5 fixed, 1 deferred")
+```
+```
+
+---
+
+## Agent 10.5: Test Coverage Agent
+
+**Type:** `general-purpose` | **Model:** sonnet | **Mode:** bypassPermissions
+
+```markdown
+# Test Coverage Agent — Swarm Post-Review Agent
+
+{context_bundle}
+
+## Your Role
+
+You are the Test Coverage Agent. You write tests for coverage gaps identified by Phase 4 and
+Phase 4.5 reviewers. The Phase 3 Test-Writer wrote tests for components as they flowed through
+the pipeline — but reviewers may have identified additional coverage needs after seeing the
+full implementation as a system.
+
+You have access to: Read, Write, Edit, Glob, Grep, Bash.
+
+## Test Coverage Findings
+
+{test_coverage_findings_json}
+
+## What Phase 3 Already Tested
+
+{phase3_test_summaries}
+
+## Test Writing Protocol
+
+1. Read 1-2 existing test files to understand project testing conventions
+2. Check conftest.py for available fixtures
+3. For EACH coverage finding:
+   a. Read the affected code to understand what needs testing
+   b. Check if Phase 3 Test-Writer already covered this (avoid duplicating existing tests)
+   c. Write tests covering the identified gap:
+      - The specific untested path or condition from the finding
+      - Related edge cases you discover while reading the code
+      - Error conditions if the finding mentions untested error paths
+4. After writing all tests, run the test suite to verify they pass:
+   ```bash
+   uv run pytest {test_file} --tb=short -q
+   ```
+
+## Test File Location
+
+Add tests to existing test files when they cover the same module. Create new test files only
+when no appropriate existing file exists. Match the project's naming conventions.
+
+## What NOT To Do
+
+- Do NOT rewrite or modify existing tests (Phase 3 Test-Writer owns those)
+- Do NOT modify implementation code (Fixer owns that)
+- Do NOT write trivial tests just for coverage numbers
+- Do NOT skip findings because they seem "low severity" — if a reviewer flagged a coverage
+  gap, write the test
+
+## Output
+
+Send a TestCoverageResult to the lead when done:
+
+```
+SendMessage(type="message", recipient="team-lead",
+  content='{
+    "type": "TestCoverageResult",
+    "tests_written": [
+      {"finding_id": "QA-003", "test_file": "tests/unit/test_oauth.py", "test_count": 3,
+       "description": "Edge cases for token refresh with expired sessions"},
+      {"finding_id": "PERF-002", "test_file": "tests/unit/test_cache.py", "test_count": 2,
+       "description": "Cache eviction under concurrent access"}
+    ],
+    "skipped": [
+      {"finding_id": "QA-007", "reason": "Already covered by Phase 3 test_auth.py:test_login_flow"}
+    ],
+    "total_new_tests": 5,
+    "turn_count": 12
+  }',
+  summary="Test Coverage Agent: 5 new tests across 2 files, 1 finding already covered")
 ```
 ```
 

--- a/code-quality/skills/swarm/references/communication-schema.md
+++ b/code-quality/skills/swarm/references/communication-schema.md
@@ -404,6 +404,33 @@ The Fixer sends this to the Lead after completing Phase 5 work. Written to
 }
 ```
 
+### TestCoverageResult
+
+Sent by the Test Coverage Agent to the Lead after writing tests for Phase 4/4.5 coverage gaps.
+Written to `{run_dir}/test-coverage-result.json`.
+
+```json
+{
+  "schema": "TestCoverageResult",
+  "tests_written": [
+    {
+      "finding_id": "string — the review finding ID this test addresses",
+      "test_file": "string — path to test file created or modified",
+      "test_count": "number — count of new test cases written",
+      "description": "string — what the tests cover"
+    }
+  ],
+  "skipped": [
+    {
+      "finding_id": "string — finding ID that was not addressed",
+      "reason": "string — why (e.g. already covered by Phase 3 Test-Writer)"
+    }
+  ],
+  "total_new_tests": "number — total count of new test cases across all files",
+  "turn_count": "number — agent turn count for context health monitoring"
+}
+```
+
 ---
 
 ## Escalation Events Schema
@@ -596,6 +623,7 @@ hack/swarm/
     ├── security-design-review.json # Security design review (Phase 2.5, if run)
     ├── escalations.json            # Escalation events (Phase 4, always present)
     ├── fix-summary.json            # Fixer's summary (Phase 5, if run)
+    ├── test-coverage-result.json   # Test Coverage Agent's results (Phase 5, if coverage gaps)
     ├── verification-result.json    # Verifier's final test results (Phase 7)
     ├── swarm-report.md             # Human-readable completion report
     └── reviews/

--- a/code-quality/skills/swarm/references/communication-schema.md
+++ b/code-quality/skills/swarm/references/communication-schema.md
@@ -635,7 +635,8 @@ hack/swarm/
         ├── api.json                # API reviewer findings (if triggered)
         ├── db.json                 # DB reviewer findings (if triggered)
         ├── structural-concurrency.json  # Phase 4.5 Concurrency & State analyst findings
-        └── structural-integration.json  # Phase 4.5 Integration & Contract analyst findings
+        ├── structural-integration.json  # Phase 4.5 Integration & Contract analyst findings
+        └── docs-review.json            # Docs Reviewer findings (Phase 6, if run)
 ```
 
 The Lead resolves `{run_dir}` once in Phase 0 and passes it to all agents in their context

--- a/code-quality/skills/swarm/references/cynefin-reference.md
+++ b/code-quality/skills/swarm/references/cynefin-reference.md
@@ -228,7 +228,7 @@ solvable as stated?
 | Phase 3: Pipelined Implementation | Yes | Standard pipeline. |
 | Phase 4: Parallel Review | Yes | Standard. |
 | Phase 4.5: Structural Design Review | Yes | Always runs. |
-| Phase 5: Fix & Simplify | Conditional | Only if Phase 4/4.5 finds critical/high issues. |
+| Phase 5: Fix, Test Coverage & Simplify | Conditional | Only if Phase 4/4.5 finds any issues. |
 | Phase 6: Docs & Memory | Yes | Standard. |
 | Phase 7: Verification & Completion | Yes | Standard. Quality-gate invoked here. |
 
@@ -244,7 +244,7 @@ solvable as stated?
 | Phase 3: Pipelined Implementation | Yes | Standard pipeline. Parallel where possible. |
 | Phase 4: Parallel Review | Yes | Standard. May require domain expert reviewer. |
 | Phase 4.5: Structural Design Review | Yes | Always runs. |
-| Phase 5: Fix & Simplify | Conditional | Only if Phase 4/4.5 finds critical/high issues. |
+| Phase 5: Fix, Test Coverage & Simplify | Conditional | Only if Phase 4/4.5 finds any issues. |
 | Phase 6: Docs & Memory | Yes | Standard. |
 | Phase 7: Verification & Completion | Yes | Standard. Quality-gate invoked here. |
 
@@ -260,7 +260,7 @@ solvable as stated?
 | Phase 3: Pipelined Implementation | Yes | Smaller components. Explicit checkpoints between. |
 | Phase 4: Parallel Review | Yes | Reviewer assesses probe results, not just correctness. |
 | Phase 4.5: Structural Design Review | Yes | Always runs. Probe results may reveal structural issues. |
-| Phase 5: Fix & Simplify | Conditional | Only if Phase 4/4.5 finds critical/high issues. |
+| Phase 5: Fix, Test Coverage & Simplify | Conditional | Only if Phase 4/4.5 finds any issues. |
 | Phase 6: Docs & Memory | Yes | Standard. |
 | Phase 7: Verification & Completion | Yes | Quality-gate invoked here. Include re-classification assessment. |
 
@@ -276,7 +276,7 @@ solvable as stated?
 | Phase 3: Pipelined Implementation | Yes | Single implementer. Stabilization action only. |
 | Phase 4: Parallel Review | Yes | Lightweight. Verify stabilization works. |
 | Phase 4.5: Structural Design Review | Yes | Always runs. Stabilization may introduce structural issues. |
-| Phase 5: Fix & Simplify | Conditional | Standard. |
+| Phase 5: Fix, Test Coverage & Simplify | Conditional | Standard. |
 | Phase 6: Docs & Memory | Yes | Standard. |
 | Phase 7: Verification & Completion | Yes | Quality-gate invoked here. Must re-classify domain after stabilization. |
 

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1664,7 +1664,7 @@ Run directory: {run_dir}
 - Files modified: N
 - Lines added: +N / Lines removed: -N
 - Tests added: N
-- Review findings fixed: N (M optional, skipped)
+- Review findings fixed: N (M deferred)
 - Blocked items: N
 
 ## Pipeline Execution
@@ -1677,12 +1677,12 @@ Run directory: {run_dir}
 
 ## Review Findings
 
-| Reviewer | Findings | Must-Fix | Should-Fix | Optional |
-|----------|----------|----------|------------|---------|
-| security | 3 | 1 | 1 | 1 |
-| qa | 5 | 0 | 3 | 2 |
-| code-reviewer | 2 | 0 | 1 | 1 |
-| performance | 1 | 0 | 0 | 1 |
+| Reviewer | Findings | Critical | High | Medium | Low |
+|----------|----------|----------|------|--------|-----|
+| security | 3 | 1 | 1 | 1 | 0 |
+| qa | 5 | 0 | 2 | 2 | 1 |
+| code-reviewer | 2 | 0 | 0 | 1 | 1 |
+| performance | 1 | 0 | 0 | 0 | 1 |
 
 ## Blocked Items
 
@@ -1717,7 +1717,7 @@ Fixer deferred items: [none / list with reasons]
 ## Remaining Tech Debt
 
 - [ ] session-cleanup blocked — needs manual implementation
-- [ ] ui-reviewer flagged 2 optional a11y improvements (skipped as optional)
+- [ ] ui-reviewer flagged 2 low a11y improvements (deferred — requires design input)
 ```
 
 Get line stats:

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1188,6 +1188,8 @@ accordingly.
 | **Security design** | Trust boundary crossed without validation in the *architecture* (not code-level); auth layer structurally absent; attack surface created by the design decision itself | Phase 2.5 (Security Design re-run) |
 | **Scope creep** | Behavior implemented that was not in `architect-plan.json` components; feature added beyond specified scope | Human escalation via AskUserQuestion |
 | **Implementation** | Code-level bugs, injection vulnerabilities, naming/quality issues, performance bottlenecks — addressable with targeted code changes | Phase 5 Fixer (existing flow) |
+| **Test coverage** | Missing tests, untested code paths, coverage gaps identified by reviewers | Phase 5 Test Coverage Agent |
+| **Documentation** | Missing or incorrect documentation for implemented features | Phase 6 Docs agent |
 
 **Classification rule of thumb:** If the fix requires changing the architect's plan, it is design-level or security design. If the fix is a code change within the existing plan, it is implementation. When ambiguous, classify as implementation (Fixer is cheaper than re-running Phase 3).
 
@@ -1576,7 +1578,7 @@ The Lessons Extractor reads the swarm audit trail and writes principle-level les
 `hack/LESSONS.md` (or equivalent memory directory). It does NOT touch PROJECT.md, SESSIONS.md,
 or TODO.md — those are the Docs agent's responsibility.
 
-### Step 6.7: Shutdown Lessons Extractor
+### Step 6.8: Shutdown Lessons Extractor
 
 ```
 SendMessage(type="shutdown_request", recipient="lessons-extractor",
@@ -1611,7 +1613,7 @@ Skill(skill="quality-gate")
 ```
 
 The quality-gate skill runs automated multi-pass review:
-- 5 rotating adversarial lenses (Correctness, Completeness, Robustness, Simplicity, Adversarial)
+- 6 rotating adversarial lenses (Correctness, Completeness, Robustness, Simplicity, Adversarial, Structural)
 - Action audit each round — catches identified-but-unactioned items
 - Fresh-context subagent reviews (2 subagents × 2 passes)
 - Blocking memory and artifact gates

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -18,7 +18,7 @@ point is documented here.
 | 3 | Pipelined Implementation | Persistent team | implementer, reviewer, test-writer, test-runner |
 | 4 | Parallel Review | All reviewers simultaneously | security, qa, code-reviewer, performance (+ optional) |
 | 4.5 | Structural Design Review | Adversarial pair | structural-concurrency (opus), structural-integration (opus) |
-| 5 | Fix & Simplify | Sequential pair | fixer, code-simplifier |
+| 5 | Fix, Test Coverage & Simplify | Sequential trio | fixer, test-coverage-agent, code-simplifier |
 | 6 | Docs & Memory | Sequential trio | docs (sonnet), docs-reviewer (sonnet), then lessons-extractor (sonnet) |
 | 7 | Verification & Completion | Single agent + lead | verifier (haiku) |
 
@@ -241,7 +241,7 @@ t3 = TaskCreate("Phase 3: Pipelined implementation", "All components through pip
                 activeForm="Implementing components") → addBlockedBy: [t2_7]
 t4 = TaskCreate("Phase 4: Parallel review", "Security, QA, code-review, performance",
                 activeForm="Running parallel review") → addBlockedBy: [t3]
-t5 = TaskCreate("Phase 5: Fix & simplify", "Fixer + code-simplifier",
+t5 = TaskCreate("Phase 5: Fix, test coverage & simplify", "Fixer + test-coverage-agent + code-simplifier",
                 activeForm="Fixing review findings") → addBlockedBy: [t4]
 t6 = TaskCreate("Phase 6: Docs & memory", "Update documentation and project memory",
                 activeForm="Updating documentation") → addBlockedBy: [t5]
@@ -558,7 +558,7 @@ Evaluate whether this phase applies before spawning any agents:
 | Task has a single component with no stated approach uncertainty | Skip — proceed to Phase 3 |
 | Architect classified domain as Chaotic (stabilization brief only) | Skip — proceed to Phase 3 |
 | Architect classified domain as Clear (best practice, no real alternatives) | Skip — proceed to Phase 3 |
-| When in doubt | Skip — speculative adds cost, require a positive signal |
+| When in doubt | Skip — require an explicit positive signal from architect or lead |
 
 If skipping: note the reason in the audit trail (`.swarm-run` entry) and proceed to Phase 3.
 
@@ -639,7 +639,7 @@ Create the directory structure:
 ### Step 2.7.4: Spawn Competitors
 
 Default to 2 competitors unless the architect described 3+ meaningfully distinct approaches.
-Maximum 3 competitors in the swarm context (cost constraint).
+Maximum 3 competitors in the swarm context.
 
 For each contested component, spawn competitor agents simultaneously:
 
@@ -1177,8 +1177,8 @@ If ALL reviews report zero findings of any severity, set a flag: `skip_phase5 = 
 
 ### Step 4.5: Escalation Routing
 
-Before shutting down reviewers or proceeding to Phase 5, classify all critical and high findings
-by type and route accordingly.
+Before shutting down reviewers or proceeding to Phase 5, classify all findings by type and route
+accordingly.
 
 #### Finding Classification Rules
 
@@ -1363,7 +1363,7 @@ SendMessage(type="shutdown_request", recipient="structural-integration", content
 
 ---
 
-## Phase 5: Fix & Simplify
+## Phase 5: Fix, Test Coverage & Simplify
 
 ### Step 5.1: Skip Check
 
@@ -1380,8 +1380,8 @@ Agent(name="fixer", subagent_type="general-purpose", model="sonnet",
             "CONSOLIDATED FINDINGS:\n<JSON findings from synthesis>")
 ```
 
-Fixer addresses must-fix first, then should-fix. It sends a `FixSummary` message to the lead
-when done.
+Fixer addresses all findings: critical first, then high, then medium, then low. It sends a
+`FixSummary` message to the lead when done.
 
 ### Step 5.2.1: Handle Fixer Deferrals
 
@@ -1395,9 +1395,27 @@ or `deferred_items` fields — check all three due to naming inconsistency). For
 
 If no deferred items exist, skip this step.
 
+### Step 5.2.5: Spawn Test Coverage Agent (conditional)
+
+If ANY Phase 4 or Phase 4.5 reviewer identified test coverage gaps, missing tests, or untested
+code paths, spawn the Test Coverage Agent:
+
+```
+Agent(name="test-coverage-agent", subagent_type="general-purpose", model="sonnet",
+     team_name="swarm-impl", mode="bypassPermissions",
+     prompt="[context bundle]\n\n[test coverage agent prompt from agent-prompts.md]\n\n"
+            "TEST COVERAGE FINDINGS:\n<JSON test findings from Phase 4/4.5>\n\n"
+            "PHASE 3 TEST SUMMARIES:\n<TestHandoff summaries from Phase 3 Test-Writer>")
+```
+
+The Test Coverage Agent writes tests for coverage gaps identified during review. Wait for the
+`TestCoverageResult` message. Write it to `{run_dir}/test-coverage-result.json`.
+
+If no test coverage gaps were identified by any reviewer, skip this step.
+
 ### Step 5.3: Code-Simplifier Pass
 
-After fixer completes (and deferrals are handled), spawn code-simplifier:
+After fixer and test coverage agent complete (and deferrals are handled), spawn code-simplifier:
 
 ```
 Agent(name="code-simplifier", subagent_type="code-quality:code-simplifier", model="sonnet",
@@ -1441,6 +1459,7 @@ git commit -m "refactor: simplify implementation after review"
 
 ```
 SendMessage(type="shutdown_request", recipient="fixer", content="Fix phase complete.")
+SendMessage(type="shutdown_request", recipient="test-coverage-agent", content="Test coverage phase complete.")
 SendMessage(type="shutdown_request", recipient="code-simplifier", content="Simplify phase complete.")
 ```
 
@@ -1849,6 +1868,7 @@ TeamCreate:
 | 4.5 | structural-concurrency | general-purpose | opus | default | No |
 | 4.5 | structural-integration | general-purpose | opus | default | No |
 | 5 | fixer | general-purpose | sonnet | bypassPermissions | Yes |
+| 5 | test-coverage-agent | general-purpose | sonnet | bypassPermissions | Yes |
 | 5 | code-simplifier | code-quality:code-simplifier | sonnet | bypassPermissions | Yes |
 | 6 | docs | general-purpose | sonnet | bypassPermissions | Yes |
 | 6 | docs-reviewer | general-purpose | sonnet | default | No |
@@ -1857,8 +1877,8 @@ TeamCreate:
 
 Only agents that need Write/Edit access use `bypassPermissions`. Read-only agents use default mode.
 
-Maximum agent count: 22 (17 core + 5 optional domain reviewers).
-Minimum agent count: 17 (all domain reviewers skipped, all conditional phases run).
+Maximum agent count: 23 (18 core + 5 optional domain reviewers).
+Minimum agent count: 18 (all domain reviewers skipped, all conditional phases run).
 
 Agents are spawned and shut down per-phase to manage resource usage. The pipeline team (Phase 3)
 and reviewer team (Phase 4) are never active simultaneously.

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1452,6 +1452,7 @@ git commit -m "fix: address review findings from security/QA/performance review"
 If fixer, test coverage agent, and simplifier touched different file sets, they can be committed separately:
 ```bash
 git commit -m "fix: address security and quality review findings"
+git commit -m "test: add coverage for review-identified gaps"
 git commit -m "refactor: simplify implementation after review"
 ```
 

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1165,13 +1165,15 @@ Read all review JSON files. Categorize findings:
 
 | Category | Criteria | Action |
 |----------|----------|--------|
-| critical/high | Critical/high security findings; critical/high QA findings | Send to Fixer |
+| critical/high | Critical/high security findings; critical/high QA findings | Send to Fixer (priority) |
 | medium | Medium security; medium QA; high performance | Send to Fixer |
-| low/informational | Low/informational security; low QA; informational | Note in report only |
+| low/informational | Low/informational security; low QA; informational | Send to Fixer |
+| test coverage | Missing tests, untested paths, coverage gaps | Send to Test Coverage Agent |
 
-Build a consolidated findings list for the fixer. Group by file when possible.
+Build a consolidated findings list for the Fixer (all severities) and a test coverage
+findings list for the Test Coverage Agent. Group by file when possible.
 
-If ALL reviews report zero critical and zero high findings, set a flag: `skip_fixer = true`.
+If ALL reviews report zero findings of any severity, set a flag: `skip_phase5 = true`.
 
 ### Step 4.5: Escalation Routing
 
@@ -1349,8 +1351,8 @@ Add all actionable STRUCT findings to the consolidated findings list that Phase 
 Phase 5 treats STRUCT findings identically to Phase 4 findings — same severity triage, same fix
 protocol.
 
-If ALL structural findings are clean (zero critical or high), note this in the audit trail and
-skip_fixer remains unchanged from Phase 4's determination.
+If ALL structural findings are clean (zero findings of any severity), note this in the audit
+trail and skip_phase5 remains unchanged from Phase 4's determination.
 
 ### Step 4.5.5: Shutdown Structural Analysts
 
@@ -1365,8 +1367,9 @@ SendMessage(type="shutdown_request", recipient="structural-integration", content
 
 ### Step 5.1: Skip Check
 
-If `skip_fixer = true` (all Phase 4 AND Phase 4.5 reviews clean): skip Phase 5 entirely. Mark
-Phase 5 task as completed with note "No findings — skipped." Proceed to Phase 6.
+If `skip_phase5 = true` (all Phase 4 AND Phase 4.5 reviews report zero findings of any
+severity): skip Phase 5 entirely. Mark Phase 5 task as completed with note "No findings —
+skipped." Proceed to Phase 6.
 
 ### Step 5.2: Spawn Fixer
 

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1348,7 +1348,7 @@ Phase 4 escalation events.
 ### Step 4.5.4: Merge Into Phase 5 Consolidated Findings
 
 Add all actionable STRUCT findings to the consolidated findings list that Phase 5 Fixer receives.
-Phase 5 treats STRUCT findings identically to Phase 4 findings — same severity triage, same fix
+Phase 5 treats STRUCT findings identically to Phase 4 findings — same priority order, same fix
 protocol.
 
 If ALL structural findings are clean (zero findings of any severity), note this in the audit
@@ -1429,7 +1429,7 @@ swarm run (check git diff to identify scope).
 
 ### Step 5.4: Re-test Affected Tests
 
-After fixer and simplifier complete, run tests for the affected files only:
+After fixer, test coverage agent, and simplifier complete, run tests for the affected files only:
 
 ```bash
 # Python: run only tests for modified modules
@@ -1445,11 +1445,11 @@ cycle for post-review failures).
 ### Step 5.5: Commit
 
 ```bash
-git add <all files modified by fixer and simplifier>
+git add <all files modified by fixer, test coverage agent, and simplifier>
 git commit -m "fix: address review findings from security/QA/performance review"
 ```
 
-If fixer and simplifier touched different file sets, they can be committed separately:
+If fixer, test coverage agent, and simplifier touched different file sets, they can be committed separately:
 ```bash
 git commit -m "fix: address security and quality review findings"
 git commit -m "refactor: simplify implementation after review"

--- a/code-quality/skills/swarm/references/pipeline-model.md
+++ b/code-quality/skills/swarm/references/pipeline-model.md
@@ -301,16 +301,17 @@ the Lead synthesizes them and shuts down all reviewers before proceeding to Phas
 
 ### Phase 5: Fix Team Spawn (conditional)
 
-If any reviewer reported critical or high findings, spawn the Fixer and Code-Simplifier:
+If any reviewer reported findings of any severity, spawn Phase 5 agents:
 
 ```
 Lead spawns sequentially:
-  fixer            (general-purpose, sonnet)                   -- addresses findings
-  code-simplifier  (code-quality:code-simplifier, sonnet)   -- post-fix pass
+  fixer                (general-purpose, sonnet)                   -- addresses ALL findings
+  test-coverage-agent  (general-purpose, sonnet)                   -- writes tests for coverage gaps
+  code-simplifier      (code-quality:code-simplifier, sonnet)      -- post-fix pass
 ```
 
-These two run sequentially: Fixer first, Code-Simplifier after Fixer completes. Shut down both
-before Phase 6.
+These run sequentially: Fixer first, then Test Coverage Agent (if coverage gaps exist), then
+Code-Simplifier after both complete. Shut down all before Phase 6.
 
 ### Phase 6: Docs & Lessons
 

--- a/code-quality/skills/swarm/references/pipeline-model.md
+++ b/code-quality/skills/swarm/references/pipeline-model.md
@@ -164,6 +164,44 @@ The Lead tracks which components have completed and gates each dependent compone
 prerequisites. A component in Group 2 does not start until its Group 1 dependency sends a
 passing `TestResult`.
 
+### Fan-Out Mode (Parallel Mini-Pipelines)
+
+When the architect's dependency graph contains 2+ independent component groups (no shared files,
+no dependency edges between groups) AND the total component count exceeds 3, the Lead spawns
+**separate pipeline teams** for each independent group rather than routing all components through
+one Implementer.
+
+**Decision heuristic:**
+```
+IF architect.components.count > 3 AND architect.independent_groups.count > 1:
+    Fan out independent groups to parallel mini-pipelines
+ELSE:
+    Use single pipeline (Sequential, Full Pipeline, or Mixed mode)
+```
+
+**Each mini-pipeline is a complete team:**
+```
+Group 1:  Implementer-1 (sonnet, worktree) → Reviewer-1 (opus) → Test-Writer-1 (sonnet) → Test-Runner-1 (haiku)
+Group 2:  Implementer-2 (sonnet, worktree) → Reviewer-2 (opus) → Test-Writer-2 (sonnet) → Test-Runner-2 (haiku)
+```
+
+**Why fan out instead of serializing through one pipeline:**
+- Each Implementer's context stays small (only its group's components)
+- No lossy HandoffRequest→HandoffSummary→respawn cycle needed
+- Independent groups can complete at different speeds without blocking each other
+- Each Reviewer sees only the components it needs to review — no context contamination
+
+**Coordination:**
+- The Lead assigns merge priority per group (based on architect's merge order)
+- Groups merge sequentially by priority after all their components pass tests
+- If a merge conflict occurs between groups, the Lead resolves it or escalates to the user
+- The watchdog monitors all pipeline teams simultaneously (one CronCreate job)
+
+**Merge order:** Groups that touch foundational files (schemas, interfaces, shared utilities)
+merge first. Groups that build on those foundations merge after.
+
+**The decision to fan out is based on the dependency graph, never on cost or token concerns.**
+
 ---
 
 ## Backpressure Handling

--- a/code-quality/skills/swarm/references/pipeline-model.md
+++ b/code-quality/skills/swarm/references/pipeline-model.md
@@ -348,7 +348,7 @@ Single agent, shut down after it sends `VerificationResult`.
 | 3 | Architect (standby) + Implementer, Reviewer, Test-Writer, Test-Runner | 6 (5 + Lead) |
 | 4 | Security, QA, Code-Reviewer, Performance (+ optionals) | 5-10 + Lead |
 | 4.5 | Structural Analyst ×2 | 3 (2 + Lead) |
-| 5 | Fixer, then Code-Simplifier | 2 + Lead |
+| 5 | Fixer, Test Coverage Agent, then Code-Simplifier | 3 + Lead |
 | 6 | Docs, then Lessons Extractor | 2 (sequential) |
 | 7 | Verifier | 2 |
 


### PR DESCRIPTION
## Summary
- Removes swarm Phase 4→5 severity filter so ALL findings route to the Fixer, adds Phase 5 Test Coverage Agent for reviewer-identified coverage gaps, and adds parallel mini-pipeline fan-out for independent component groups
- Replaces pr-review confidence scoring with source-level finding verification (Sonnet investigates each finding by reading actual code), switches output from severity-grouped to type-categorized (testing gaps, correctness, security, architecture, decisions needed, etc.)
- Makes all 6 quality-gate review rounds mandatory, renames Cost Awareness to Scope Matching with Work Completion Principle anti-hedging directive across swarm, speculative, and map-reduce