### PR TITLE
refactor(code-quality): adds shared memory reference, run-ID naming

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research, business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, map-reduce, speculative, reflect, and index-repo",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research, business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, map-reduce, speculative, reflect, and index-repo",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/commands/review-project.md
+++ b/code-quality/commands/review-project.md
@@ -19,7 +19,9 @@ Perform comprehensive project review and TODO validation with **actual testing a
 
 ## Your Task
 
-Run thorough validation of all items in `hack/TODO.md` by TESTING implementations, not just checking files.
+First, detect the project memory directory using the convention in `code-quality/references/project-memory-reference.md` (Directory Detection section). All `{memory_dir}` references below resolve to the detected directory.
+
+Run thorough validation of all items in `{memory_dir}/TODO.md` by TESTING implementations, not just checking files.
 
 ---
 
@@ -88,9 +90,9 @@ Continuing with project review...
 ### 1a. Extract Claims from Project Memory
 
 **Sources to parse:**
-1. **hack/PROJECT.md** - Architecture decisions, migrations, removals, gotchas
-2. **hack/SESSIONS.md** - Session summaries of work completed
-3. **hack/TODO.md** - Completed items (marked `[x]`)
+1. **{memory_dir}/PROJECT.md** - Architecture decisions, migrations, removals, gotchas
+2. **{memory_dir}/SESSIONS.md** - Session summaries of work completed
+3. **{memory_dir}/TODO.md** - Completed items (marked `[x]`)
 
 **Example claims to extract:**
 - "Migrated all fonts from Roboto to Inter"
@@ -173,14 +175,14 @@ Verify:
 
 **After verification, archive all except last 2-3 sessions:**
 
-1. Create archive file: `hack/archived/SESSIONS-archive-[YYYY-MM].md`
+1. Create archive file: `{memory_dir}/archived/SESSIONS-archive-[YYYY-MM].md`
 2. Move verified sessions older than last 3 to archive
 3. Add footer to SESSIONS.md:
 
 ```markdown
 ---
 ## Archived Sessions
-Previous sessions archived to: `hack/archived/SESSIONS-archive-*.md`
+Previous sessions archived to: `{memory_dir}/archived/SESSIONS-archive-*.md`
 Note: These should rarely be needed. If you find yourself referencing
 archives frequently, important context may be missing from PROJECT.md.
 ```
@@ -303,10 +305,10 @@ Only after user has answered clarification questions:
 - Items removed as irrelevant: W
 
 ## Files Modified
-- PROJECT.md: [changes]
-- TODO.md: [changes]
-- SESSIONS.md: [changes]
-- hack/archived/: [if created]
+- {memory_dir}/PROJECT.md: [changes]
+- {memory_dir}/TODO.md: [changes]
+- {memory_dir}/SESSIONS.md: [changes]
+- {memory_dir}/archived/: [if created]
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```

--- a/code-quality/commands/session-end.md
+++ b/code-quality/commands/session-end.md
@@ -10,11 +10,7 @@ Before ending this session, update the project's persistent memory in `hack/` (o
 
 ### Step 1: Locate Memory Directory
 
-Check for existing directories in this order:
-1. `hack/`
-2. `.local/`
-3. `scratch/`
-4. `.dev/`
+Detect the project memory directory using the convention in `code-quality/references/project-memory-reference.md` (Directory Detection section).
 
 If none exist and this session had meaningful work, create `hack/` and add it to `.gitignore`.
 
@@ -26,16 +22,7 @@ Read all markdown files in the memory directory to understand what's already doc
 
 ## Content Placement Rules (CRITICAL)
 
-**Where information belongs:**
-
-| Content Type | Correct File | WRONG Files |
-|--------------|--------------|-------------|
-| Decisions, rationale, gotchas | PROJECT.md | SESSIONS.md, NEXT.md |
-| Technical discoveries | PROJECT.md | SESSIONS.md |
-| Future tasks/todos | TODO.md | SESSIONS.md, NEXT.md |
-| What was done (3-5 bullets) | SESSIONS.md | - |
-| Next direction pointer | NEXT.md | - |
-| Principle-level lessons | LESSONS.md | PROJECT.md, SESSIONS.md |
+See `code-quality/references/project-memory-reference.md` (Content Placement Rules section) for the authoritative table of where each content type belongs.
 
 ---
 
@@ -148,10 +135,10 @@ After updating memory files, scan the session for lessons worth capturing:
 **Extraction process:**
 1. Identify principle-level patterns (not implementation-specific details)
 2. Format as: `- [Category] Pattern → What to do differently → Why it matters (YYYY-MM-DD)`
-3. Check existing `hack/LESSONS.md` for duplicates or contradictions
+3. Check existing `{memory_dir}/LESSONS.md` for duplicates or contradictions
 4. If contradicting an existing lesson, mark the old one `[SUPERSEDED by YYYY-MM-DD]`
-5. Append new lessons to the `## Active` section of `hack/LESSONS.md`
-6. If `hack/LESSONS.md` doesn't exist, create it with the Active and Archived sections
+5. Append new lessons to the `## Active` section of `{memory_dir}/LESSONS.md`
+6. If `{memory_dir}/LESSONS.md` doesn't exist, create it with the Active and Archived sections
 
 **Context compaction note:** In long sessions, early human corrections may be compacted
 out of context. If the session was long, ask the user:

--- a/code-quality/commands/session-start.md
+++ b/code-quality/commands/session-start.md
@@ -10,11 +10,7 @@ Prepare for productive work by loading existing project memory or setting up a n
 
 ### Step 1: Detect Project State
 
-Check for existing memory directories in this order:
-1. `hack/`
-2. `.local/`
-3. `scratch/`
-4. `.dev/`
+Detect the project memory directory using the convention in `code-quality/references/project-memory-reference.md` (Directory Detection section).
 
 **If memory directory exists:** → Execute **Existing Project Flow**
 **If no memory directory:** → Execute **New Project Flow**

