### PR TITLE
fix(dev-guard): reduces stop hook aggression on legitimate questions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.45.1",
+      "version": "1.46.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.45.1",
+  "version": "1.46.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -162,13 +162,25 @@ def _build_prompt(ctx: dict) -> str:
         "not deferred without explicit user agreement."
     )
     criteria.append(
-        "DEFERRED WORK: Does the final message punt work to the user that Claude should "
-        "have done itself? Phrases like 'should be verified', 'needs to be confirmed', "
-        "'you should check', 'verify against your', 'please verify', "
+        "LEGITIMATE PAUSE: Is the assistant asking a genuine clarifying question that "
+        "requires user input before proceeding? Questions about user preferences "
+        "('Should I use approach A or B?'), scope ('Which files should this apply to?'), "
+        "or missing context ('What is the expected behavior?') are GOOD — they prevent "
+        "wasted work on wrong assumptions. If the assistant needs information it cannot "
+        "determine from the codebase alone, PASS. Only flag as incomplete if the assistant "
+        "could answer its own question using available tools (Read, Grep, WebSearch, etc.)."
+    )
+    criteria.append(
+        "DEFERRED WORK: Does the final message punt ACTIONABLE work to the user that "
+        "Claude should have done itself? Phrases like 'should be verified', 'needs to be "
+        "confirmed', 'you should check', 'verify against your', 'please verify', "
         "'you may want to update' — when the assistant has tools (Read, Grep, "
         "WebSearch, LSP, MCP servers) to do that verification — mean the assistant "
         "identified work that needs doing and punted it. That is incomplete work. "
-        "If it should be verified, verify it. If it needs checking, check it."
+        "If it should be verified, verify it. If it needs checking, check it. "
+        "NOTE: Asking a clarifying question before acting is NOT deferred work — "
+        "it is prudent information gathering. Only flag as deferred when the assistant "
+        "has both the tools AND the context to complete the work independently."
     )
 
     if work_type in ("code_config", "mixed"):
@@ -240,6 +252,9 @@ def _build_prompt(ctx: dict) -> str:
         "- findings must be null when decision=pass.",
         "- Be precise. Do not fail for cosmetic issues or minor style choices.",
         "- When in doubt, pass. The goal is catching genuinely incomplete or incorrect work.",
+        "- If the assistant needs user input but stopped with a text question instead of "
+        "using AskUserQuestion, include in findings: 'Use AskUserQuestion tool to ask "
+        "the user — it raises a notification so they know you need input.'",
     ]
 
     return "\n".join(lines)

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -27,9 +27,9 @@ Stdout schema:
     "findings": list[str] | null   -- null on pass, specific issues on fail
   }
 
-Exit codes:
+Exit codes (internal to subprocess, consumed by stop-hook.py):
   0 -- pass (allow stop)
-  2 -- fail (block stop, Claude should continue)
+  2 -- fail (stop-hook.py translates to JSON block on its stdout)
 
 Fails open (exits 0) on any infrastructure error (import, auth, timeout, parse).
 

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -166,9 +166,13 @@ def _build_prompt(ctx: dict) -> str:
         "requires user input before proceeding? Questions about user preferences "
         "('Should I use approach A or B?'), scope ('Which files should this apply to?'), "
         "or missing context ('What is the expected behavior?') are GOOD — they prevent "
