### PR TITLE
fix(dev-guard): adds redirection exception to stop directive criterion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.49.0",
+      "version": "1.50.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -152,12 +152,17 @@ def _build_prompt(ctx: dict) -> str:
 
     # Universal criteria — USER DIRECTIVE first
     criteria.append(
-        "USER STOP DIRECTIVE: If the user's most recent message explicitly tells the "
-        "assistant to stop, pause, wait, slow down, or otherwise cease working "
-        "(e.g. 'stop', 'slow your roll', 'hold on', 'wait', 'pause', 'that's enough', "
-        "'chill', 'easy'), the assistant stopping IS the correct and complete response. "
-        "PASS immediately. Prior incomplete work is irrelevant — the user has overridden "
-        "the task. Do NOT evaluate other criteria."
+        "USER STOP DIRECTIVE: If the user's most recent message is PRIMARILY a stop "
+        "directive — telling the assistant to stop, pause, wait, slow down, or cease "
+        "working (e.g. 'stop', 'slow your roll', 'hold on', 'wait', 'pause', "
+        "'that's enough', 'chill', 'easy') — WITHOUT also giving continuation "
+        "instructions, follow-up tasks, or redirections in the same message, "
+        "then the assistant stopping IS the correct response. PASS immediately. "
+        "Prior incomplete work is irrelevant — the user has overridden the task. "
+        "Do NOT evaluate other criteria. "
+        "If the message combines a stop word WITH a continuation directive "
+        "(e.g. 'hold on, then keep going', 'wait, do X first, then continue'), "
+        "it is a REDIRECTION — do NOT short-circuit, evaluate all criteria normally."
     )
     criteria.append(
         "CLAIM ACCURACY: Do the claims in the final message match the work evidence? "

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -1636,3 +1636,9 @@ class TestBuildPromptCriteria:
         stop_idx = prompt.index("USER STOP DIRECTIVE")
         claim_idx = prompt.index("CLAIM ACCURACY")
         assert stop_idx < claim_idx
+
+    def test_user_stop_directive_has_redirection_clause(self):
+        mod = self._load_llm_module()
+        prompt = mod._build_prompt(self._minimal_ctx())
+        assert "REDIRECTION" in prompt
+        assert "continuation directive" in prompt

--- a/dev-guard/tests/test_stop_hook_llm_integration.py
+++ b/dev-guard/tests/test_stop_hook_llm_integration.py
@@ -370,6 +370,48 @@ def test_incomplete_work_fails(
 
 
 # ═════════════════════════════════════════════════════════════════════════════
+# FAIL scenarios: stop word + continuation directive = redirection, not stop
+# The assistant should follow the redirection but stopped and deferred → FAIL.
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize(
+    "user_msg, assistant_msg",
+    [
+        pytest.param(
+            "hold on, tell me what's going on, then get back to work",
+            "I was comparing the two plugins but I'm not sure what to focus on. "
+            "Can you clarify what you'd like me to investigate?",
+            id="hold-on-then-get-back-to-work",
+        ),
+        pytest.param(
+            "wait, explain your approach, then continue with the implementation",
+            "I was going to refactor the module. Should I proceed?",
+            id="wait-explain-then-continue",
+        ),
+    ],
+)
+def test_stop_with_continuation_directive_fails(user_msg: str, assistant_msg: str) -> None:
+    """Stop word + continuation directive — assistant deferred instead of continuing → FAIL."""
+    result = _call_evaluator(
+        _ctx(
+            user_msgs=[
+                "Investigate the safety-net vs dev-guard overlap.",
+                user_msg,
+            ],
+            assistant_msg=assistant_msg,
+            triggers=["completion_claim"],
+            work_type="code_config",
+            tools=["Read", "Grep"],
+            prior_assistant_msgs=[
+                "I'll compare the two plugins now.",
+            ],
+        )
+    )
+    _assert_fail(result, user_msg[:60])
+
+
+# ═════════════════════════════════════════════════════════════════════════════
 # FAIL scenarios: stop words in technical context (NOT stop directives)
 # These messages use "stop/wait/pause" as technical vocabulary, not directives.
 # The assistant should have done work but didn't → FAIL.


### PR DESCRIPTION
## Summary
- Refines USER STOP DIRECTIVE criterion to only short-circuit on pure stop messages, not messages that combine stop words with continuation directives
- Adds 2 LLM integration tests for stop+continuation scenarios (e.g. 'hold on, explain, then get back to work')
- Adds unit test verifying redirection clause presence in prompt