### PR TITLE
feat(dev-guard): adds stash ownership verification in worktrees

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.47.0",
+      "version": "1.48.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -1575,9 +1575,10 @@ def _check_worktree_stash(cmd: str) -> None:
             )
         return
 
-    # pop/apply/drop without a specific stash ref
+    # pop/apply/drop — require stash ref AND verify it belongs to this worktree
     if subcmd in ("pop", "apply", "drop"):
-        if not re.search(r"stash@\{", cmd):
+        ref_match = re.search(r"stash@\{(\d+)\}", cmd)
+        if not ref_match:
             _exit_with_decision(
                 f"In a worktree, bare 'git stash {subcmd}' risks targeting "
                 f"another worktree's stash.\n"
@@ -1587,6 +1588,47 @@ def _check_worktree_stash(cmd: str) -> None:
                 rule_name=f"worktree-stash-bare-{subcmd}",
                 matched_segment=cmd,
             )
+        else:
+            # Verify the stash at this index belongs to this worktree
+            stash_ref = f"stash@{{{ref_match.group(1)}}}"
+            try:
+                # Test hook: inject fake stash list output
+                test_stash = (
+                    os.environ.get("_GUARD_TEST_STASH_LIST")
+                    if os.environ.get("PYTEST_CURRENT_TEST")
+                    else None
+                )
+                if test_stash is not None:
+                    stash_output = test_stash
+                else:
+                    r = subprocess.run(
+                        ["git", "stash", "list", "--format=%gs"],
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+                    stash_output = r.stdout if r.returncode == 0 else ""
+                lines = stash_output.strip().splitlines()
+                idx = int(ref_match.group(1))
+                if idx < len(lines):
+                    msg = lines[idx]
+                    if prefix not in msg:
+                        _exit_with_decision(
+                            f"{stash_ref} does not belong to "
+                            f"this worktree ({wt_name}).\n"
+                            f"Stash message: {msg}\n"
+                            f"Find your stashes: "
+                            f"git stash list --grep='{prefix}'",
+                            "block",
+                            rule_name="worktree-stash-wrong-owner",
+                            matched_segment=cmd,
+                        )
+            except (
+                subprocess.SubprocessError,
+                FileNotFoundError,
+                OSError,
+            ):
+                pass  # Fail open if we can't verify
         return
 
     # clear is always dangerous in worktrees

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1466,6 +1466,13 @@ class TestGitBranchEnforcement:
 class TestWorktreeStash:
     """Worktree-namespaced stash enforcement: blocks bare stash ops in worktrees."""
 
+    # Fake stash list: index 0 belongs to my-feature, index 1 does not
+    FAKE_STASH_LIST = (
+        "On worktree-my-feature: wt/my-feature: save wip\n"
+        "On main: unrelated stash from main\n"
+        "On worktree-other: wt/other-branch: someone elses work\n"
+    )
+
     @staticmethod
     def _env(tmp_path, worktree_name="my-feature"):
         return {
@@ -1473,6 +1480,7 @@ class TestWorktreeStash:
             "GUARD_DB_PATH": str(tmp_path / "test.db"),
             "PYTEST_CURRENT_TEST": "yes",
             "_GUARD_TEST_WORKTREE": worktree_name,
+            "_GUARD_TEST_STASH_LIST": TestWorktreeStash.FAKE_STASH_LIST,
         }
 
     @staticmethod
@@ -1545,17 +1553,17 @@ class TestWorktreeStash:
         )
         assert result.returncode == 0
 
-    def test_pop_with_ref_allowed(self, tmp_path):
-        """'git stash pop stash@{N}' is allowed (agent found the right index)."""
+    def test_pop_with_matching_ref_allowed(self, tmp_path):
+        """'git stash pop stash@{0}' allowed when stash belongs to this worktree."""
         result = run_guard(
             "Bash",
-            {"command": "git stash pop stash@{2}"},
+            {"command": "git stash pop stash@{0}"},
             env=self._env(tmp_path),
         )
         assert result.returncode == 0
 
-    def test_apply_with_ref_allowed(self, tmp_path):
-        """'git stash apply stash@{0}' is allowed."""
+    def test_apply_with_matching_ref_allowed(self, tmp_path):
+        """'git stash apply stash@{0}' allowed when stash belongs to this worktree."""
         result = run_guard(
             "Bash",
             {"command": "git stash apply stash@{0}"},
@@ -1563,15 +1571,44 @@ class TestWorktreeStash:
         )
         assert result.returncode == 0
 
-    def test_drop_with_ref_allowed(self, tmp_path):
-        """'git stash drop stash@{1}' is allowed."""
+    def test_drop_with_matching_ref_allowed(self, tmp_path):
+        """'git stash drop stash@{0}' allowed when stash belongs to this worktree."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash drop stash@{0}"},
+            env=self._env(tmp_path),
+        )
+        # drop with matching ref → worktree check passes, then stash-drop ASK rule fires
+        assert result.returncode == 0
+
+    # ── BLOCKED: pop/apply/drop targeting another worktree's stash ──
+
+    def test_pop_wrong_owner_blocked(self, tmp_path):
+        """'git stash pop stash@{1}' blocked when stash belongs to another worktree."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash pop stash@{1}"},
+            env=self._env(tmp_path),
+        )
+        assert_guard(result, 2, "does not belong to")
+
+    def test_apply_wrong_owner_blocked(self, tmp_path):
+        """'git stash apply stash@{2}' blocked when stash belongs to another worktree."""
+        result = run_guard(
+            "Bash",
+            {"command": "git stash apply stash@{2}"},
+            env=self._env(tmp_path),
+        )
+        assert_guard(result, 2, "does not belong to")
+
+    def test_drop_wrong_owner_blocked(self, tmp_path):
+        """'git stash drop stash@{1}' blocked when stash belongs to another worktree."""
         result = run_guard(
             "Bash",
             {"command": "git stash drop stash@{1}"},
             env=self._env(tmp_path),
         )
-        # drop with ref in a worktree → worktree check passes, then stash-drop ASK rule fires
-        assert result.returncode == 0
+        assert_guard(result, 2, "does not belong to")
 
     def test_stash_list_allowed(self, tmp_path):
         """'git stash list' is always allowed in a worktree."""


### PR DESCRIPTION
## Summary
- Verifies stash@{N} belongs to the current worktree before allowing pop/apply/drop by checking for `wt/<name>` prefix in the stash message
- Blocks operations targeting another worktree's stash with guidance to find the correct index
- Bumps dev-guard version 1.47.0 → 1.48.0