--- a/code-quality/references/project-memory-reference.md
+++ b/code-quality/references/project-memory-reference.md
@@ -1,0 +1,146 @@
+# Project Memory Reference
+
+> **Cross-reference note:** This file is referenced by multiple skills and commands. When editing, check all consumers.
+> Consumers — Skills: swarm (+ references), speculative, unfuck, map-reduce, incremental-planning, deep-research, index-repo,
+> roadmap, pr-review, quality-gate, bug-investigation, file-audit. Commands: session-start, session-end, review-project.
+
+Canonical definitions for project memory conventions. All memory-aware skills and commands in this plugin reference
+this file. Do not maintain ad-hoc memory conventions elsewhere — point here.
+
+---
+
+## Directory Detection
+
+Skills detect the memory directory by checking for existence in priority order. Use the first match found.
+
+| Priority | Directory | Notes |
+|----------|-----------|-------|
+| 1 | `hack/` | Primary; most projects use this |
+| 2 | `.local/` | Alternative for projects that prefer hidden dirs |
+| 3 | `scratch/` | Alternative naming convention |
+| 4 | `.dev/` | Alternative for dev-only scratch space |
+
+**Detection rule:** Check each directory for existence in order; use the first one found. If none exist, skip memory
+operations — do not create the directory. Skills that only read memory must never create the memory directory.
+
+**Worktree resolution:** See [Worktree Resolution](#worktree-resolution) for git worktree handling.
+
+---
+
+## Content Placement Rules
+
+Where content belongs within a memory directory. All skills must respect these placement rules.
+
+| Content Type | Correct File | NOT in |
+|--------------|--------------|--------|
+| Decisions and rationale | `PROJECT.md` | `SESSIONS.md`, `NEXT.md` |
+| Architecture details | `PROJECT.md` | `SESSIONS.md` |
+| Gotchas and discoveries | `PROJECT.md` | `TODO.md` |
+| Future tasks | `TODO.md` | `SESSIONS.md`, `NEXT.md` |
+| Session summary | `SESSIONS.md` (3–5 bullets) | — |
+| Next focus | `NEXT.md` (pointer only) | — |
+| Principle-level lessons | `LESSONS.md` | `PROJECT.md`, `SESSIONS.md` |
+
+**Anti-patterns:**
+
+- **SESSIONS.md is a log, not documentation.** If you are writing paragraphs, it belongs in `PROJECT.md`.
+- **NEXT.md is a pointer, not a plan.** Reference TODO items; do not write implementation details.
+
+---
+
+## Run-ID Naming Convention
+
+Run IDs uniquely identify skill invocations for audit trails, report filenames, and branch names.
+They encode the current branch and a unix timestamp to be sortable, unique, and traceable.
+
+### Format
+
+```
+<branch-slug>-<unix-timestamp>
+```
+
+Example: `feat-auth-1711388400`
+
+### Generation (EXACT — all skills MUST use this)
+
+```bash
+BRANCH_SLUG=$(git branch --show-current | tr '[:upper:]/' '[:lower:]-' | sed 's/[^a-z0-9-]//g' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
+BRANCH_SLUG=${BRANCH_SLUG:-detached}
+TIMESTAMP=$(date +%s)
+RUN_ID="${BRANCH_SLUG}-${TIMESTAMP}"
+```
+
+### Branch Slug Sanitization Rules
+
+| Rule | Detail |
+|------|--------|
+| Source | `git branch --show-current` |
+| Slashes | Convert to hyphens |
+| Uppercase | Convert to lowercase |
+| Non-alphanumeric | Strip (except hyphens) |
+| Length | Truncate to 40 chars after sanitization |
+| Detached HEAD / empty | Use `detached` as slug |
+| Consecutive hyphens | Collapse to single hyphen |
+| Leading/trailing hyphens | Strip |
+
+### Usage Patterns
+
+| Use case | Pattern | Example |
+|----------|---------|---------|
+| Audit trail directories | `{memory_dir}/{skill}/{run-id}/` | `hack/swarm/feat-auth-1711388400/` |
+| Report/plan filenames | `{memory_dir}/{type}/{run-id}-<topic>.md` | `hack/plans/feat-auth-1711388400-scope.md` |
+| Git branch names | `{skill}/{run-id}-<task-slug>` or `{skill}/{run-id}` | `swarm/feat-auth-1711388400-api` |
+
+### Non-Scope
+
+Date stamps in content (lesson dates, report headers) remain `YYYY-MM-DD`. Run IDs are for filenames and paths only.
+
+### Backward Compatibility
+
+Existing directories using old naming formats are left as-is. Run IDs apply to new skill invocations only.
+
+---
+
+## Memory Files
+
+Files that may appear in a memory directory. Skills read only what they need; session-start/session-end own the write format.
+
+### Core Files (always present in an initialized memory dir)
+
+| File | Purpose |
+|------|---------|
+| `PROJECT.md` | Architecture decisions, implementation details, gotchas |
+| `TODO.md` | Task list with checkboxes `- [ ] Task` / `- [x] Task (date)` |
+| `SESSIONS.md` | Session log (3–5 bullets per session, newest first) |
+| `NEXT.md` | Pointer to next task — one line referencing a TODO item |
+| `LESSONS.md` | Principle-level lessons: `[Category] Pattern → Action → Why (date)` |
+
+### Optional Files (skill-specific)
+
+| File | Created by | Purpose |
+|------|------------|---------|
+| `BUGS.md` | bug-investigation | Active and resolved bug tracking |
+| `WORK_ETHIC.md` | session-start | Agent behavior rules for this project |
+
+---
+
+## Worktree Resolution
+
+Skills running inside a git worktree must resolve where to find (and write) memory files.
+
+### Resolution Order
+
+1. **Symlink check:** If the memory dir exists as a symlink in the current worktree, follow it. Use the resolved path.
+2. **Main worktree fallback:** If no memory dir in current worktree, locate the main worktree:
+   ```bash
+   git worktree list --porcelain | head -1 | sed 's/^worktree //'
+   ```
+   Use `{main_worktree_path}/{memory_dir}/` (e.g., `{main_worktree_path}/hack/`).
+3. **No memory dir anywhere:** Skip memory operations entirely. Do not create the directory.
+
+### Read vs. Write Behavior
+
+| Operation | Behavior |
+|-----------|---------|
+| **Write** (audit trails, run outputs) | Write to resolved memory dir; run-ID subdirectory prevents contention across worktrees |
+| **Read** (shared memory files) | Read from resolved main memory dir (PROJECT.md, TODO.md, etc. are shared) |

--- a/code-quality/skills/bug-investigation/SKILL.md
+++ b/code-quality/skills/bug-investigation/SKILL.md
@@ -18,17 +18,19 @@ autonomously, documenting root causes and resolution plans in a central tracking
 
 This skill activates when:
 - User says they want to report bugs/issues for investigation
-- User describes a bug and a `hack/BUGS.md` exists or needs to be created
+- User describes a bug and a `BUGS.md` exists in the memory directory or needs to be created
 - User asks to "hunt bugs", "audit the UI", or "investigate issues"
 
 ## Phase 1: Setup
 
 ### Check for Existing BUGS.md
 
-Before starting, check if `hack/BUGS.md` already exists:
+Before starting, detect the memory directory using the convention in
+`code-quality/references/project-memory-reference.md` (Directory Detection section).
+Then check if `{memory_dir}/BUGS.md` already exists:
 
 ```
-Read hack/BUGS.md
+Read {memory_dir}/BUGS.md
 ```
 
 **If it exists:** Review it for stale entries.
@@ -41,6 +43,7 @@ Read hack/BUGS.md
 - Determine the next bug ID from the highest existing BUG-NNN + 1
 
 **If it doesn't exist:** Create it with the template below and confirm to the user.
+**If no memory directory found:** Skip BUGS.md and notify the user that tracking requires a memory directory.
 
 ### BUGS.md Template
 
@@ -124,7 +127,7 @@ You are investigating a bug for [project description] at [absolute project path]
 4. [Verify the issue — confirm the bug exists by reading the relevant code paths]
 
 ## Output
-READ [absolute path to hack/BUGS.md] first to find the insertion point, then EDIT it
+READ [absolute path to {memory_dir}/BUGS.md] first to find the insertion point, then EDIT it
 to insert a new entry at the top (after the HTML template comment, before the first
 existing BUG entry). Use this exact format:
 
@@ -191,7 +194,7 @@ Do NOT dump the full agent report into the conversation.
 
 When the user is done reporting bugs or asks to review status:
 
-1. Read `hack/BUGS.md` and summarize:
+1. Read `{memory_dir}/BUGS.md` and summarize:
    - Total bugs documented
    - Breakdown by severity (Critical/High/Medium/Low)
    - Breakdown by status (Investigating/Root Cause Found/Fix Ready/Fixed)
@@ -230,7 +233,7 @@ The agent starts fresh with no conversation context. Include:
 
 ### Direct the Output Location
 
-Always include the absolute path to BUGS.md and the exact BUG-NNN ID to use.
+Always include the absolute path to `{memory_dir}/BUGS.md` and the exact BUG-NNN ID to use.
 Agents should READ the file first (to find the insertion point) then EDIT it.
 
 ### Keep Investigation Focused
@@ -259,7 +262,7 @@ Mitigation strategies:
 
 ### Setup
 ```
-1. Check for hack/BUGS.md → clean up or create
+1. Detect memory dir (per project-memory-reference.md) → check for {memory_dir}/BUGS.md → clean up or create
 2. Determine next BUG-NNN ID
 3. Confirm readiness to user
 ```

--- a/code-quality/skills/deep-research/SKILL.md
+++ b/code-quality/skills/deep-research/SKILL.md
@@ -107,13 +107,18 @@ Include viewpoints from:
 
 ### Output Location
 
-If a `hack/` directory exists in the current working directory, write the research report to a file:
+Detect the project memory directory using the convention in
+`code-quality/references/project-memory-reference.md` (Directory Detection section).
 
-1. Create `hack/research/` if it does not exist
-2. Write the report to `hack/research/YYYY-MM-DD-<topic>.md` (use today's date and a short kebab-case topic slug, e.g. `2026-03-16-vertex-ai-pricing.md`)
-3. After writing, tell the user the file path
+If a memory directory is found, write the research report to a file:
 
-If no `hack/` directory exists, deliver the report in the conversation only.
+1. Generate a run ID per the Run-ID Naming Convention in that reference.
+2. Create `{memory_dir}/research/` if it does not exist.
+3. Write the report to `{memory_dir}/research/{run-id}-<topic>.md`
+   (e.g. `hack/research/feat-auth-1711388400-vertex-ai-pricing.md`).
+4. After writing, tell the user the file path.
+
+If no memory directory exists, deliver the report in the conversation only.
 
 ### Research Report Structure
 

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -33,7 +33,7 @@ Comprehensive, resumable code quality audit system that analyzes every non-gitig
 ORCHESTRATOR (you)
 ├── Phase 1: Discovery
 │   ├── git ls-files (find non-gitignored files)
-│   ├── Read project memory (hack/CONTEXT.md, TODO.md, NOTES.md)
+│   ├── Read project memory ({memory_dir}/PROJECT.md, {memory_dir}/TODO.md, {memory_dir}/LESSONS.md)
 │   └── Initialize queue.json
 │
 ├── Phase 2: Parallel Analysis
@@ -58,19 +58,22 @@ ORCHESTRATOR (you)
 
 ### Step 1: Initialization
 
+Detect the memory directory using the convention in
+`code-quality/references/project-memory-reference.md` (Directory Detection section).
+
 ```bash
 # Check for existing queue
-if hack/file-audit/queue.json exists:
+if {memory_dir}/file-audit/queue.json exists:
     Resume from last batch position
 else:
     # Discover files
     git ls-files --cached --others --exclude-standard
 
-    # Read project memory
-    Read hack/CONTEXT.md, hack/TODO.md, hack/NOTES.md (if exist)
+    # Read project memory (files per project-memory-reference.md Memory Files section)
+    Read {memory_dir}/PROJECT.md, {memory_dir}/TODO.md, {memory_dir}/LESSONS.md (if exist)
 
     # Create queue
-    Initialize hack/file-audit/queue.json with all files as "pending"
+    Initialize {memory_dir}/file-audit/queue.json with all files as "pending"
 ```
 
 ### Step 2: Parallel Processing Loop
@@ -122,7 +125,7 @@ IF total_files <= 20 (or /map-reduce unavailable):
    - Issues by category (unused_code, incorrect_usage, duplication, documentation_drift)
    - Issues by severity (error, warning, info)
 3. Generate consolidated TODO list
-4. Write hack/file-audit/inventory.json
+4. Write {memory_dir}/file-audit/inventory.json
 ```
 
 ---
@@ -141,9 +144,9 @@ Language: {language}
 ## Project Context
 Dependencies: {project_dependencies}
 Project Memory:
-- CONTEXT.md: {context_md_summary}
+- PROJECT.md: {project_md_summary}
 - TODO.md: {todo_md_summary}
-- NOTES.md: {notes_md_summary}
+- LESSONS.md: {lessons_md_summary}
 
 ## Your Task
 
@@ -165,7 +168,7 @@ Project Memory:
    - Check for: deprecated APIs, wrong signatures, missing error handling
 
 5. **Documentation Drift Check**
-   - Compare code behavior vs CONTEXT.md claims
+   - Compare code behavior vs PROJECT.md claims
    - Flag mismatches
 
 6. **Pattern Extraction**
@@ -231,7 +234,7 @@ IMPORTANT:
 
 ## Output Files
 
-### hack/file-audit/queue.json
+### {memory_dir}/file-audit/queue.json
 
 ```json
 {
@@ -248,7 +251,7 @@ IMPORTANT:
 }
 ```
 
-### hack/file-audit/inventory.json
+### {memory_dir}/file-audit/inventory.json
 
 ```json
 {
@@ -304,7 +307,7 @@ IMPORTANT:
 - `near_duplicate`: Very similar code (structural hash + >80% similarity)
 
 ### documentation_drift
-- `code_doc_mismatch`: Code behavior differs from CONTEXT.md claims
+- `code_doc_mismatch`: Code behavior differs from PROJECT.md claims
 - `missing_feature`: Documented feature not implemented in code
 - `undocumented_feature`: Significant code without documentation
 
@@ -324,7 +327,7 @@ IMPORTANT:
 
 When `/file-audit --resume` is invoked:
 
-1. Read `hack/file-audit/queue.json`
+1. Read `{memory_dir}/file-audit/queue.json`
 2. Find files with `status: "pending"` or `status: "in_progress"`
 3. Reset any `in_progress` to `pending` (they were interrupted)
 4. Continue from next pending batch
@@ -357,11 +360,12 @@ When LSP is unavailable for a file type:
 
 ## Integration with Project Memory
 
-The analyzer reads `hack/` files to:
+The analyzer reads project memory files (detected per `code-quality/references/project-memory-reference.md`) to:
 
-1. **Understand intended behavior**: CONTEXT.md describes architecture
+1. **Understand intended behavior**: `PROJECT.md` describes architecture and decisions
 2. **Check for drift**: Compare code vs documented intent
 3. **Identify stale docs**: Flag when code changed but docs didn't
-4. **Understand priorities**: TODO.md shows active work
+4. **Understand priorities**: `TODO.md` shows active work
+5. **Apply lessons**: `LESSONS.md` provides principle-level context for the project
 
 This enables detection of `documentation_drift` issues that pure code analysis would miss.

--- a/code-quality/skills/file-audit/references/analyzer-prompt.md
+++ b/code-quality/skills/file-audit/references/analyzer-prompt.md
@@ -35,16 +35,20 @@ You are analyzing a single file as part of a comprehensive code quality audit. Y
 **Project Root:** {{PROJECT_ROOT}}
 **Known Dependencies:** {{DEPENDENCIES}}
 
-### Project Memory (from hack/ directory)
+### Project Memory
 
-**CONTEXT.md Summary:**
-{{CONTEXT_MD_SUMMARY}}
+Detect the memory directory using the convention in
+`code-quality/references/project-memory-reference.md` (Directory Detection section).
+Memory files are read from `{memory_dir}/`.
+
+**PROJECT.md Summary:**
+{{PROJECT_MD_SUMMARY}}
 
 **TODO.md Summary:**
 {{TODO_MD_SUMMARY}}
 
-**NOTES.md Summary:**
-{{NOTES_MD_SUMMARY}}
+**LESSONS.md Summary:**
+{{LESSONS_MD_SUMMARY}}
 
 ---
 
@@ -135,8 +139,8 @@ If Context7 is unavailable, note `"context7_validated": false` in the dependency
 
 Compare the file's actual behavior against project memory:
 
-1. **Check CONTEXT.md claims:**
-   - Does this file implement what CONTEXT.md says it should?
+1. **Check PROJECT.md claims:**
+   - Does this file implement what PROJECT.md says it should?
    - Are there architectural claims that don't match reality?
 
 2. **Check TODO.md completions:**
@@ -180,7 +184,7 @@ Compile all findings into issues:
 | LSP findReferences = 0 | unused_code.unreferenced_function |
 | Context7 deprecation warning | incorrect_usage.deprecated_api |
 | Context7 signature mismatch | incorrect_usage.wrong_signature |
-| Code vs CONTEXT.md mismatch | documentation_drift.code_doc_mismatch |
+| Code vs PROJECT.md mismatch | documentation_drift.code_doc_mismatch |
 | TODO marked done but missing | documentation_drift.missing_feature |
 
 For each issue, provide:
@@ -276,7 +280,7 @@ This is a deep audit. Take time to:
 Every issue must have concrete evidence:
 - "LSP findReferences returned empty"
 - "Context7 docs state: '@validator is deprecated'"
-- "CONTEXT.md claims rate limiting but none found"
+- "PROJECT.md claims rate limiting but none found"
 
 Never flag issues based on suspicion alone.
 
@@ -292,7 +296,7 @@ Every issue should have a clear suggested fix:
 - Remove X
 - Replace X with Y
 - Add error handling for Z
-- Update CONTEXT.md to reflect actual behavior
+- Update PROJECT.md to reflect actual behavior
 
 ### Handle Errors Gracefully
 If LSP fails:
@@ -318,9 +322,9 @@ When generating the prompt, substitute these variables:
 | `{{LANGUAGE}}` | Detected from extension (.py, .ts, .go, etc.) |
 | `{{PROJECT_ROOT}}` | Git root or specified project directory |
 | `{{DEPENDENCIES}}` | From package.json, pyproject.toml, go.mod |
-| `{{CONTEXT_MD_SUMMARY}}` | First 500 chars or key points from hack/CONTEXT.md |
-| `{{TODO_MD_SUMMARY}}` | Active items from hack/TODO.md |
-| `{{NOTES_MD_SUMMARY}}` | Key gotchas from hack/NOTES.md |
+| `{{PROJECT_MD_SUMMARY}}` | First 500 chars or key points from `{memory_dir}/PROJECT.md` |
+| `{{TODO_MD_SUMMARY}}` | Active items from `{memory_dir}/TODO.md` |
+| `{{LESSONS_MD_SUMMARY}}` | Key lessons from `{memory_dir}/LESSONS.md` |
 
 ---
 
@@ -357,9 +361,9 @@ prompt = ANALYZER_TEMPLATE.format(
     LANGUAGE=language,
     PROJECT_ROOT="/path/to/project",
     DEPENDENCIES="fastapi, sqlalchemy, bcrypt, pydantic",
-    CONTEXT_MD_SUMMARY=project_memory.get("context", "No CONTEXT.md found"),
+    PROJECT_MD_SUMMARY=project_memory.get("project", "No PROJECT.md found"),
     TODO_MD_SUMMARY=project_memory.get("todo", "No TODO.md found"),
-    NOTES_MD_SUMMARY=project_memory.get("notes", "No NOTES.md found")
+    LESSONS_MD_SUMMARY=project_memory.get("lessons", "No LESSONS.md found")
 )
 
 result = Agent(

--- a/code-quality/skills/file-audit/references/issue-types.md
+++ b/code-quality/skills/file-audit/references/issue-types.md
@@ -382,10 +382,10 @@ Issues where code behavior differs from documented behavior in project memory fi
 
 **Severity:** warning
 
-**Detection:** Comparison of actual code behavior vs CONTEXT.md claims.
+**Detection:** Comparison of actual code behavior vs PROJECT.md claims.
 
 **Criteria:**
-- CONTEXT.md describes one behavior, code implements different behavior
+- PROJECT.md describes one behavior, code implements different behavior
 - Architecture document says one thing, implementation does another
 
 **Example:**
@@ -395,10 +395,10 @@ Issues where code behavior differs from documented behavior in project memory fi
   "subtype": "code_doc_mismatch",
   "severity": "warning",
   "location": {"line": 1, "end_line": 100},
-  "description": "CONTEXT.md claims rate limiting on all endpoints, but this file has none",
+  "description": "PROJECT.md claims rate limiting on all endpoints, but this file has none",
   "code_behavior": "No rate limiting middleware or decorator detected",
-  "documented_behavior": "All endpoints have rate limiting (hack/CONTEXT.md:45)",
-  "suggested_fix": "Either add rate limiting or update CONTEXT.md to note exceptions"
+  "documented_behavior": "All endpoints have rate limiting ({memory_dir}/PROJECT.md:45)",
+  "suggested_fix": "Either add rate limiting or update PROJECT.md to note exceptions"
 }
 ```
 
@@ -423,7 +423,7 @@ Issues where code behavior differs from documented behavior in project memory fi
   "severity": "warning",
   "location": {"line": 1},
   "description": "TODO.md claims 'password reset flow complete' but no reset endpoint found",
-  "documented_behavior": "Password reset flow (hack/TODO.md:23, marked complete)",
+  "documented_behavior": "Password reset flow ({memory_dir}/TODO.md:23, marked complete)",
   "code_behavior": "No password reset endpoint in auth routes",
   "suggested_fix": "Either implement the feature or uncheck the TODO item"
 }
@@ -438,7 +438,7 @@ Issues where code behavior differs from documented behavior in project memory fi
 **Detection:** Significant functionality exists without documentation.
 
 **Criteria:**
-- Major feature (>100 lines) not mentioned in CONTEXT.md
+- Major feature (>100 lines) not mentioned in PROJECT.md
 - Public API not documented
 - Significant behavior not noted anywhere
 
@@ -450,9 +450,9 @@ Issues where code behavior differs from documented behavior in project memory fi
   "severity": "info",
   "location": {"line": 200, "end_line": 350},
   "symbol": "AdminDashboard",
-  "description": "AdminDashboard class (150 lines) not documented in CONTEXT.md",
+  "description": "AdminDashboard class (150 lines) not documented in PROJECT.md",
   "code_behavior": "Full admin dashboard implementation with user management",
-  "suggested_fix": "Add section to CONTEXT.md describing admin dashboard architecture"
+  "suggested_fix": "Add section to PROJECT.md describing admin dashboard architecture"
 }
 ```
 

--- a/code-quality/skills/incremental-planning/SKILL.md
+++ b/code-quality/skills/incremental-planning/SKILL.md
@@ -102,8 +102,8 @@ specific questions — not generic ones.
 ### Actions
 
 - Launch an **Explore agent** (`Agent` with `subagent_type: "Explore"`) for relevant codebase areas
-- Read `hack/PROJECT.md` (or equivalent memory file) for past architectural decisions
-- Read `hack/LESSONS.md` for relevant past lessons (if exists). Silently incorporate applicable
+- Read `PROJECT.md` from the memory directory (detect using `code-quality/references/project-memory-reference.md` Directory Detection section) for past architectural decisions
+- Read `LESSONS.md` (if exists) from the memory directory for relevant past lessons. Silently incorporate applicable
   lessons — especially Architecture and Planning categories — into your approach without
   announcing each one. Do not quote lessons verbatim in chat.
 - Search **claude-mem** MCP for relevant past work, decisions, and learnings
@@ -215,16 +215,17 @@ Now write the plan. One section at a time.
 
 Before creating the plan file, check where it belongs:
 
-1. Check if the project uses a local memory directory — look for `hack/`, `.local/`,
-   `scratch/`, or `.dev/` in the project root (check in this order)
-2. **If found:** Create plans in `{memory-dir}/plans/YYYY-MM-DD-<feature>.md`
+1. Detect the project memory directory using the convention in
+   `code-quality/references/project-memory-reference.md` (Directory Detection section).
+2. **If found:** Generate a run ID per the Run-ID Naming Convention in that reference, then
+   create the plan at `{memory_dir}/plans/{run-id}-<feature>.md`
    (create the `plans/` subdirectory if it doesn't exist)
-3. **If none found:** Fall back to `~/.claude/plans/YYYY-MM-DD-<feature>.md`
+3. **If none found:** Fall back to `~/.claude/plans/{run-id}-<feature>.md`
    (create `~/.claude/plans/` if it doesn't exist)
 
 **Do NOT create a `hack/` directory if one doesn't exist.** That's a project-level decision.
 
-Announce the location: "Plan file: `hack/plans/2026-02-15-session-auth.md`"
+Announce the location: "Plan file: `hack/plans/feat-auth-1711388400-session-auth.md`"
 
 ### Writing Sequence
 
@@ -487,6 +488,6 @@ NEVER IN CHAT: Full plan content, task details, code blocks from the plan
 
 ### Plan File Location
 ```
-1. hack/plans/ (or .local/plans/, scratch/plans/, .dev/plans/) → if memory dir exists
-2. ~/.claude/plans/ → fallback for all other cases
+1. {memory_dir}/plans/{run-id}-<feature>.md → if memory dir exists (detect per project-memory-reference.md)
+2. ~/.claude/plans/{run-id}-<feature>.md → fallback for all other cases
 ```

--- a/code-quality/skills/incremental-planning/references/lessons-template.md
+++ b/code-quality/skills/incremental-planning/references/lessons-template.md
@@ -1,7 +1,7 @@
 # LESSONS.md Template
 
 Structured learning system for capturing principle-level insights across sessions.
-Lives at `hack/LESSONS.md` (or equivalent memory directory). Created on first use.
+Lives at `{memory_dir}/LESSONS.md` (detect directory per `code-quality/references/project-memory-reference.md`). Created on first use.
 
 ## File Format
 

--- a/code-quality/skills/index-repo/SKILL.md
+++ b/code-quality/skills/index-repo/SKILL.md
@@ -41,8 +41,9 @@ For each file category, identify:
 
 ### Phase 3: Generate PROJECT_INDEX.md
 
-Determine output location: check for a project memory directory (`hack/`, `.local/`, `scratch/`,
-`.dev/`) and write there. Fall back to project root only if none exists.
+Determine output location: detect the project memory directory using the convention in
+`code-quality/references/project-memory-reference.md` (Directory Detection section).
+Write there. Fall back to project root only if none exists.
 
 ```markdown
 # Project Index: {project_name}
@@ -100,5 +101,5 @@ Generated: {timestamp}
 
 ## Output
 
-Creates `PROJECT_INDEX.md` in the project memory directory (`hack/`, `.local/`, `scratch/`,
-`.dev/`) or project root if none exists (~3K tokens, human-readable).
+Creates `PROJECT_INDEX.md` in the project memory directory (detected per
+`code-quality/references/project-memory-reference.md`) or project root if none exists (~3K tokens, human-readable).

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -73,8 +73,10 @@ LEAD (you)
    If the user wants more than 8, use AskUserQuestion to confirm — document in fidelity-guide.md
    that uncapped splitting is a known fidelity risk.
 
-5. **Create audit trail:** `hack/map-reduce/YYYY-MM-DD/` (append `-2`, `-3` for multiple runs).
-   Write `hack/map-reduce/YYYY-MM-DD/chunks/` subdirectory for ChunkResult files.
+5. **Create audit trail:** Generate a run-ID using the convention in
+   `code-quality/references/project-memory-reference.md` (Run-ID Naming Convention section).
+   Create `{memory_dir}/map-reduce/{run-id}/` and `{memory_dir}/map-reduce/{run-id}/chunks/`
+   subdirectory for ChunkResult files.
 
 6. **Create tasks upfront:** use TaskCreate with addBlockedBy for the full task graph (one task
    per chunk + one for reduction + one for delivery) so progress is visible from the start.
@@ -210,7 +212,7 @@ Never leave an orphaned cron job.
 
 ```
 hack/map-reduce/
-└── YYYY-MM-DD/
+└── {run-id}/                   # e.g. feat-auth-1711388400
     ├── chunks/
     │   ├── chunk-1.json        # ChunkResult from mapper 1
     │   ├── chunk-2.json        # ChunkResult from mapper 2

--- a/code-quality/skills/map-reduce/references/communication-schema.md
+++ b/code-quality/skills/map-reduce/references/communication-schema.md
@@ -26,12 +26,12 @@ before spawning the mapper (so the mapper can read it on startup if preferred ov
       "exported_symbols": ["string — function/class names exported from this file"]
     }
   ],
-  "output_path": "string — where to write ChunkResult (e.g. 'hack/map-reduce/YYYY-MM-DD/chunks/chunk-1.json')",
+  "output_path": "string — where to write ChunkResult (e.g. 'hack/map-reduce/{run-id}/chunks/chunk-1.json')",
   "context": {
     "project": "string — project name",
     "task": "string — original user task description",
     "branch": "string — current git branch name",
-    "run_dir": "string — path to hack/map-reduce/YYYY-MM-DD",
+    "run_dir": "string — path to hack/map-reduce/{run-id}",
     "tool_guard": "Use Read/Write/Edit/Glob/Grep/Bash for file ops. No raw shell for file reads."
   }
 }
@@ -105,12 +105,12 @@ size limits).
   "failed_chunks": ["string — chunk_ids that returned status 'failed'"],
   "chunk_results_dir": "string — path to {run_dir}/chunks/ directory",
   "reduction_instructions": "string — how to synthesize: deduplicate, cross-validate, rank by severity, merge evidence",
-  "output_path": "string — where to write ReductionResult (e.g. 'hack/map-reduce/YYYY-MM-DD/reduction-result.json')",
+  "output_path": "string — where to write ReductionResult (e.g. 'hack/map-reduce/{run-id}/reduction-result.json')",
   "context": {
     "project": "string — project name",
     "task": "string — original user task description",
     "branch": "string — current git branch name",
-    "run_dir": "string — path to hack/map-reduce/YYYY-MM-DD",
+    "run_dir": "string — path to hack/map-reduce/{run-id}",
     "tool_guard": "Use Read/Write/Edit/Glob/Grep/Bash for file ops. No raw shell for file reads."
   }
 }
@@ -174,7 +174,7 @@ promotes or invalidates all `chunk-local` findings from mappers before writing o
 
 ```
 hack/map-reduce/
-└── YYYY-MM-DD/               # or YYYY-MM-DD-2, YYYY-MM-DD-3 for multiple runs
+└── {run-id}/                 # e.g. feat-auth-1711388400
     ├── chunks/
     │   ├── chunk-1.json      # ChunkResult from mapper 1 (written by mapper)
     │   ├── chunk-2.json      # ChunkResult from mapper 2

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -104,10 +104,10 @@ Store as `{claude_md_rules}` and `{contributing_md_rules}`.
 
 ### Discover Implementation Plan
 
-Search for a plan file that matches the PR's topic. Check both the repo root and any active
-worktree:
-- `hack/plans/` — glob for files whose name relates to the PR title or branch name
-- If the current repo is in a worktree, also check the main worktree's `hack/plans/`
+Search for a plan file that matches the PR's topic. Detect the memory directory using the
+convention in `code-quality/references/project-memory-reference.md` (Directory Detection and
+Worktree Resolution sections), then check `{memory_dir}/plans/` for files whose name relates
+to the PR title or branch name.
 
 If a matching plan file is found, read it and store as `{plan_content}`. If no plan exists,
 use: `"No implementation plan found."` The Correctness Reviewer uses this to detect plan drift.

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -56,7 +56,7 @@ Determine work type from session activity:
 | Signal | Work Type |
 |--------|-----------|
 | `git diff` has results | **Code** |
-| Plan file written to `hack/plans/` | **Planning** |
+| Plan file written to `{memory_dir}/plans/` | **Planning** |
 | Research/analysis conversation, no file edits | **Research** |
 | Edits to `.md`, `.yaml`, `.json`, `.toml` config | **Config/Artifact** |
 | Short Q&A, no tool use | **Question** |
@@ -405,22 +405,25 @@ not re-running them.
 Cannot proceed past this gate without completing all applicable checks.
 Memory that drifts from reality is worse than no memory.
 
+Update project memory files per the content placement rules in
+`code-quality/references/project-memory-reference.md`. Key surfaces:
+
 | Memory Surface | Action |
 |----------------|--------|
-| **hack/TODO.md** | Mark completed items `[x]` with date. Add new tasks. Remove stale items. |
-| **hack/PROJECT.md** | Document decisions, gotchas, architecture changes from this work. |
-| **hack/NEXT.md** | Update pointer to actual next task. |
-| **hack/SESSIONS.md** | Append 3-5 bullet summary (if session-end isn't imminent). |
-| **hack/plans/** | Delete completed plans. Update partial plans with progress. Delete superseded plans. |
+| **{memory_dir}/TODO.md** | Mark completed items `[x]` with date. Add new tasks. Remove stale items. |
+| **{memory_dir}/PROJECT.md** | Document decisions, gotchas, architecture changes from this work. |
+| **{memory_dir}/NEXT.md** | Update pointer to actual next task. |
+| **{memory_dir}/SESSIONS.md** | Append 3-5 bullet summary (if session-end isn't imminent). |
+| **{memory_dir}/plans/** | Delete completed plans. Update partial plans with progress. Delete superseded plans. |
 | **claude-mem** | Search for related observations. Flag stale ones. Save new cross-session insights. |
 | **Serena memories** | List, verify accuracy, update stale, write new project knowledge. |
 | **Auto-memory** | Check project memory path, verify and update if relevant. |
-| **hack/LESSONS.md** | Check if current work produced principle-level lessons worth capturing. If human corrections or rejected approaches occurred, extract and write lessons before proceeding. |
+| **{memory_dir}/LESSONS.md** | Check if current work produced principle-level lessons worth capturing. If human corrections or rejected approaches occurred, extract and write lessons before proceeding. |
 
-**Skip conditions:** hack/ doesn't exist → skip hack/ checks. No plans directory → skip plan
-checks. claude-mem MCP unavailable → skip claude-mem checks. Serena MCP unavailable → skip
-Serena memory checks. Pure question with no persistent insights → skip memory saves.
-hack/LESSONS.md doesn't exist → skip LESSONS check.
+**Skip conditions:** No memory dir found (per Directory Detection section of the reference) → skip
+memory-dir checks. No plans directory → skip plan checks. claude-mem MCP unavailable → skip
+claude-mem checks. Serena MCP unavailable → skip Serena memory checks. Pure question with no
+persistent insights → skip memory saves. LESSONS.md doesn't exist → skip LESSONS check.
 
 ---
 
@@ -490,14 +493,14 @@ confirming each applicable item.
 
 Durable means: **another agent in a fresh session can find the work without being told where
 to look.** PRs show up in `gh pr list`. Commits show up in `git log`. Plan files show up in
-`hack/plans/`. Project decisions show up in `hack/PROJECT.md`. Conversation-only knowledge
+`{memory_dir}/plans/`. Project decisions show up in `{memory_dir}/PROJECT.md`. Conversation-only knowledge
 and working-tree-only changes fail this test.
 
 | Work Type | Persistence Check |
 |-----------|-------------------|
 | **Code** | Changes are on a **pushed feature branch with a PR** (verifiable via `gh pr view`). Not just committed locally — pushed and PR-visible. Uncommitted or committed-but-not-pushed work is NOT durable. |
-| **Planning** | Plan written to `hack/plans/YYYY-MM-DD-<topic>.md`. New tasks added to `hack/TODO.md`. Decisions documented in `hack/PROJECT.md`. |
-| **Research** | Findings written to `hack/research/YYYY-MM-DD-<topic>.md` (if hack/ exists), or to `hack/PROJECT.md`, or saved to claude-mem. Key findings must survive session end. |
+| **Planning** | Plan written to `{memory_dir}/plans/{run-id}-<topic>.md`. New tasks added to `{memory_dir}/TODO.md`. Decisions documented in `{memory_dir}/PROJECT.md`. |
+| **Research** | Findings written to `{memory_dir}/research/{run-id}-<topic>.md` (if memory dir exists), or to `{memory_dir}/PROJECT.md`, or saved to claude-mem. Key findings must survive session end. |
 | **All types** | For each significant artifact, state WHERE it is persisted and HOW a future agent finds it. "It's in the working tree" or "it's in the conversation" fails this gate. |
 
 **Skip conditions:** Pure question with no artifacts → skip. Work explicitly scoped as

--- a/code-quality/skills/roadmap/SKILL.md
+++ b/code-quality/skills/roadmap/SKILL.md
@@ -36,9 +36,10 @@ Before ingesting any plans, check whether an existing roadmap document already e
 
 ### Step 1: Locate plan directory
 
-Check for `hack/`, `.local/`, `scratch/`, `.dev/` in the project root (in this order).
+Detect the project memory directory using the convention in
+`code-quality/references/project-memory-reference.md` (Directory Detection section).
 
-- **If found:** Plan directory is `{memory-dir}/plans/`
+- **If found:** Plan directory is `{memory_dir}/plans/`
 - **If none found:** **Skip Phase 0** — proceed to Phase 1. Stateful roadmap management
   requires a project-local memory directory. `~/.claude/plans/` is shared across all projects
   and globbing it would surface cross-project roadmaps, leading to false positives and
@@ -364,12 +365,14 @@ Write the roadmap file following the schema in `references/phase-schema.md`.
 
 Use the same logic as `/incremental-planning`:
 
-1. Check for `hack/`, `.local/`, `scratch/`, `.dev/` in the project root (in this order)
-2. **If found:** Write to `{memory-dir}/plans/YYYY-MM-DD-roadmap-<name>.md`
+1. Detect the project memory directory using the convention in
+   `code-quality/references/project-memory-reference.md` (Directory Detection section).
+2. **If found:** Generate a run ID per the Run-ID Naming Convention in that reference, then
+   write to `{memory_dir}/plans/{run-id}-roadmap-<name>.md`
    (create the `plans/` subdirectory if it doesn't exist)
-3. **If none found:** Fall back to `~/.claude/plans/YYYY-MM-DD-roadmap-<name>.md`
+3. **If none found:** Fall back to `~/.claude/plans/{run-id}-roadmap-<name>.md`
 
-**Announce location:** "Roadmap file: `hack/plans/2026-03-20-roadmap-auth-launch.md`"
+**Announce location:** "Roadmap file: `hack/plans/feat-auth-1711388400-roadmap-auth-launch.md`"
 
 Do NOT create a `hack/` directory if one doesn't exist.
 
@@ -564,8 +567,8 @@ NEVER IN CHAT: Full roadmap content, raw table data, raw diff content from subag
 ### Roadmap File Location (Phase 4 — document generation)
 
 ```
-1. hack/plans/ (or .local/plans/, scratch/plans/, .dev/plans/) → if memory dir exists
-2. ~/.claude/plans/ → fallback for all other cases
+1. {memory_dir}/plans/{run-id}-roadmap-<name>.md → if memory dir exists (detect per project-memory-reference.md)
+2. ~/.claude/plans/{run-id}-roadmap-<name>.md → fallback for all other cases
 ```
 
 **Phase 0 detection** only runs when a project memory dir exists (option 1 above).

--- a/code-quality/skills/roadmap/references/phase-schema.md
+++ b/code-quality/skills/roadmap/references/phase-schema.md
@@ -190,8 +190,8 @@ Where `{plan-name}` is the plan filename without date prefix and `.md` extension
 spaces and underscores replaced by hyphens.
 
 Examples:
-- Plan file: `hack/plans/2026-03-20-auth-refactor.md` → Branch: `roadmap/phase-1/auth-refactor`
-- Plan file: `hack/plans/2026-03-20-db-migration.md` → Branch: `roadmap/phase-2/db-migration`
+- Plan file: `hack/plans/{run-id}-auth-refactor.md` → Branch: `roadmap/phase-1/auth-refactor`
+- Plan file: `hack/plans/{run-id}-db-migration.md` → Branch: `roadmap/phase-2/db-migration`
 
 Branches must not collide across tracks in the same phase or across phases.
 
@@ -207,8 +207,8 @@ Two plans where Plan B depends on files created by Plan A's first two tasks.
 # Roadmap: Auth Refactor + Session Storage
 
 **Source plans:**
-- /home/user/project/hack/plans/2026-03-20-auth-refactor.md
-- /home/user/project/hack/plans/2026-03-20-session-storage.md
+- /home/user/project/hack/plans/{run-id}-auth-refactor.md
+- /home/user/project/hack/plans/{run-id}-session-storage.md
 
 **Total phases:** 2
 **Critical path:** Auth Refactor (Phase 1, Tasks 1-2) → Session Storage (Phase 2) — session
@@ -221,7 +221,7 @@ storage depends on the auth middleware interface defined in Tasks 1-2 of Auth Re
 
 | Track | Plan | Tasks | Worktree Branch | Depends On | Skill | Domain |
 |-------|------|-------|-----------------|------------|-------|--------|
-| A | /home/user/project/hack/plans/2026-03-20-auth-refactor.md | Tasks 1-2 | roadmap/phase-1/auth-refactor | None | /swarm | Complicated |
+| A | /home/user/project/hack/plans/{run-id}-auth-refactor.md | Tasks 1-2 | roadmap/phase-1/auth-refactor | None | /swarm | Complicated |
 
 **Sync point:** All tracks must complete before Phase 2 begins.
 **Merge order:** Track A only.
@@ -233,8 +233,8 @@ storage depends on the auth middleware interface defined in Tasks 1-2 of Auth Re
 
 | Track | Plan | Tasks | Worktree Branch | Depends On | Skill | Domain |
 |-------|------|-------|-----------------|------------|-------|--------|
-| A | /home/user/project/hack/plans/2026-03-20-auth-refactor.md | Tasks 3-5 | roadmap/phase-2/auth-refactor | None | /swarm | Complicated |
-| B | /home/user/project/hack/plans/2026-03-20-session-storage.md | All | roadmap/phase-2/session-storage | None | /swarm | Clear |
+| A | /home/user/project/hack/plans/{run-id}-auth-refactor.md | Tasks 3-5 | roadmap/phase-2/auth-refactor | None | /swarm | Complicated |
+| B | /home/user/project/hack/plans/{run-id}-session-storage.md | All | roadmap/phase-2/session-storage | None | /swarm | Clear |
 
 **Sync point:** All tracks must complete before merging to main. Final phase.
 **Merge order:** Track A first (touches middleware layer), then Track B (additive session layer, no conflicts expected).
@@ -251,9 +251,9 @@ and Plan B's API layer (Phase 2) before it can implement the frontend.
 # Roadmap: Full Stack Feature Launch
 
 **Source plans:**
-- /home/user/project/hack/plans/2026-03-20-db-schema.md
-- /home/user/project/hack/plans/2026-03-20-api-layer.md
-- /home/user/project/hack/plans/2026-03-20-frontend-ui.md
+- /home/user/project/hack/plans/{run-id}-db-schema.md
+- /home/user/project/hack/plans/{run-id}-api-layer.md
+- /home/user/project/hack/plans/{run-id}-frontend-ui.md
 
 **Total phases:** 3
 **Critical path:** DB Schema (Phase 1) → API Layer (Phase 2) → Frontend UI (Phase 3) —
@@ -266,8 +266,8 @@ each layer depends on the contract defined by the layer below it.
 
 | Track | Plan | Tasks | Worktree Branch | Depends On | Skill | Domain |
 |-------|------|-------|-----------------|------------|-------|--------|
-| A | /home/user/project/hack/plans/2026-03-20-db-schema.md | All | roadmap/phase-1/db-schema | None | /swarm | Complicated |
-| B | /home/user/project/hack/plans/2026-03-20-api-layer.md | Tasks 1-2 | roadmap/phase-1/api-layer | None | /swarm | Complicated |
+| A | /home/user/project/hack/plans/{run-id}-db-schema.md | All | roadmap/phase-1/db-schema | None | /swarm | Complicated |
+| B | /home/user/project/hack/plans/{run-id}-api-layer.md | Tasks 1-2 | roadmap/phase-1/api-layer | None | /swarm | Complicated |
 
 **Sync point:** All tracks must complete before Phase 2 begins.
 **Merge order:** Track A first (schema migrations must land before API references them), then Track B.
@@ -279,7 +279,7 @@ each layer depends on the contract defined by the layer below it.
 
 | Track | Plan | Tasks | Worktree Branch | Depends On | Skill | Domain |
 |-------|------|-------|-----------------|------------|-------|--------|
-| A | /home/user/project/hack/plans/2026-03-20-api-layer.md | Tasks 3-7 | roadmap/phase-2/api-layer | None | /swarm | Complicated |
+| A | /home/user/project/hack/plans/{run-id}-api-layer.md | Tasks 3-7 | roadmap/phase-2/api-layer | None | /swarm | Complicated |
 
 **Sync point:** All tracks must complete before Phase 3 begins.
 **Merge order:** Track A only.
@@ -291,8 +291,8 @@ each layer depends on the contract defined by the layer below it.
 
 | Track | Plan | Tasks | Worktree Branch | Depends On | Skill | Domain |
 |-------|------|-------|-----------------|------------|-------|--------|
-| A | /home/user/project/hack/plans/2026-03-20-frontend-ui.md | All | roadmap/phase-3/frontend-ui | None | /swarm | Complex |
-| B | /home/user/project/hack/plans/2026-03-20-api-layer.md | Tasks 8-9 | roadmap/phase-3/api-layer | None | /swarm | Clear |
+| A | /home/user/project/hack/plans/{run-id}-frontend-ui.md | All | roadmap/phase-3/frontend-ui | None | /swarm | Complex |
+| B | /home/user/project/hack/plans/{run-id}-api-layer.md | Tasks 8-9 | roadmap/phase-3/api-layer | None | /swarm | Clear |
 
 **Sync point:** All tracks must complete before merging to main. Final phase.
 **Merge order:** Track B first (API hardening is additive), then Track A (frontend may reference finalized API contracts).

--- a/code-quality/skills/speculative/SKILL.md
+++ b/code-quality/skills/speculative/SKILL.md
@@ -35,8 +35,9 @@ Gather the problem and success criteria before spawning anything.
    - Simplicity (is it the minimum necessary complexity?)
    - Add or substitute criteria based on user priorities
 
-3. Create the audit trail directory at `hack/speculative/YYYY-MM-DD/`. If the directory
-   already exists (multiple runs same day), append a sequence number.
+3. Generate a run-ID using the convention in `code-quality/references/project-memory-reference.md`
+   (Run-ID Naming Convention section) and create the audit trail directory at
+   `{memory_dir}/speculative/{run-id}/`.
 
 4. Create all tasks upfront with `TaskCreate` so the plan is visible from the start.
 
@@ -153,7 +154,7 @@ User request
      v
 Phase 0: Specification
   +-- AskUserQuestion (ambiguity, criteria, competitor count)
-  +-- Create hack/speculative/YYYY-MM-DD/
+  +-- Generate run-ID, create {memory_dir}/speculative/{run-id}/
   +-- TaskCreate for all phases
      |
      v
@@ -215,7 +216,7 @@ the selection.
 
 ### Audit Trail
 
-Write all structured outputs to `hack/speculative/YYYY-MM-DD/`:
+Write all structured outputs to `{run_dir}/`:
 - `implementations/competitor-{id}.json` — each competitor's ImplementationResult
 - `judgment.json` — judge's JudgmentResult
 - `speculative-report.md` — final human-readable completion report

--- a/code-quality/skills/speculative/references/communication-schema.md
+++ b/code-quality/skills/speculative/references/communication-schema.md
@@ -16,7 +16,7 @@ Every agent receives this bundle when spawned. The Lead constructs it in Phase 0
   "project": "string — project name from repo root",
   "task": "string — original user task description, verbatim",
   "branch": "string — current git branch name",
-  "run_dir": "string — absolute or repo-relative path to hack/speculative/YYYY-MM-DD",
+  "run_dir": "string — absolute or repo-relative path to hack/speculative/{run-id}",
   "tool_guard": "Use Read/Write/Edit/Glob/Grep/Bash for file ops. No raw shell for file reads."
 }
 ```
@@ -178,7 +178,7 @@ same date append a sequence number.
 
 ```
 hack/speculative/
-└── YYYY-MM-DD/                    # or YYYY-MM-DD-2, YYYY-MM-DD-3 for multiple runs
+└── {run-id}/                      # e.g. feat-auth-1711388400
     ├── implementations/
     │   ├── competitor-1.json          # competitor-1's ImplementationResult
     │   ├── competitor-2.json          # competitor-2's ImplementationResult

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -70,8 +70,8 @@ Run the project test suite and record the baseline (pass/fail count, any pre-exi
 Check git status — ensure the working tree is clean, identify the current branch, and determine
 whether a feature branch is needed. If not already on a feature branch, create one from
 `upstream/main` or `origin/main`. Verify that auto-compaction is enabled — the /swarm skill
-depends on it for reliable agent operation (warn the user if disabled). Create the audit trail
-directory at `hack/swarm/YYYY-MM-DD/` (append sequence number if the directory already exists).
+depends on it for reliable agent operation (warn the user if disabled). Generate a run ID using the convention in `code-quality/references/project-memory-reference.md`
+(Run-ID Naming Convention section) and create the audit trail directory at `hack/swarm/{run-id}/`.
 Call `TeamCreate("swarm-impl")`, then create all tasks upfront with `addBlockedBy` dependencies
 so the full task graph is visible from the start.
 
@@ -102,7 +102,7 @@ The Cynefin classification (`cynefin_domain` and `domain_justification`) is writ
 `architect-plan.json` and is advisory — it informs how phases run, never whether mandatory phases
 run. The Lead reads the classification to inform Phase 2.5 skip decisions.
 
-Output is a structured JSON plan written to `hack/swarm/YYYY-MM-DD/architect-plan.json`
+Output is a structured JSON plan written to `{run_dir}/architect-plan.json`
 (see schema in `references/communication-schema.md`). The architect also identifies global risks,
 data model changes, API surface changes, and **documentation impact** — a `documentation_impact`
 array listing which documentation surfaces are affected and why (READMEs, manifests, registries,
@@ -234,7 +234,7 @@ tasks. The Lead decides based on the dependency graph — never based on cost or
 
 Spawn ALL review agents simultaneously: Security, QA, Code-Reviewer, Performance, and any
 auto-detected optional reviewers (UI, API, DB). All reviewers operate in read-only mode on the
-completed implementation. Each writes structured JSON findings to `hack/swarm/YYYY-MM-DD/reviews/`
+completed implementation. Each writes structured JSON findings to `{run_dir}/reviews/`
 (see schema in `references/communication-schema.md`). The Lead collects ALL findings and
 synthesizes into a consolidated view. Every finding — regardless of severity — is routed to
 Phase 5 for action. No finding is silently dropped or left unactioned in the audit trail.
@@ -352,8 +352,8 @@ The Docs agent performs three passes:
 corresponding documentation needs updating (README behavior descriptions, API docs, config docs,
 CONTRIBUTING.md). Update only what is directly affected.
 
-The Docs agent also detects the project's memory directory (`hack/`, `.local/`, `scratch/`,
-`.dev/`) and updates PROJECT.md with architectural decisions, TODO.md with completed and new
+The Docs agent also detects the project's memory directory (per `code-quality/references/project-memory-reference.md`,
+Directory Detection section) and updates PROJECT.md with architectural decisions, TODO.md with completed and new
 items, and SESSIONS.md with a 3-5 bullet summary.
 
 **Skip conditions for Phase 6 docs (memory updates always run):**
@@ -391,8 +391,9 @@ schema with `DOC-R` prefix. Critical/High findings are routed back to the Docs a
 in the audit trail.
 
 After the Docs Reviewer completes (or confirms clean), spawn a separate **Lessons Extractor** agent (sonnet model). This
-agent scans the swarm run's audit trail and extracts principle-level lessons to `hack/LESSONS.md`
-(creating the file if it does not exist). It reads:
+agent scans the swarm run's audit trail and extracts principle-level lessons to
+`{memory_dir}/LESSONS.md` (creating the file if it does not exist, where `{memory_dir}` is the
+project memory directory detected per `code-quality/references/project-memory-reference.md`). It reads:
 - `{run_dir}/architect-plan.json` — Cynefin domain, questions raised, risks flagged
 - `{run_dir}/reviews/` — recurring finding patterns across reviewers
 - `{run_dir}/escalations.json` — escalation events (if the file exists)
@@ -413,7 +414,7 @@ Verifier reports green, invoke the `quality-gate` skill for automated multi-pass
 rotating adversarial lenses, fresh-context subagent reviews, and blocking memory/artifact gates.
 If there are 20 or more modified files, run an `/unfuck` sweep to
 catch any issues introduced at scale. Generate the final audit report at
-`hack/swarm/YYYY-MM-DD/swarm-report.md`. Announce completion with a summary and report path.
+`{run_dir}/swarm-report.md`. Announce completion with a summary and report path.
 Shut down all teammates via `SendMessage(type="shutdown_request")` and call `TeamDelete`.
 
 ---
@@ -427,7 +428,7 @@ User request
 Phase 0: Pre-flight
   +-- Baseline tests
   +-- Git branch check/create
-  +-- Create hack/swarm/YYYY-MM-DD/
+  +-- Generate run-ID, create {memory_dir}/swarm/{run-id}/
   +-- TeamCreate + TaskGraph
      |
      v
@@ -493,14 +494,14 @@ Phase 5: Fix, Test Coverage & Simplify (if any findings exist)
 Phase 6: Docs & Memory
   +-- Docs agent: repo docs + hack/ updates
   +-- Docs Reviewer: verify Docs agent's work
-  +-- Lessons Extractor: audit trail → hack/LESSONS.md
+  +-- Lessons Extractor: audit trail → {memory_dir}/LESSONS.md
      |
      v
 Phase 7: Verification & Completion
   +-- Verifier: full test + lint
   +-- quality-gate skill
   +-- /unfuck sweep (if 20+ files changed)
-  +-- Generate swarm-report.md
+  +-- Generate {run_dir}/swarm-report.md
   +-- Shutdown all teammates, TeamDelete
 ```
 
@@ -560,7 +561,7 @@ and report to the user with full context.
 
 ### Audit Trail
 
-Write all structured outputs to `hack/swarm/YYYY-MM-DD/`:
+Write all structured outputs to `{run_dir}/`:
 - `architect-plan.json` — architect's component plan
 - `reviews/security.json`, `reviews/qa.json`, etc. — review findings
 - `escalations.json` — escalation events for Lessons extraction
@@ -580,7 +581,7 @@ After escalation, wait for user input before proceeding.
   "project": "<project name>",
   "task": "<original task description>",
   "branch": "<current git branch>",
-  "run_dir": "hack/swarm/YYYY-MM-DD",
+  "run_dir": "{memory_dir}/swarm/{run-id}",
   "key_files": ["<files identified by architect as central>"],
   "tool_guard": "Use Read/Write/Edit/Glob/Grep/Bash for file ops. No raw shell for file reads."
 }

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -1676,14 +1676,8 @@ You have access to: Read, Write, Edit, Glob, Grep.
 
 ### Step 1: Detect Memory Directory
 