-        "wasted work on wrong assumptions. If the assistant needs information it cannot "
-        "determine from the codebase alone, PASS. Only flag as incomplete if the assistant "
-        "could answer its own question using available tools (Read, Grep, WebSearch, etc.)."
+        "wasted work on wrong assumptions. This criterion applies when the question is "
+        "asked BEFORE work is attempted, not as a trailing qualifier after claiming "
+        "completion. If the final message both claims work is done AND asks a question, "
+        "evaluate the completion claim under CLAIM ACCURACY first. If the assistant needs "
+        "information it cannot determine from the codebase alone and has NOT yet acted, "
+        "PASS. Only flag as incomplete if the assistant could answer its own question "
+        "using available tools (Read, Grep, WebSearch, etc.)."
     )
     criteria.append(
         "DEFERRED WORK: Does the final message punt ACTIONABLE work to the user that "

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -61,6 +61,9 @@ _WRITE_TOOLS = frozenset({"Edit", "Write", "NotebookEdit"})
 # Agent/task tool names
 _AGENT_TOOLS = frozenset({"Agent", "Task", "TeamCreate"})
 
+# Interactive question tool — agent is legitimately asking the user
+_QUESTION_TOOL = "AskUserQuestion"
+
 # Factual question patterns (no ML)
 _FACTUAL_PATTERNS = re.compile(
     r"\b(version|api|schema|support|require|format|compatible|"
@@ -727,14 +730,16 @@ def _exit_pass(message: str | None = None) -> NoReturn:
 
 
 def _exit_block(findings: list[str] | None) -> NoReturn:
-    """Exit 2 with findings printed to stderr."""
-    if findings:
-        print("Stop hook findings:", file=sys.stderr)
-        for finding in findings:
-            print(f"  - {finding}", file=sys.stderr)
-    else:
-        print("Stop hook: quality check failed. Please review your work.", file=sys.stderr)
-    sys.exit(2)
+    """Exit 0 with decision=block JSON on stdout.
+
+    Uses structured JSON output instead of exit 2 + stderr. This avoids the
+    misleading 'Stop hook error' UI label (anthropics/claude-code#34600) and
+    gives the agent a clean ``reason`` string as its next instruction.
+    """
+    reason = " ".join(findings) if findings else "Quality check failed. Please review your work."
+    output = {"decision": "block", "reason": reason}
+    print(json.dumps(output))
+    sys.exit(0)
 
 
 # ── Main ─────────────────────────────────────────────────────────────────────
@@ -809,6 +814,16 @@ def main() -> None:
     # ── Git diff check ───────────────────────────────────────────────────────
     current_diff_hash = _git_diff_hash(cwd)
     diff_changed = bool(current_diff_hash and current_diff_hash != last_diff_hash)
+
+    # ── Fast-exit: AskUserQuestion is last tool call ─────────────────────
+    # Agent's final action was asking the user — legitimate pause for context.
+    if new_tool_calls and new_tool_calls[-1] == _QUESTION_TOOL:
+        _log_stop_event(session_id, "ask_user_question")
+        state = _update_session_state(
+            state, session_id, current_diff_hash, len(all_tool_calls), file_size
+        )
+        _save_state(state)
+        _exit_pass()
 
     # ── Detect signals ───────────────────────────────────────────────────────
     write_signals = _detect_write_signals(new_tool_calls)

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -10,8 +10,7 @@ question classification, work-type determination), and either exits 0 (allow
 stop) or delegates to stop-hook-llm.py for LLM evaluation.
 
 Exit codes:
-  0 -- allow stop (fast-exit or LLM pass)
-  2 -- block stop, Claude should continue (LLM fail)
+  0 -- always. Allow stop (plain exit) or block via JSON {"decision":"block","reason":"..."}
 
 State file: ~/.claude/stop-hook-state.json (overridable via STOP_HOOK_STATE_PATH)
 """

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -873,15 +873,15 @@ def main() -> None:
         _save_state(state)
         _exit_pass()
 
-    # ── Exit-with-guidance: Research + short response ────────────────────────
+    # ── Fast-exit: Research + short response ────────────────────────────────
     if research_used and response_is_short and not write_signals and not diff_changed:
         state = _update_session_state(
             state, session_id, current_diff_hash, len(all_tool_calls), file_size
         )
         _save_state(state)
-        _exit_pass("Research done, verify external claims if any.")
+        _exit_pass()
 
-    # ── Exit-with-guidance: Read-only + question ─────────────────────────────
+    # ── Fast-exit: Read-only + factual question ──────────────────────────────
     if (
         not write_signals
         and not diff_changed
@@ -894,7 +894,7 @@ def main() -> None:
             state, session_id, current_diff_hash, len(all_tool_calls), file_size
         )
         _save_state(state)
-        _exit_pass("Answer based on code exploration.")
+        _exit_pass()
 
     # ── Build trigger reasons ────────────────────────────────────────────────
     trigger_reasons: list[str] = []

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -735,7 +735,9 @@ def _exit_block(findings: list[str] | None) -> NoReturn:
     misleading 'Stop hook error' UI label (anthropics/claude-code#34600) and
     gives the agent a clean ``reason`` string as its next instruction.
     """
-    reason = " ".join(findings) if findings else "Quality check failed. Please review your work."
+    reason = "\n- ".join(findings) if findings else "Quality check failed. Please review your work."
+    if findings and len(findings) > 1:
+        reason = "- " + reason  # prefix first item with bullet too
     output = {"decision": "block", "reason": reason}
     print(json.dumps(output))
     sys.exit(0)

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -816,13 +816,17 @@ def main() -> None:
 
     # ── Fast-exit: AskUserQuestion is last tool call ─────────────────────
     # Agent's final action was asking the user — legitimate pause for context.
+    # Only fast-exit when no write activity occurred this turn. If the agent
+    # made changes AND asked a question, still route through the LLM evaluator.
     if new_tool_calls and new_tool_calls[-1] == _QUESTION_TOOL:
-        _log_stop_event(session_id, "ask_user_question")
-        state = _update_session_state(
-            state, session_id, current_diff_hash, len(all_tool_calls), file_size
-        )
-        _save_state(state)
-        _exit_pass()
+        _pre_write = _detect_write_signals(new_tool_calls)
+        if not _pre_write and not diff_changed:
+            _log_stop_event(session_id, "ask_user_question")
+            state = _update_session_state(
+                state, session_id, current_diff_hash, len(all_tool_calls), file_size
+            )
+            _save_state(state)
+            _exit_pass()
 
     # ── Detect signals ───────────────────────────────────────────────────────
     write_signals = _detect_write_signals(new_tool_calls)

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -278,22 +278,22 @@ class TestQuestionClassification:
         assert result.returncode == 0
 
     def test_factual_question_does_not_exit_via_meta_opinion(self, tmp_path):
-        """Factual question with no tools → exit-with-guidance path, still exits 0."""
+        """Factual question with no tools → fast-exit path, exits 0."""
         result = self._run_with_user_message(
             tmp_path,
             "What is the Python version requirement?",
             "Python 3.10+.",
         )
-        # Read-only + factual question → exit-with-guidance (exit 0)
+        # Read-only + factual question → fast-exit (exit 0)
         assert result.returncode == 0
 
 
-# ── Exit-with-guidance ────────────────────────────────────────────────────────
+# ── Fast-exit: research and read-only paths ──────────────────────────────────
 
 
-class TestExitWithGuidance:
-    def test_research_short_response_guidance_message(self, tmp_path):
-        """WebSearch used + short response → prints guidance to stdout."""
+class TestResearchAndReadOnlyFastExit:
+    def test_research_short_response_exits_0(self, tmp_path):
+        """WebSearch used + short response → fast-exit 0."""
         transcript = tmp_path / "transcript.jsonl"
         session_id = str(uuid.uuid4())
         entries = [
@@ -314,13 +314,9 @@ class TestExitWithGuidance:
         )
         result = run_hook(payload, state_path=tmp_path / "state.json")
         assert result.returncode == 0
-        assert (
-            "verify external claims" in result.stdout.lower()
-            or "research done" in result.stdout.lower()
-        )
 
     def test_context7_mcp_counts_as_research(self, tmp_path):
-        """Context7 MCP tool (prefix match) triggers research guidance."""
+        """Context7 MCP tool (prefix match) triggers research fast-exit."""
         transcript = tmp_path / "transcript.jsonl"
         session_id = str(uuid.uuid4())
         entries = [
@@ -339,13 +335,9 @@ class TestExitWithGuidance:
         )
         result = run_hook(payload, state_path=tmp_path / "state.json")
         assert result.returncode == 0
-        assert (
-            "verify external claims" in result.stdout.lower()
-            or "research done" in result.stdout.lower()
-        )
 
     def test_github_mcp_search_code_counts_as_research(self, tmp_path):
-        """Selective GitHub MCP tool triggers research guidance."""
+        """Selective GitHub MCP tool triggers research fast-exit."""
         transcript = tmp_path / "transcript.jsonl"
         session_id = str(uuid.uuid4())
         entries = [
@@ -364,13 +356,9 @@ class TestExitWithGuidance:
         )
         result = run_hook(payload, state_path=tmp_path / "state.json")
         assert result.returncode == 0
-        assert (
-            "verify external claims" in result.stdout.lower()
-            or "research done" in result.stdout.lower()
-        )
 
     def test_github_mcp_list_issues_not_research(self, tmp_path):
-        """Non-research GitHub MCP tool (list_issues) does NOT trigger research guidance."""
+        """Non-research GitHub MCP tool (list_issues) does NOT trigger research fast-exit."""
         transcript = tmp_path / "transcript.jsonl"
         session_id = str(uuid.uuid4())
         entries = [
@@ -389,12 +377,9 @@ class TestExitWithGuidance:
         )
         result = run_hook(payload, state_path=tmp_path / "state.json")
         assert result.returncode == 0
-        # Should NOT get research guidance — this is project management, not research
-        assert "verify external claims" not in result.stdout.lower()
-        assert "research done" not in result.stdout.lower()
 
-    def test_read_only_factual_question_guidance_message(self, tmp_path):
-        """Read tool + factual question → prints guidance to stdout."""
+    def test_read_only_factual_question_exits_0(self, tmp_path):
+        """Factual question with no tools → fast-exit 0."""
         transcript = tmp_path / "transcript.jsonl"
         session_id = str(uuid.uuid4())
         entries = [
@@ -410,8 +395,6 @@ class TestExitWithGuidance:
             last_assistant_message="It reads files.",
         )
         result = run_hook(payload, state_path=tmp_path / "state.json")
-        assert result.returncode == 0
-        # Either guidance message or plain exit 0 — both acceptable for factual + no tools
         assert result.returncode == 0
 
 

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -447,8 +447,9 @@ class TestAskUserQuestionFastExit:
             assert "block" not in result.stdout
 
     def test_ask_user_question_not_last_tool_does_not_fast_exit(self, tmp_path):
-        """AskUserQuestion followed by Edit → no fast-exit (agent kept working)."""
-        write_mock_llm(tmp_path / "plugin", decision="pass")
+        """AskUserQuestion followed by Edit → no fast-exit, LLM invoked."""
+        # Use fail-returning mock to prove LLM was actually invoked (not fast-exited)
+        write_mock_llm(tmp_path / "plugin", decision="fail", findings=["Tests not run."])
         transcript = tmp_path / "transcript.jsonl"
         session_id = str(uuid.uuid4())
         entries = [
@@ -473,8 +474,11 @@ class TestAskUserQuestionFastExit:
             state_path=tmp_path / "state.json",
             plugin_root=str(tmp_path / "plugin"),
         )
-        # Should NOT fast-exit — AskUserQuestion was not the last tool call
-        assert result.returncode == 0  # LLM mock returns pass
+        # LLM was invoked (not fast-exited) and returned block
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "Tests not run" in output["reason"]
 
 
 # ── Signal detection: write tools ─────────────────────────────────────────────

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -480,6 +480,41 @@ class TestAskUserQuestionFastExit:
         assert output["decision"] == "block"
         assert "Tests not run" in output["reason"]
 
+    def test_ask_user_question_last_but_edit_also_used_invokes_llm(self, tmp_path):
+        """Edit + AskUserQuestion (last) → no fast-exit because write signals present."""
+        write_mock_llm(tmp_path / "plugin", decision="fail", findings=["Tests not run."])
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Implement the auth module."},
+            {"type": "tool_use", "name": "Edit", "id": "t1"},
+            {"type": "tool_use", "name": "AskUserQuestion", "id": "t2"},
+            {
+                "role": "assistant",
+                "content": "I've started the implementation. Should I add OAuth2 as well?",
+            },
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message=(
+                "I've started the implementation. Should I add OAuth2 as well?"
+            ),
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        # Write signals present → LLM invoked despite AskUserQuestion being last
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "Tests not run" in output["reason"]
+
 
 # ── Signal detection: write tools ─────────────────────────────────────────────
 

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -415,6 +415,68 @@ class TestExitWithGuidance:
         assert result.returncode == 0
 
 
+# ── Fast-exit: AskUserQuestion ────────────────────────────────────────────────
+
+
+class TestAskUserQuestionFastExit:
+    def test_ask_user_question_last_tool_exits_0(self, tmp_path):
+        """AskUserQuestion as last tool call → fast-exit 0 (agent asked user)."""
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix the authentication bug."},
+            {"type": "tool_use", "name": "Read", "id": "t1"},
+            {"type": "tool_use", "name": "AskUserQuestion", "id": "t2"},
+            {
+                "role": "assistant",
+                "content": "Should I use OAuth2 or session-based auth for this fix?",
+            },
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="Should I use OAuth2 or session-based auth for this fix?",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0
+        # Should NOT contain decision=block JSON
+        if result.stdout.strip():
+            assert "block" not in result.stdout
+
+    def test_ask_user_question_not_last_tool_does_not_fast_exit(self, tmp_path):
+        """AskUserQuestion followed by Edit → no fast-exit (agent kept working)."""
+        write_mock_llm(tmp_path / "plugin", decision="pass")
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix the bug."},
+            {"type": "tool_use", "name": "AskUserQuestion", "id": "t1"},
+            {"type": "tool_use", "name": "Edit", "id": "t2"},
+            {
+                "role": "assistant",
+                "content": "I've completed the fix. The changes are ready.",
+            },
+        ]
+        write_transcript(transcript, entries)
+        seed_state(tmp_path / "state.json", session_id)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            last_assistant_message="I've completed the fix. The changes are ready.",
+        )
+        result = run_hook(
+            payload,
+            state_path=tmp_path / "state.json",
+            plugin_root=str(tmp_path / "plugin"),
+        )
+        # Should NOT fast-exit — AskUserQuestion was not the last tool call
+        assert result.returncode == 0  # LLM mock returns pass
+
+
 # ── Signal detection: write tools ─────────────────────────────────────────────
 
 
