### PR TITLE
feat(dev-guard): adds worktree-namespaced stash enforcement

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.46.0",
+      "version": "1.47.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -1495,6 +1495,112 @@ def _check_git_trusted_dirs(cmd: str) -> None:
     )
 
 
+def _get_worktree_name() -> str | None:
+    """Return the worktree directory name if CWD is inside a git worktree, else None.
+
+    A git worktree has --git-dir pointing to .git/worktrees/<name> while
+    --git-common-dir points to the main repo's .git.  When they differ,
+    we're in a worktree and the name is the last path component of --git-dir.
+
+    During tests, honours _GUARD_TEST_WORKTREE env var.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        wt = os.environ.get("_GUARD_TEST_WORKTREE")
+        if wt is not None:
+            return wt or None  # empty string → None
+    try:
+        git_dir = subprocess.run(
+            ["git", "rev-parse", "--git-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        git_common = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        git_dir_abs = str(Path(git_dir).resolve())
+        git_common_abs = str(Path(git_common).resolve())
+        if git_dir_abs != git_common_abs:
+            return Path(git_dir_abs).name
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        pass
+    return None
+
+
+_STASH_OP_RE = re.compile(r"git\s+stash(?:\s+(\w+))?")
+_STASH_READ_SUBCMDS = {"list", "show", "branch"}
+
+
+def _check_worktree_stash(cmd: str) -> None:
+    """Block bare git stash operations in worktrees; require worktree-namespaced stashes.
+
+    In a worktree, stash is repo-wide and shared across all worktrees.
+    Concurrent agents can pop each other's work.  This enforces:
+      - push: must use ``-m 'wt/<worktree>: ...'``
+      - pop/apply/drop: must specify ``stash@{N}`` (after finding it via
+        ``git stash list --grep='wt/<worktree>'``)
+      - bare ``git stash`` (implicit push): blocked
+      - list/show: always allowed
+    """
+    m = _STASH_OP_RE.search(cmd)
+    if not m:
+        return
+
+    subcmd = m.group(1)  # None for bare "git stash"
+
+    # Read-only stash operations are always fine
+    if subcmd in _STASH_READ_SUBCMDS:
+        return
+
+    wt_name = _get_worktree_name()
+    if wt_name is None:
+        return  # Not in a worktree — regular stash rules apply
+
+    prefix = f"wt/{wt_name}"
+
+    # Bare "git stash" or "git stash push" without -m wt/<name>
+    if subcmd is None or subcmd == "push":
+        # Check for -m with worktree prefix
+        if not re.search(r"""-m\s+['"]?wt/""" + re.escape(wt_name), cmd):
+            _exit_with_decision(
+                f"In a worktree, stashes must be namespaced to prevent cross-worktree collisions.\n"
+                f"Use: git stash push -m '{prefix}: <description>'\n"
+                f"Then retrieve with: git stash list --grep='{prefix}'",
+                "block",
+                rule_name="worktree-stash-unnamed",
+                matched_segment=cmd,
+            )
+        return
+
+    # pop/apply/drop without a specific stash ref
+    if subcmd in ("pop", "apply", "drop"):
+        if not re.search(r"stash@\{", cmd):
+            _exit_with_decision(
+                f"In a worktree, bare 'git stash {subcmd}' risks targeting "
+                f"another worktree's stash.\n"
+                f"First find your stash: git stash list --grep='{prefix}'\n"
+                f"Then: git stash {subcmd} stash@{{N}}",
+                "block",
+                rule_name=f"worktree-stash-bare-{subcmd}",
+                matched_segment=cmd,
+            )
+        return
+
+    # clear is always dangerous in worktrees
+    if subcmd == "clear":
+        _exit_with_decision(
+            "git stash clear in a worktree would destroy ALL stashes across ALL worktrees.\n"
+            f"Drop individual stashes instead: git stash list "
+            f"--grep='{prefix}' then git stash drop stash@{{N}}",
+            "block",
+            rule_name="worktree-stash-clear",
+            matched_segment=cmd,
+        )
+
+
 def check_git_safety(cmd: str, fetch_seen: bool = False) -> None:
     """Check a command against git safety rules. Exits on block or ask match."""
     # Early exit: not a git command
@@ -1550,6 +1656,9 @@ def check_git_safety(cmd: str, fetch_seen: bool = False) -> None:
             rule_name="branch-needs-fetch",
             matched_segment=cmd,
         )