-Check in order:
-```
-Glob("hack/PROJECT.md")     → if found, memory_dir = "hack/"
-Glob(".local/PROJECT.md")   → if found, memory_dir = ".local/"
-Glob("scratch/PROJECT.md")  → if found, memory_dir = "scratch/"
-Glob(".dev/PROJECT.md")     → if found, memory_dir = ".dev/"
-```
-
+Detect the project memory directory using the convention in
+`code-quality/references/project-memory-reference.md` (Directory Detection section).
 If no memory directory exists, skip memory updates.
 
 ### Step 2: Architect-Guided Documentation Updates (Pass 1)
@@ -1846,8 +1840,7 @@ Send summary to lead when done.
 **Type:** `general-purpose` | **Model:** sonnet | **Mode:** bypassPermissions
 
 > **DISTINCT FROM Docs agent.** The Docs agent updates PROJECT.md, TODO.md, SESSIONS.md, and
-> repo documentation. The Lessons Extractor writes ONLY to `hack/LESSONS.md` (or equivalent
-> memory directory). Do NOT write to other memory files.
+> repo documentation. The Lessons Extractor writes ONLY to `{memory_dir}/LESSONS.md`. Do NOT write to other memory files.
 
 ```markdown
 # Lessons Extractor — Swarm Phase 6 Agent
@@ -1872,28 +1865,16 @@ If a Bash command is blocked, switch to the equivalent native tool.
 
 You are the Lessons Extractor. You scan this swarm run's audit trail and extract
 principle-level lessons — patterns and insights that will help future swarm runs be more
-effective. You write ONLY to `hack/LESSONS.md` (creating it if needed).
+effective. You write ONLY to `{memory_dir}/LESSONS.md` (creating it if needed).
 
 You do NOT write code. You do NOT update PROJECT.md, SESSIONS.md, or TODO.md.
 You do NOT record implementation details, file paths, or code snippets.
 
 ## Step 1: Locate Memory Directory
 
-Check in order:
-```
-Glob("hack/LESSONS.md")     → if found, lessons_file = "hack/LESSONS.md"
-Glob(".local/LESSONS.md")   → if found, lessons_file = ".local/LESSONS.md"
-Glob("scratch/LESSONS.md")  → if found, lessons_file = "scratch/LESSONS.md"
-Glob(".dev/LESSONS.md")     → if found, lessons_file = ".dev/LESSONS.md"
-```
-
-If none found, also check if the memory directory itself exists:
-```
-Glob("hack/PROJECT.md")     → memory_dir = "hack/"
-Glob(".local/PROJECT.md")   → memory_dir = ".local/"
-```
-
-Set `lessons_file = {memory_dir}/LESSONS.md`. If no memory directory exists at all, skip
+Detect the project memory directory using the convention in
+`code-quality/references/project-memory-reference.md` (Directory Detection section).
+Set `lessons_file = {memory_dir}/LESSONS.md`. If no memory directory exists, skip
 writing and report that no memory directory was found.
 
 ## Step 2: Read the Audit Trail

--- a/code-quality/skills/swarm/references/communication-schema.md
+++ b/code-quality/skills/swarm/references/communication-schema.md
@@ -18,7 +18,7 @@ the `key_files` list after the Architect completes.
   "project": "string — project name from repo root",
   "task": "string — original user task description, verbatim",
   "branch": "string — current git branch name",
-  "run_dir": "string — absolute or repo-relative path to hack/swarm/YYYY-MM-DD",
+  "run_dir": "string — absolute or repo-relative path to hack/swarm/{run-id}",
   "key_files": [
     "string — file paths identified by architect as central to this task"
   ],
@@ -618,7 +618,7 @@ date append a sequence number.
 
 ```
 hack/swarm/