@@ -447,8 +509,8 @@ class TestWriteToolSignals:
         )
         assert result.returncode == 0
 
-    def test_edit_tool_llm_fail_exits_2(self, tmp_path):
-        """Edit tool + completion claim + mock LLM fail → exit 2."""
+    def test_edit_tool_llm_fail_blocks_via_json(self, tmp_path):
+        """Edit tool + completion claim + mock LLM fail → exit 0 with decision=block JSON."""
         write_mock_llm(tmp_path / "plugin", decision="fail", findings=["Tests were not run."])
         session_id, transcript, msg = self._make_transcript_with_tool(tmp_path, "Edit")
         payload = make_payload(
@@ -461,8 +523,10 @@ class TestWriteToolSignals:
             state_path=tmp_path / "state.json",
             plugin_root=str(tmp_path / "plugin"),
         )
-        assert result.returncode == 2
-        assert "Tests were not run" in result.stderr
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "Tests were not run" in output["reason"]
 
     def test_write_tool_triggers_llm_path(self, tmp_path):
         write_mock_llm(tmp_path / "plugin", decision="pass")
@@ -650,7 +714,7 @@ class TestLLMSubprocess:
         result = run_hook(payload, state_path=state_path, plugin_root=str(tmp_path / "plugin"))
         assert result.returncode == 0
 