+
+    # Worktree stash safety — must come before generic stash-drop ASK rule
+    _check_worktree_stash(cmd)
 
     # ASK rules — prompt user for confirmation
     for name, check_fn, message in GIT_ASK_RULES:

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -891,6 +891,7 @@ class TestTerminalPipeNoop:
             "printf-midpipe-3stage-allow",
             "echo-middle-segment-allow",
             "printf-middle-segment-allow",
+            # ANSI-C quoting in terminal position → blocked
             "echo-ansi-c-terminal-block",
             "printf-ansi-c-terminal-block",
         ],
@@ -1448,12 +1449,176 @@ class TestGitBranchEnforcement:
             "chain-fetch-and-upstream",
         ],
     )
-    def test_branch_enforcement(self, command, expected_exit, expected_msg):
-        result = run_bash(command)
+    def test_branch_enforcement(self, command, expected_exit, expected_msg, tmp_path):
+        env = {**os.environ, "GUARD_DB_PATH": str(tmp_path / "test.db")}
+        result = run_guard("Bash", {"command": command}, env=env)
         if expected_exit == "ask":
             assert_ask_decision(result, expected_msg)
         else:
             assert_guard(result, expected_exit, expected_msg)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Worktree stash safety
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestWorktreeStash:
+    """Worktree-namespaced stash enforcement: blocks bare stash ops in worktrees."""
+
+    @staticmethod
+    def _env(tmp_path, worktree_name="my-feature"):
+        return {
+            **os.environ,
+            "GUARD_DB_PATH": str(tmp_path / "test.db"),
+            "PYTEST_CURRENT_TEST": "yes",
+            "_GUARD_TEST_WORKTREE": worktree_name,
+        }
+
+    @staticmethod
+    def _env_no_worktree(tmp_path):
+        return {
+            **os.environ,
+            "GUARD_DB_PATH": str(tmp_path / "test.db"),
+            "PYTEST_CURRENT_TEST": "yes",
+            "_GUARD_TEST_WORKTREE": "",  # empty → not in worktree
+        }
+
+    # ── BLOCKED: bare stash in worktree ──
+
+    def test_bare_stash_blocked(self, tmp_path):
+        """Bare 'git stash' (implicit push) is blocked in a worktree."""
+        result = run_guard("Bash", {"command": "git stash"}, env=self._env(tmp_path))
+        assert_guard(result, 2, "wt/my-feature")
+
+    def test_stash_push_no_name_blocked(self, tmp_path):
+        """'git stash push' without -m is blocked in a worktree."""
+        result = run_guard("Bash", {"command": "git stash push"}, env=self._env(tmp_path))
+        assert_guard(result, 2, "wt/my-feature")
+
+    def test_stash_push_wrong_name_blocked(self, tmp_path):
+        """'git stash push -m' with wrong prefix is blocked."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash push -m 'wt/other-branch: stuff'"},
+            env=self._env(tmp_path),
+        )
+        assert_guard(result, 2, "wt/my-feature")
+
+    def test_bare_pop_blocked(self, tmp_path):
+        """Bare 'git stash pop' is blocked in a worktree."""
+        result = run_guard("Bash", {"command": "git stash pop"}, env=self._env(tmp_path))
+        assert_guard(result, 2, "wt/my-feature")
+
+    def test_bare_apply_blocked(self, tmp_path):
+        """Bare 'git stash apply' is blocked in a worktree."""
+        result = run_guard("Bash", {"command": "git stash apply"}, env=self._env(tmp_path))
+        assert_guard(result, 2, "wt/my-feature")
+
+    def test_bare_drop_blocked(self, tmp_path):
+        """Bare 'git stash drop' is blocked in a worktree."""
+        result = run_guard("Bash", {"command": "git stash drop"}, env=self._env(tmp_path))
+        assert_guard(result, 2, "wt/my-feature")
+
+    def test_stash_clear_blocked(self, tmp_path):
+        """'git stash clear' is always blocked in a worktree."""
+        result = run_guard("Bash", {"command": "git stash clear"}, env=self._env(tmp_path))
+        assert_guard(result, 2, "ALL worktrees")
+
+    # ── ALLOWED: properly namespaced stash in worktree ──
+
+    def test_stash_push_correct_name_allowed(self, tmp_path):
+        """'git stash push -m wt/<name>: ...' is allowed."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash push -m 'wt/my-feature: save wip'"},
+            env=self._env(tmp_path),
+        )
+        assert result.returncode == 0
+
+    def test_stash_push_double_quotes_allowed(self, tmp_path):
+        """Double-quoted worktree name also works."""
+        result = run_guard(
+            "Bash",
+            {"command": 'git stash push -m "wt/my-feature: save wip"'},
+            env=self._env(tmp_path),
+        )
+        assert result.returncode == 0
+
+    def test_pop_with_ref_allowed(self, tmp_path):
+        """'git stash pop stash@{N}' is allowed (agent found the right index)."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash pop stash@{2}"},
+            env=self._env(tmp_path),
+        )
+        assert result.returncode == 0
+
+    def test_apply_with_ref_allowed(self, tmp_path):
+        """'git stash apply stash@{0}' is allowed."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash apply stash@{0}"},
+            env=self._env(tmp_path),
+        )
+        assert result.returncode == 0
+
+    def test_drop_with_ref_allowed(self, tmp_path):
+        """'git stash drop stash@{1}' is allowed."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash drop stash@{1}"},
+            env=self._env(tmp_path),
+        )
+        # drop with ref in a worktree → worktree check passes, then stash-drop ASK rule fires
+        assert result.returncode == 0
+
+    def test_stash_list_allowed(self, tmp_path):
+        """'git stash list' is always allowed in a worktree."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash list"},
+            env=self._env(tmp_path),
+        )
+        assert result.returncode == 0
+
+    def test_stash_show_allowed(self, tmp_path):
+        """'git stash show' is always allowed in a worktree."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash show stash@{0}"},
+            env=self._env(tmp_path),
+        )
+        assert result.returncode == 0
+
+    def test_stash_list_grep_allowed(self, tmp_path):
+        """'git stash list --grep' is allowed (how agents find their stash)."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash list --grep='wt/my-feature'"},
+            env=self._env(tmp_path),
+        )
+        assert result.returncode == 0
+
+    # ── NOT IN WORKTREE: all stash ops pass through ──
+
+    def test_bare_stash_outside_worktree_allowed(self, tmp_path):
+        """Bare 'git stash' outside a worktree is not blocked by this rule."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash"},
+            env=self._env_no_worktree(tmp_path),
+        )
+        assert result.returncode == 0
+
+    def test_bare_pop_outside_worktree_allowed(self, tmp_path):
+        """Bare 'git stash pop' outside a worktree is not blocked by this rule."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash pop"},
+            env=self._env_no_worktree(tmp_path),
+        )
+        assert result.returncode == 0
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Blocks bare git stash operations in worktrees to prevent cross-worktree stash collisions, requiring `wt/<name>` prefixed messages and explicit `stash@{N}` refs for pop/apply/drop
- Fixes pre-existing duplicate `TestTerminalPipeNoop` class and isolates branch enforcement tests from trust DB state
- Bumps dev-guard version 1.46.0 → 1.47.0