-└── YYYY-MM-DD/               # or YYYY-MM-DD-2, YYYY-MM-DD-3 for multiple runs
+└── {run-id}/                 # e.g. feat-auth-1711388400
     ├── architect-plan.json         # Architect's component decomposition plan
     ├── security-design-review.json # Security design review (Phase 2.5, if run)
     ├── escalations.json            # Escalation events (Phase 4, always present)

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -122,24 +122,29 @@ If a PR exists, note it — commits to this branch will update the PR automatica
 
 | Current state | Action |
 |---------------|--------|
-| Already on `swarm/YYYY-MM-DD-*` or matching feature branch | Use it |
-| On main/master | Create `swarm/YYYY-MM-DD-<task-slug>` |
+| Already on `swarm/*` or matching feature branch | Use it |
+| On main/master | Create `swarm/{run-id}-<task-slug>` |
 | On unrelated feature branch | Ask user: use current branch or create new one? |
 | `--worktree` flag in task description | Use `EnterWorktree` |
 
-Branch creation:
+Branch creation uses the run-ID convention from `code-quality/references/project-memory-reference.md`
+(Run-ID Naming Convention section). Generate the run-ID first, then create the branch:
 ```bash
+BRANCH_SLUG=$(git branch --show-current | tr '[:upper:]/' '[:lower:]-' | sed 's/[^a-z0-9-]//g' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
+BRANCH_SLUG=${BRANCH_SLUG:-detached}
+TIMESTAMP=$(date +%s)
+RUN_ID="${BRANCH_SLUG}-${TIMESTAMP}"
 git fetch origin main
-git switch -c swarm/$(date +%Y-%m-%d)-<task-slug> origin/main
+git switch -c swarm/${RUN_ID}-<task-slug> origin/main
 ```
 
 The task slug is a 2-4 word kebab-case summary of the task. Example:
-`swarm/2026-02-27-add-oauth-integration`
+`swarm/feat-auth-1711388400-add-oauth-integration`
 
 ### Step 0.4: Plan File Detection
 
 ```
-Glob("hack/plans/*.md")
+Glob("{memory_dir}/plans/*.md")
 ```
 
 Read any plan file whose name or content matches the task description. If found:
@@ -181,12 +186,21 @@ aggressive recycling thresholds in Phase 3 (recycle at 15 turns instead of 25).
 
 ### Step 0.6: Create Audit Trail Directory
 
-```
-{run_dir} = hack/swarm/YYYY-MM-DD
+Generate the run-ID (if not already done in Step 0.3) using the exact commands from
+`code-quality/references/project-memory-reference.md` (Run-ID Naming Convention section):
+```bash
+BRANCH_SLUG=$(git branch --show-current | tr '[:upper:]/' '[:lower:]-' | sed 's/[^a-z0-9-]//g' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
+BRANCH_SLUG=${BRANCH_SLUG:-detached}
+TIMESTAMP=$(date +%s)
+RUN_ID="${BRANCH_SLUG}-${TIMESTAMP}"
 ```
 
-Use today's date. If the directory already exists (re-run), append sequence number:
-`hack/swarm/2026-02-27-2`
+Detect the project memory directory using `code-quality/references/project-memory-reference.md`
+(Directory Detection section). Then:
+
+```
+{run_dir} = {memory_dir}/swarm/{run-id}
+```
 
 Create structure:
 ```
@@ -201,8 +215,9 @@ so the directory is not empty:
 ```json
 {
   "task": "<user task description>",
-  "started": "2026-02-27T10:00:00Z",
-  "branch": "swarm/2026-02-27-<slug>",
+  "started": "<ISO 8601 timestamp>",
+  "run_id": "<run-id>",
+  "branch": "swarm/<run-id>-<slug>",
   "baseline_tests": {"passed": 47, "failed": 0}
 }
 ```
@@ -623,12 +638,18 @@ Weights must sum to 1.0.
 
 ### Step 2.7.3: Create Speculative Run Directory
 
-```
-{speculative_run_dir} = hack/speculative/YYYY-MM-DD
+Generate a new run-ID for the speculative fork (same convention from
+`code-quality/references/project-memory-reference.md`):
+```bash
+BRANCH_SLUG=$(git branch --show-current | tr '[:upper:]/' '[:lower:]-' | sed 's/[^a-z0-9-]//g' | sed 's/-\{2,\}/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
+BRANCH_SLUG=${BRANCH_SLUG:-detached}
+TIMESTAMP=$(date +%s)
+SPEC_RUN_ID="${BRANCH_SLUG}-${TIMESTAMP}"
 ```
 
-If that directory already exists (a separate /speculative run happened today), append a sequence
-number: `hack/speculative/YYYY-MM-DD-2`.
+```
+{speculative_run_dir} = {memory_dir}/speculative/{spec-run-id}
+```
 
 Create the directory structure:
 ```
@@ -1501,13 +1522,8 @@ documentation needs updating (README behavior descriptions, API docs, config doc
 
 ### Step 6.3: Project Memory
 
-The docs agent detects the memory directory by checking in order:
-```
-Glob("hack/PROJECT.md")     → hack/ directory
-Glob(".local/PROJECT.md")   → .local/ directory
-Glob("scratch/PROJECT.md")  → scratch/ directory
-Glob(".dev/PROJECT.md")     → .dev/ directory
-```
+The docs agent detects the memory directory using the convention in
+`code-quality/references/project-memory-reference.md` (Directory Detection section).
 
 If found, update:
 
@@ -1575,7 +1591,7 @@ Agent(name="lessons-extractor", subagent_type="general-purpose", model="sonnet",
 ```
 
 The Lessons Extractor reads the swarm audit trail and writes principle-level lessons to
-`hack/LESSONS.md` (or equivalent memory directory). It does NOT touch PROJECT.md, SESSIONS.md,
+`{memory_dir}/LESSONS.md`. It does NOT touch PROJECT.md, SESSIONS.md,
 or TODO.md — those are the Docs agent's responsibility.
 
 ### Step 6.8: Shutdown Lessons Extractor
@@ -1749,7 +1765,7 @@ Full report: {run_dir}/swarm-report.md
 ```
 
 **Persistence requirement:** The Lead (not the Docs agent) MUST write blocked and deferred
-items to `hack/TODO.md` (or the project's task tracking file) in this step. The Docs agent
+items to `{memory_dir}/TODO.md` (or the project's task tracking file) in this step. The Docs agent
 doesn't know about deferred items — only the Lead has this context from Step 5.2.1 TaskCreate
 entries. Use `- [ ] <item>: <reason> (swarm YYYY-MM-DD)` format. A swarm-report.md in a dated
 directory is not discoverable by future agents — project memory files are.

--- a/code-quality/skills/swarm/references/pipeline-model.md
+++ b/code-quality/skills/swarm/references/pipeline-model.md
@@ -355,7 +355,7 @@ Code-Simplifier after both complete. Shut down all before Phase 6.
 
 ```
 Lead spawns sequentially:
-  docs               (general-purpose, sonnet)  -- updates docs and hack/ memory
+  docs               (general-purpose, sonnet)  -- updates docs and project memory
   docs-reviewer      (general-purpose, sonnet)  -- verifies docs agent's work (read-only)
   lessons-extractor  (general-purpose, sonnet)  -- extracts principle-level lessons from swarm run
 ```
@@ -363,7 +363,7 @@ Lead spawns sequentially:
 Three agents, run sequentially. Docs agent completes first, then Docs Reviewer verifies the
 documentation changes (critical/high findings route back to Docs for fixes, max 1 iteration).
 After Docs Reviewer confirms clean, Lessons Extractor reads the audit trail and writes to
-`hack/LESSONS.md`. Shut down each after it reports completion.
+`{memory_dir}/LESSONS.md`. Shut down each after it reports completion.
 
 ### Phase 7: Verifier
 

--- a/code-quality/skills/unfuck/SKILL.md
+++ b/code-quality/skills/unfuck/SKILL.md
@@ -41,8 +41,9 @@ Phase 4 verifies everything passes and generates a report.
 ### Phase 0: Index & Setup
 1. Create TeamCreate swarm: `cleanup-swarm`
 2. Spawn parallel setup teammates for: repo indexing (`code-quality:index-repo`), language detection, tool detection
-3. Create feature branch: `cleanup/comprehensive-YYYY-MM-DD` (from `origin/main`)
-4. Create `hack/unfuck/YYYY-MM-DD/discovery/` directory for agent output (date-scoped per run)
+3. Generate a run-ID using the convention in `code-quality/references/project-memory-reference.md`
+   (Run-ID Naming Convention section) and create feature branch: `cleanup/comprehensive-{run-id}` (from `origin/main`)
+4. Create `{memory_dir}/unfuck/{run-id}/discovery/` directory for agent output
 5. Collect setup results and build context bundle for discovery agents
 
 ### Phase 1: Discovery (7 parallel agents)
@@ -53,7 +54,7 @@ retry-on-failure for individual discovery agents, and structured ReductionResult
 If /map-reduce skill is unavailable, fall back to direct parallel agents as described below.
 
 All agents run simultaneously in background. Each writes structured JSON findings to
-`hack/unfuck/YYYY-MM-DD/discovery/`. Full prompts in `references/discovery-agents.md`.
+`{run_dir}/discovery/`. Full prompts in `references/discovery-agents.md`.
 
 | Agent | Role | Paired Skills | External Tools | Output |
 |-------|------|---------------|----------------|--------|
@@ -83,7 +84,7 @@ When falling back to direct approach, it reads the raw discovery JSON files dire
    if available, or manual dedup otherwise)
 3. Cross-references compound patterns (dead + divergent = safe to remove)
 4. Prioritizes: security → dead code → duplicates → AI slop → complexity → architecture → docs
-5. Writes `hack/unfuck/YYYY-MM-DD/cleanup-plan.md` with per-finding detail
+5. Writes `{run_dir}/cleanup-plan.md` with per-finding detail
 6. Creates TaskList with one task per category
 7. Sends summary to orchestrator; orchestrator **AskUserQuestion** if: public API deletions,
    5+ file architectural changes, ambiguous findings, security policy decisions, or >100 total findings
@@ -108,7 +109,7 @@ The orchestrator assigns categories in priority order (security → dead code �
 2. Run code quality checks on all modified files
 3. Apply `code-quality:quality-gate` verification patterns
 4. Invoke `code-quality:reflect` to verify completeness against the original cleanup plan
-5. Generate `hack/unfuck/YYYY-MM-DD/cleanup-report.md` with:
+5. Generate `{run_dir}/cleanup-report.md` with:
    - Summary stats (files modified, lines added/removed, net delta, issues fixed by category)
    - Per-category breakdown with specific changes and commit SHAs
    - Blocked items (test failures, needs-review) with stash names and manual fix guidance
@@ -119,7 +120,7 @@ The orchestrator assigns categories in priority order (security → dead code �
 
 ## Git Workflow
 
-- Creates feature branch: `cleanup/comprehensive-YYYY-MM-DD` (from `origin/main`)
+- Creates feature branch: `cleanup/comprehensive-{run-id}` (from `origin/main`)
 - One commit per cleanup category (security, dead-code, duplicates, ai-slop, complexity, architecture, docs)
 - Conventional commit messages
 - Blocked categories are stashed with descriptive names for manual recovery
@@ -137,10 +138,10 @@ The orchestrator assigns categories in priority order (security → dead code �
 
 | File | Purpose | Persistent |
 |------|---------|------------|
-| `hack/unfuck/YYYY-MM-DD/cleanup-plan.md` | Prioritized findings with fix strategies | Yes |
-| `hack/unfuck/YYYY-MM-DD/cleanup-report.md` | Final report with stats and blocked items | Yes |
-| `hack/unfuck/YYYY-MM-DD/discovery/*.json` | Raw agent findings (7 files) | Cleaned up |
-| `hack/unfuck/YYYY-MM-DD/available-tools.json` | Detected external tools | Cleaned up |
+| `{run_dir}/cleanup-plan.md` | Prioritized findings with fix strategies | Yes |
+| `{run_dir}/cleanup-report.md` | Final report with stats and blocked items | Yes |
+| `{run_dir}/discovery/*.json` | Raw agent findings (7 files) | Cleaned up |
+| `{run_dir}/available-tools.json` | Detected external tools | Cleaned up |
 
 ## References
 

--- a/code-quality/skills/unfuck/references/discovery-agents.md
+++ b/code-quality/skills/unfuck/references/discovery-agents.md
@@ -1228,7 +1228,7 @@ You have access to: Read, Write, Edit, Glob, Grep, Bash, LSP, Agent, AskUserQues
    - `CHANGELOG.md` (or `HISTORY.md`, `CHANGES.md`)
    - `docs/` directory
    - `API.md` or `api/` docs
-   - Project memory files: `hack/PROJECT.md`, `hack/TODO.md`
+   - Project memory files: `{memory_dir}/PROJECT.md`, `{memory_dir}/TODO.md`
 
 3. **Find inline documentation:**
    - Docstrings in Python files

--- a/code-quality/skills/unfuck/references/orchestration-playbook.md
+++ b/code-quality/skills/unfuck/references/orchestration-playbook.md
@@ -20,13 +20,22 @@ This is the complete coordination reference for the `/unfuck` cleanup skill. The
 
 ### Run directory
 
-All artifacts for a single `/unfuck` run go under a date-scoped directory so multiple runs don't clash:
+All artifacts for a single `/unfuck` run go under a run-ID-scoped directory for uniqueness:
+
+Generate the run-ID using the exact commands from `code-quality/references/project-memory-reference.md`
+(Run-ID Naming Convention section):
+```bash
+BRANCH_SLUG=$(git branch --show-current | tr '[:upper:]/' '[:lower:]-' | sed 's/[^a-z0-9-]//g' | cut -c1-40)
+TIMESTAMP=$(date +%s)
+RUN_ID="${BRANCH_SLUG}-${TIMESTAMP}"
+```
+
+Detect the project memory directory using `code-quality/references/project-memory-reference.md`
+(Directory Detection section). Then:
 
 ```
-{run_dir} = hack/unfuck/YYYY-MM-DD
+{run_dir} = {memory_dir}/unfuck/{run-id}
 ```
-
-Use today's actual date (e.g., `hack/unfuck/2026-02-18`). If the directory already exists (re-run scenario), append a sequence number: `hack/unfuck/2026-02-18-2`.
 
 All paths in this playbook use `{run_dir}` to refer to this directory. The orchestrator resolves it once and passes the resolved path to all agents via the context bundle.
 
@@ -48,7 +57,7 @@ This parallelism saves time since `code-quality:index-repo` and tool detection a
 
 ### Step 0.1: Generate repo index
 
-Spawn a `setup-indexer` teammate to invoke the `code-quality:index-repo` skill. This creates `PROJECT_INDEX.md` in the project memory directory (`hack/`, `.local/`, `scratch/`, `.dev/`, or project root as fallback), giving every agent a ~3K-token project reference instead of reading the full codebase.
+Spawn a `setup-indexer` teammate to invoke the `code-quality:index-repo` skill. This creates `PROJECT_INDEX.md` in the project memory directory (per `code-quality/references/project-memory-reference.md`, Directory Detection section, or project root as fallback), giving every agent a ~3K-token project reference instead of reading the full codebase.
 
 ### Step 0.2: Detect project languages
 
@@ -100,12 +109,12 @@ If a tool is unavailable, record its fallback from `references/external-tools.md
 ### Step 0.4: Create feature branch
 
 ```bash
-git switch -c cleanup/comprehensive-YYYY-MM-DD origin/main
+git switch -c cleanup/comprehensive-${RUN_ID} origin/main
 ```
 
-Use today's actual date. Always branch from `origin/main` (fetch first if needed). If the branch already exists (re-run scenario), append a sequence number: `cleanup/comprehensive-YYYY-MM-DD-2`.
+Always branch from `origin/main` (fetch first if needed). The run-ID ensures uniqueness across runs.
 
-**IMPORTANT:** Do NOT use "unfuck" in the branch name — use professional naming like `cleanup/comprehensive-YYYY-MM-DD`.
+**IMPORTANT:** Do NOT use "unfuck" in the branch name — use professional naming like `cleanup/comprehensive-{run-id}`.
 
 ### Step 0.5: Create output directories
 
@@ -553,7 +562,7 @@ Or via Bash using the auto-detected test command from Phase 3.
 
 If final tests fail, identify which commit introduced the regression:
 ```bash
-git log --oneline cleanup/comprehensive-YYYY-MM-DD~N..HEAD
+git log --oneline cleanup/comprehensive-${RUN_ID}~N..HEAD
 ```
 Then bisect or check each commit's changes against the failing tests.
 
@@ -577,7 +586,7 @@ Agent(name="quality-review", subagent_type="general-purpose",
 Apply `code-quality:quality-gate` verification patterns:
 - Every commit compiles/parses cleanly
 - Test suite passes on HEAD
-- No uncommitted changes remain (except `hack/` artifacts)
+- No uncommitted changes remain (except `{memory_dir}/` artifacts)
 - No untracked source files created accidentally
 - Linter passes (if available)
 
@@ -590,7 +599,7 @@ Write `{run_dir}/cleanup-report.md`:
 
 Generated: YYYY-MM-DD HH:MM
 Project: <project name>
-Branch: cleanup/comprehensive-YYYY-MM-DD
+Branch: cleanup/comprehensive-{run-id}
 
 ## Summary
 - **Files modified:** N
@@ -705,7 +714,7 @@ If reflection identifies gaps, address them before announcing completion.
 Report to the user:
 
 ```
-Cleanup complete. Branch: cleanup/comprehensive-YYYY-MM-DD
+Cleanup complete. Branch: cleanup/comprehensive-{run-id}
 
 Summary: N files modified, -N lines net, N issues fixed across M categories.
 N items blocked (need manual review).
@@ -714,7 +723,7 @@ Full report: {run_dir}/cleanup-report.md
 Cleanup plan: {run_dir}/cleanup-plan.md
 
 Next steps:
-- Review the branch diff: git diff main..cleanup/comprehensive-YYYY-MM-DD
+- Review the branch diff: git diff main..cleanup/comprehensive-{run-id}
 - Check blocked items in the report (if any)
 - Create a PR when satisfied: `gh pr create`
 ```


### PR DESCRIPTION
## Summary
- Creates `project-memory-reference.md` as single source of truth for directory detection, content placement, run-ID naming (`<branch-slug>-<unix-timestamp>`), and worktree resolution
- Replaces all `YYYY-MM-DD` audit trail paths across 15 skills and 9 reference files with run-ID convention, eliminating parallel worktree contention
- Bumps code-quality version 3.5.0 to 3.6.0