-    def test_llm_fail_exits_2_with_findings(self, tmp_path):
+    def test_llm_fail_blocks_with_findings_in_reason(self, tmp_path):
         write_mock_llm(
             tmp_path / "plugin",
             decision="fail",
@@ -658,16 +722,20 @@ class TestLLMSubprocess:
         )
         payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
         result = run_hook(payload, state_path=state_path, plugin_root=str(tmp_path / "plugin"))
-        assert result.returncode == 2
-        assert "No tests run" in result.stderr
-        assert "TODOs remain" in result.stderr
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "No tests run" in output["reason"]
+        assert "TODOs remain" in output["reason"]
 
-    def test_llm_fail_exits_2_no_findings_still_has_message(self, tmp_path):
+    def test_llm_fail_no_findings_still_has_reason(self, tmp_path):
         write_mock_llm(tmp_path / "plugin", decision="fail", findings=None)
         payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
         result = run_hook(payload, state_path=state_path, plugin_root=str(tmp_path / "plugin"))
-        assert result.returncode == 2
-        assert result.stderr.strip()  # something printed
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert output["reason"]  # non-empty reason
 
     def test_missing_llm_script_fails_open(self, tmp_path):
         """No stop-hook-llm.py → subprocess fails → fail-open → exit 0."""
@@ -909,8 +977,10 @@ class TestHackDirModified:
             plugin_root=str(tmp_path / "plugin"),
         )
         # LLM was invoked (not fast-exited) and returned fail
-        assert result.returncode == 2
-        assert "Planning incomplete" in result.stderr
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "Planning incomplete" in output["reason"]
 
     def test_hack_research_with_websearch_triggers_llm(self, tmp_path):
         """WebSearch + hack/research/ modified → research trigger → LLM invoked."""
@@ -950,8 +1020,10 @@ class TestHackDirModified:
             state_path=tmp_path / "state.json",
             plugin_root=str(tmp_path / "plugin"),
         )
-        assert result.returncode == 2
-        assert "Research incomplete" in result.stderr
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "Research incomplete" in output["reason"]
 
     def test_hack_dir_old_file_does_not_trigger(self, tmp_path):
         """File in hack/plans/ older than 5 minutes → no planning trigger."""


### PR DESCRIPTION
## Summary
- Adds AskUserQuestion fast-exit (last tool call only), LEGITIMATE PAUSE LLM criterion, and AskUserQuestion guidance in block reasons to prevent the stop hook from pushing the main agent into aggressive file edits when it legitimately needs user context
- Switches `_exit_block` from exit 2 + stderr to exit 0 + JSON (`decision:block` + `reason`), fixing the misleading "Stop hook error" UI label (anthropics/claude-code#34600)
- Audit data showed 67% fail rate on question-type work (8/12); these changes target that specific false-positive pattern