### PR TITLE
feat(code-quality): adds plan-review skill and deep-research Bridged mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -81,7 +81,7 @@
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo",
       "category": "quality",
-      "tags": ["agents", "architecture", "security", "qa", "performance", "audit", "lsp", "python", "testing", "planning", "roadmap", "pr-review", "session", "reflection", "indexing"],
+      "tags": ["agents", "architecture", "security", "qa", "performance", "audit", "lsp", "python", "testing", "planning", "roadmap", "pr-review", "plan-review", "session", "reflection", "indexing"],
       "author": {
         "name": "wgordon17"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,9 +77,9 @@
     },
     {
       "name": "code-quality",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "source": "./code-quality",
-      "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research, business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, map-reduce, speculative, reflect, and index-repo",
+      "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo",
       "category": "quality",
       "tags": ["agents", "architecture", "security", "qa", "performance", "audit", "lsp", "python", "testing", "planning", "roadmap", "pr-review", "session", "reflection", "indexing"],
       "author": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Personal Claude Code plugin marketplace with 9 plugins. Master registry: `.claud
 
 - **LSP plugins (5):** `pyright-uvx`, `vtsls-npx`, `gopls-go`, `vscode-html-css-npx`, `rust-analyzer-rustup`
 - **dev-guard/** — Tool selection guard, commit validation, pre-push review (only plugin with tests)
-- **code-quality/** — Agents (architect, security, QA, performance, test-runner, code-reviewer, code-simplifier), skills (17), commands (4), and orchestration
+- **code-quality/** — Agents (architect, security, QA, performance, test-runner, code-reviewer, code-simplifier), skills (18), commands (4), and orchestration
 - **git-tools/** — Git history, hooks, commit review, contributing guide; SessionStart git instructions
 - **github-mcp/** — GitHub MCP server (HTTP, api.githubcopilot.com); full toolsets for PRs, issues, actions, code security
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Personal Claude Code plugins: LSP servers, code quality agents, development util
 
 | Plugin | Description | Components | Docs |
 |--------|-------------|------------|------|
-| code-quality | Code quality agents, development utilities, and orchestration skills | 8 agents, 17 skills, 4 commands | [README](code-quality/README.md) |
+| code-quality | Code quality agents, development utilities, and orchestration skills | 8 agents, 18 skills, 4 commands | [README](code-quality/README.md) |
 
 **Agents:**
 - `code-quality:architect` - System architecture specialist (design, technology choices, refactoring)
@@ -39,6 +39,7 @@ Personal Claude Code plugins: LSP servers, code quality agents, development util
 - `/swarm` - Full agent team implementation via TeamCreate
 - `/quality-gate` - PROACTIVE multi-pass review with adversarial lenses, fresh-context subagents, and blocking gates
 - `/pr-review` - Multi-agent PR review with finding verification
+- `/plan-review` - Multi-agent plan review with finding verification
 - `/map-reduce` - Parallelized workload processing with chunking, mapper agents, and reducer synthesis
 - `/speculative` - Competing implementations in isolated worktrees with judge selection
 - `/incremental-planning` - Incremental planning workflow with per-task review and assumption surfacing
@@ -211,9 +212,9 @@ These MCP servers enhance functionality but are not required for core operation 
 | **[GitHub MCP](https://github.com/github/github-mcp-server)** | github-mcp | **Hard** (plugin is the server) | Full GitHub API: PRs, issues, actions, code security, discussions, and more via `mcp__github__*` tools. |
 | **[Context7](https://github.com/upstash/context7)** | code-quality | **Hard** (for `/file-audit` library validation) | Library usage validation — deprecated APIs, wrong signatures. Listed in `/file-audit` allowed-tools header. |
 | **[Context7](https://github.com/upstash/context7)** | git-tools | Soft | Informational reference for git-branchless documentation in `/git-history` and `/git-tools:review-commits`. |
-| **[Serena](https://github.com/Agentic-Coding/serena)** | code-quality | Soft | `get_symbols_overview` for component-level understanding in `/incremental-planning` Phase 1. Alternative tools work. |
+| **[Serena](https://github.com/Agentic-Coding/serena)** | code-quality | Soft | `get_symbols_overview` for component-level understanding in `/incremental-planning` Phase 1 and `/deep-research` Bridged mode. Alternative tools work. |
 | **[Sequential-Thinking](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking)** | code-quality | Soft | Reasoning about scope boundaries in `/incremental-planning` and `/roadmap`. Reasoning works without it. |
-| **[claude-mem](https://github.com/pchaganti/gx-claude-mem)** | code-quality | Soft | Search past work, decisions, and learnings in `/incremental-planning` Phase 1. Enhanced context, not required. |
+| **[claude-mem](https://github.com/pchaganti/gx-claude-mem)** | code-quality | Soft | Search past work, decisions, and learnings in `/incremental-planning` Phase 1 and `/deep-research` Bridged mode. Enhanced context, not required. |
 
 ### External Plugin Dependencies
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Personal Claude Code plugins: LSP servers, code quality agents, development util
 - `code-quality:plan-adherence` - Plan file verification, task completion tracking, escalation
 
 **Skills:**
-- `/deep-research` - Multi-hop research (40+ sources, multi-perspective analysis)
+- `/deep-research` - Multi-hop research (40+ sources) with Bridged mode for internal+external analysis
 - `/business-panel` - Multi-stakeholder business impact analysis
 - `/file-audit` - Deep code quality audit system
 - `/bug-investigation` - PROACTIVE interactive bug hunting with background agents

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
-  "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research, business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, map-reduce, speculative, reflect, and index-repo",
-  "version": "3.8.0",
+  "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo",
+  "version": "3.9.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/README.md
+++ b/code-quality/README.md
@@ -1,6 +1,6 @@
 # Code Quality Plugin
 
-Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research, business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo.
+Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo.
 
 ## Agents (8)
 

--- a/code-quality/README.md
+++ b/code-quality/README.md
@@ -1,6 +1,6 @@
 # Code Quality Plugin
 
-Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research, business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, map-reduce, speculative, reflect, and index-repo.
+Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research, business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo.
 
 ## Agents (8)
 
@@ -15,11 +15,11 @@ Code quality agents, development utilities, and orchestration skills: architectu
 | `code-quality:code-simplifier` | Dead code removal, unnecessary abstraction cleanup, clarity improvement | Sonnet |
 | `code-quality:plan-adherence` | Plan file verification, task completion tracking, file structure reconciliation | Opus |
 
-## Skills (17)
+## Skills (18)
 
 | Skill | Description | Type |
 |-------|-------------|------|
-| `/deep-research` | Multi-hop research (40+ sources) | Manual |
+| `/deep-research` | Multi-hop research (40+ sources) with Bridged mode for internal+external analysis | Manual |
 | `/business-panel` | Multi-stakeholder business analysis | Manual |
 | `/file-audit` | Deep code quality audit system | Manual |
 | `/bug-investigation` | Interactive bug hunting with background agents | PROACTIVE |
@@ -27,6 +27,7 @@ Code quality agents, development utilities, and orchestration skills: architectu
 | `/swarm` | Full agent team implementation via TeamCreate | Manual |
 | `/quality-gate` | Multi-pass review with adversarial lenses, fresh-context subagents, and blocking gates | PROACTIVE |
 | `/pr-review` | Multi-agent PR review with finding verification | Manual |
+| `/plan-review` | Multi-agent plan review with independent fresh-context reviewers | Manual |
 | `/map-reduce` | Parallelized workload processing with chunking, mapper agents, and reducer synthesis | Manual |
 | `/speculative` | Competing implementations in isolated worktrees with judge selection | Manual |
 | `/incremental-planning` | Planning workflow with per-task review and assumption surfacing | Manual |
@@ -50,9 +51,9 @@ Code quality agents, development utilities, and orchestration skills: architectu
 
 - **At least one LSP plugin** — Required for `/lsp-navigation` (pyright-uvx, vtsls-npx, gopls-go, etc.).
 - **Context7 MCP** — Required for `/file-audit` library validation (deprecated APIs, wrong signatures).
-- **Serena MCP** — Optional. Enhances `/incremental-planning` Phase 1 with `get_symbols_overview`.
+- **Serena MCP** — Optional. Enhances `/incremental-planning` Phase 1 and `/deep-research` Bridged mode with `get_symbols_overview`.
 - **Sequential-Thinking MCP** — Optional. Used in `/incremental-planning` and `/roadmap` for scope boundary reasoning.
-- **claude-mem MCP** — Optional. Searches past work and decisions in `/incremental-planning` Phase 1.
+- **claude-mem MCP** — Optional. Searches past work and decisions in `/incremental-planning` Phase 1 and `/deep-research` Bridged mode.
 - **Serena reflection tools** — Optional. Enables `/reflect` skill's metacognitive checkpoints (`think_about_task_adherence`, etc.). Enable via `included_optional_tools` in `~/.serena/serena_config.yml`.
 
 ## Installation

--- a/code-quality/references/project-memory-reference.md
+++ b/code-quality/references/project-memory-reference.md
@@ -2,7 +2,7 @@
 
 > **Cross-reference note:** This file is referenced by multiple skills and commands. When editing, check all consumers.
 > Consumers — Skills: swarm (+ references), speculative, unfuck, map-reduce, incremental-planning, deep-research, index-repo,
-> roadmap, pr-review, quality-gate, bug-investigation, file-audit. Commands: session-start, session-end, review-project.
+> roadmap, pr-review, plan-review, quality-gate, bug-investigation, file-audit. Commands: session-start, session-end, review-project.
 
 Canonical definitions for project memory conventions. All memory-aware skills and commands in this plugin reference
 this file. Do not maintain ad-hoc memory conventions elsewhere — point here.

--- a/code-quality/skills/deep-research/SKILL.md
+++ b/code-quality/skills/deep-research/SKILL.md
@@ -3,8 +3,10 @@ name: deep-research
 description: |
   Use when user requests deep research, comprehensive analysis, or thorough investigation.
   Triggers on: "research X thoroughly", "deep dive into", "comprehensive analysis of",
-  "investigate X exhaustively", "compare X options", "evaluate alternatives for"
-allowed-tools: [WebSearch, WebFetch, Read, Write, Glob, Grep, Agent]
+  "investigate X exhaustively", "compare X options", "evaluate alternatives for".
+  Supports two modes: External (web research, current behavior) and Bridged (internal
+  project investigation followed by external best-practices research).
+allowed-tools: [WebSearch, WebFetch, Read, Write, Glob, Grep, Agent, AskUserQuestion]
 ---
 
 # deep-research — 5-Hop Deep Research Mode
@@ -38,17 +40,64 @@ Before starting research:
    - What does "good enough" research look like?
    - How will we know when to stop?
 
+### Phase 1.5: Research Mode Classification
+
+After completing Phase 1 scope definition, classify the research mode via `AskUserQuestion` before proceeding.
+
+**Present two options to the user:**
+
+- **External (Recommended)** — Pure external research (web sources, documentation, community). Use when the question is about technologies, patterns, or decisions unrelated to this codebase.
+- **Bridged** — Internal investigation first, then external research informed by the internal findings. Use when the question references this project's code, patterns, or architecture.
+
+**Default recommendation based on context signals:**
+
+- Signals suggesting **Bridged**: user's question references "our", "this project", "the codebase", "we", specific file paths, or internal component names.
+- Signals suggesting **External**: generic technology questions, no reference to internal code or project specifics.
+
+Present your recommended mode along with the reason, and ask the user to confirm or switch.
+
+**Routing:**
+- **External selected**: skip Phase 2.5, proceed directly to Phase 2.
+- **Bridged selected**: run Phase 2.5 before Phase 2.
+
 ### Phase 2: Source Gathering (40+ Sources Target)
+
+**Bridged mode only** — skip entirely if External mode was selected.
+
+#### Phase 2.5: Internal Investigation
+
+1. **Structural discovery** — Launch an Explore `Agent` to map relevant codebase areas. Use Serena `get_symbols_overview` if the Serena MCP is configured.
+
+2. **Pattern analysis** — Read key files identified in structural discovery. Look for:
+   - Current patterns and idioms used throughout the codebase
+   - Consistency (or inconsistency) across modules
+   - Anti-patterns or tech debt
+   - Past decisions documented in `{memory_dir}/PROJECT.md` and `{memory_dir}/LESSONS.md`
+
+3. **Cross-reference with memory** — Optional enhancements if available:
+   - If **claude-mem MCP** is configured: search past work for related research or decisions.
+   - If **Serena MCP** is configured: check Serena memories for project-specific insights.
+
+4. **Synthesize internal findings** — Produce a concise summary covering:
+   - What the project does in the relevant area
+   - What currently works well
+   - What has problems or is incomplete
+   - Open questions that external research should answer
+
+Store this summary as `{internal_findings}`. It becomes the feed-forward context for Phase 2 source gathering and informs all subsequent phases.
 
 Organize sources into categories:
 
 | Source Type | What to Look For | Priority |
 |-------------|------------------|----------|
+| **Internal sources** *(Bridged only)* | Project code, patterns, decisions from `{internal_findings}` | Highest |
 | **Primary sources** | Official documentation, specifications, papers | Highest |
 | **Secondary sources** | Tutorials, blog posts, case studies | High |
 | **Community sources** | GitHub issues, Stack Overflow, forums | Medium |
 | **Comparative sources** | Benchmarks, comparisons, reviews | High |
 | **Recent sources** | News, release notes, changelogs (2025-2026) | Critical |
+
+In **Bridged mode**, research queries for all external source types should be informed by `{internal_findings}`. For example, if internal investigation revealed a pain point with a specific pattern, target external sources that address that specific pattern rather than the topic generically.
 
 ### Phase 3: 5-Hop Exploration
 
@@ -68,6 +117,8 @@ Topic
 - Expert-level insights often appear at hop 3-4
 - Foundational context emerges at hop 4-5
 
+In **Bridged mode**, internal code patterns are treated as **hop 0**. External exploration begins from those established patterns and diverges outward, extending them with external insights rather than starting from scratch.
+
 ### Phase 4: Multi-Perspective Analysis
 
 Include viewpoints from:
@@ -80,6 +131,7 @@ Include viewpoints from:
 | **Enterprise users** | Scale, support, compliance |
 | **Indie developers** | Simplicity, cost, DX |
 | **Different tech stacks** | Integration, compatibility |
+| **Current maintainers** *(Bridged only)* | What works in the existing codebase, what's painful, migration cost |
 
 ### Phase 5: Synthesis
 
@@ -102,6 +154,12 @@ Include viewpoints from:
 5. **Provide actionable recommendations**
    - Clear, prioritized suggestions
    - Context-dependent guidance
+
+6. **Internal-external bridge analysis** *(Bridged mode only)*
+   - Alignment: where do external best practices match what the project already does?
+   - Divergence: where do external recommendations conflict with current patterns?
+   - Applicability: which external findings are directly usable vs. require adaptation?
+   - Adaptation needed: what changes would be required to adopt external recommendations in this codebase?
 
 ## Output Format
 
@@ -133,6 +191,31 @@ If no memory directory exists, deliver the report in the conversation only.
 - Date range: [most recent to oldest]
 - Key search queries used
 - Hop depth achieved
+- *(Bridged mode)* Internal files investigated: [count]
+- *(Bridged mode)* Patterns identified: [count]
+- *(Bridged mode)* MCP tools used: [list, e.g., Serena get_symbols_overview, claude-mem search]
+
+## Internal Investigation
+*(Bridged mode only — omit this section entirely for External mode)*
+
+### Current State
+[Description of what the project currently does in the researched area, with specific file/symbol references.]
+
+### Strengths
+[What works well in the current implementation. Cite files and patterns.]
+
+### Gaps
+[What is missing, problematic, or inconsistent. Cite files and patterns.]
+
+### Internal-External Bridge
+
+| Internal Pattern | External Best Practice | Alignment | Adaptation Needed |
+|-----------------|----------------------|-----------|------------------|
+| [pattern from code] | [external recommendation] | Aligned / Diverges | [what would change] |
+| ... | ... | ... | ... |
+
+### Actionable Changes
+[Specific, project-aware changes that external research suggests, grounded in the internal investigation.]
 
 ## Detailed Findings
 
@@ -208,6 +291,9 @@ If no memory directory exists, deliver the report in the conversation only.
 - **Flag areas of uncertainty** (don't pretend to know what you don't)
 - **Include recent (2025-2026) sources** where available
 - **Cross-reference claims** (verify important claims with multiple sources)
+- *(Bridged mode)* **Internal investigation must cover relevant source files** — not just PROJECT.md and LESSONS.md; read actual code files
+- *(Bridged mode)* **Internal-external bridge must be specific** — cite actual file paths, function names, and patterns, not vague descriptions
+- *(Bridged mode)* **Recommendations must be project-aware** — verify that recommendations do not contradict documented project decisions before including them
 
 ## Research Anti-Patterns to Avoid
 
@@ -226,3 +312,5 @@ Research is complete when:
 - [ ] Risks are identified and documented
 - [ ] Actionable recommendations can be made
 - [ ] Source count target (40+) is met
+- [ ] *(Bridged mode)* Internal investigation has covered relevant source files (not just memory files)
+- [ ] *(Bridged mode)* Internal-external bridge table is populated with specific file references

--- a/code-quality/skills/deep-research/SKILL.md
+++ b/code-quality/skills/deep-research/SKILL.md
@@ -62,9 +62,7 @@ Present your recommended mode along with the reason, and ask the user to confirm
 
 ### Phase 2: Source Gathering (40+ Sources Target)
 
-**Bridged mode only** — skip entirely if External mode was selected.
-
-#### Phase 2.5: Internal Investigation
+#### Phase 2.5: Internal Investigation *(Bridged mode only)*
 
 1. **Structural discovery** — Launch an Explore `Agent` to map relevant codebase areas. Use Serena `get_symbols_overview` if the Serena MCP is configured.
 

--- a/code-quality/skills/deep-research/SKILL.md
+++ b/code-quality/skills/deep-research/SKILL.md
@@ -46,15 +46,8 @@ After completing Phase 1 scope definition, classify the research mode via `AskUs
 
 **Present two options to the user:**
 
-- **External (Recommended)** — Pure external research (web sources, documentation, community). Use when the question is about technologies, patterns, or decisions unrelated to this codebase.
+- **External** — Pure external research (web sources, documentation, community). Use when the question is about technologies, patterns, or decisions unrelated to this codebase.
 - **Bridged** — Internal investigation first, then external research informed by the internal findings. Use when the question references this project's code, patterns, or architecture.
-
-**Default recommendation based on context signals:**
-
-- Signals suggesting **Bridged**: user's question references "our", "this project", "the codebase", "we", specific file paths, or internal component names.
-- Signals suggesting **External**: generic technology questions, no reference to internal code or project specifics.
-
-Present your recommended mode along with the reason, and ask the user to confirm or switch.
 
 **Routing:**
 - **External selected**: skip Phase 2.5, proceed directly to Phase 2.

--- a/code-quality/skills/deep-research/SKILL.md
+++ b/code-quality/skills/deep-research/SKILL.md
@@ -58,7 +58,7 @@ Present your recommended mode along with the reason, and ask the user to confirm
 
 **Routing:**
 - **External selected**: skip Phase 2.5, proceed directly to Phase 2.
-- **Bridged selected**: run Phase 2.5 before Phase 2.
+- **Bridged selected**: run Phase 2.5 as the first step within Phase 2 (before source gathering).
 
 ### Phase 2: Source Gathering (40+ Sources Target)
 

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -1,0 +1,410 @@
+---
+name: plan-review
+description: |
+  Multi-agent plan review with independent fresh-context reviewers. Use when asked to
+  "review plan", "review this plan", "plan review", or given a plan file path to review.
+  Spawns 6 parallel specialized reviewers (feasibility, scope, dependencies, unknown unknowns,
+  architect, security), verifies findings by re-reading the plan, and prints a structured
+  terminal report. Designed for cross-session use: write a plan in session A, review in session B.
+allowed-tools: [Read, Glob, Grep, Bash, Agent, AskUserQuestion]
+---
+
+# Plan Review Skill
+
+Multi-agent plan review. Spawns 6 parallel reviewers (4 plan-specific + 2 domain) — feasibility,
+scope & completeness, dependency ordering, unknown unknowns/spike detection, architect, and security
+— each required to read and analyze the plan independently. A verification agent then cross-checks
+findings against plan content. Results are categorized and printed as a structured terminal report.
+
+**Never modifies plan files.** Output is terminal-only.
+
+## Usage
+
+```
+/plan-review [<plan-file-path>]
+```
+
+- `<plan-file-path>` — optional. Absolute or relative path to a plan `.md` file. If omitted, the
+  skill discovers the most recent plan in `{memory_dir}/plans/`.
+
+---
+
+## Phase 0 — Setup & Plan Discovery
+
+### Parse Arguments
+
+Extract from `$ARGUMENTS`:
+- Plan file path (optional; first token if present)
+
+### Plan Discovery
+
+If a plan file path was provided in `$ARGUMENTS`, use it directly. Skip discovery.
+
+If no path was given:
+
+1. Detect the memory directory using the convention in
+   `code-quality/references/project-memory-reference.md` (Directory Detection and Worktree
+   Resolution sections). If no validated memory directory is found, stop with:
+   "No memory directory found. Pass a plan file path explicitly: `/plan-review <path>`"
+
+2. Scan `{memory_dir}/plans/` for `.md` files. If the directory does not exist or contains no
+   `.md` files, stop with:
+   "No plan files found in `{memory_dir}/plans/`. Pass a plan file path explicitly: `/plan-review <path>`"
+
+3. Sort plan files by modification time, most recent first.
+
+4. If exactly one file is found, use it. Print: "Using plan: {filename}"
+
+5. If multiple files are found, present them via `AskUserQuestion`:
+   - Show each file's filename, the value of its first `**Goal:**` or `## Goal` line (if found),
+     and its relative age (e.g., "modified 2 hours ago").
+   - Ask the user to select one.
+
+### Read Plan File
+
+Read the selected plan file. Store as `{plan_content}` and `{plan_file_path}`.
+
+Extract from the plan content:
+- `{plan_goal}` — value of `**Goal:**` header or first H2 that describes the objective
+- `{plan_domain}` — inferred from file paths, tech stack mentions, or explicit domain statement
+- `{plan_architecture}` — content of any `## Architecture` or `## Design` section
+- `{plan_decisions}` — content of any `## Decisions`, `## Trade-offs`, or `## Key Decisions` section
+- `{plan_tasks}` — count of `## Task N:` headings (or `- [ ]` top-level task items)
+- `{plan_files}` — file paths from `## File Structure` sections and task `Files:` blocks
+- `{plan_open_questions}` — content of any `## Open Questions` section
+- `{plan_trade_offs}` — content of any `## Trade-offs` section
+
+> **Note:** These extractions assume a structured plan format. If the plan lacks these headings,
+> reviewers will work with the full `{plan_content}` and report on what they can infer.
+
+### Read Project Context
+
+From the repo root:
+- Read `CLAUDE.md`. If missing, use: `"No CLAUDE.md found."`
+- Read `CONTRIBUTING.md`. If missing, use: `"No CONTRIBUTING.md found."`
+- Read `{memory_dir}/PROJECT.md`. If missing, use: `"No PROJECT.md found."`
+
+Store as `{claude_md_rules}`, `{contributing_md_rules}`, and `{project_context}`.
+
+### Build Input Context
+
+Assemble these values — passed to reviewers in Phase 2:
+- `{plan_content}` = full plan file content
+- `{plan_file_path}` = absolute path to the plan file
+- `{plan_goal}` = extracted goal or empty string
+- `{plan_tasks}` = task count integer
+- `{plan_files}` = newline-separated list of file paths from the plan
+- `{claude_md_rules}` = CLAUDE.md content or placeholder
+- `{contributing_md_rules}` = CONTRIBUTING.md content or placeholder
+- `{project_context}` = PROJECT.md content or placeholder
+
+Additional context for Unknown Unknowns reviewer:
+- `{plan_open_questions}` = extracted open questions or empty string
+- `{plan_trade_offs}` = extracted trade-offs or empty string
+- `{plan_decisions}` = extracted decisions or empty string
+
+---
+
+## Phase 1 — Reviewer Applicability
+
+Determine which of the 6 reviewers apply based on plan content.
+
+Default: all 6 reviewers run. Skip a reviewer only if its domain has zero applicability:
+
+| Reviewer | Skip condition |
+|----------|----------------|
+| Feasibility | never skip |
+| Scope & Completeness | never skip |
+| Dependency & Ordering | skip if `{plan_tasks}` < 2 (no ordering to verify with a single task) |
+| Unknown Unknowns | never skip (most critical reviewer) |
+| Architect | never skip |
+| Security | skip if `{plan_files}` contains no paths referencing auth, security, crypto, secrets, permissions, or API endpoints (case-insensitive check on file path strings and plan content keywords) |
+
+Record which reviewers will run.
+
+---
+
+## Phase 2 — Parallel Review
+
+Read `references/reviewer-prompts.md`. For each applicable reviewer, locate the corresponding
+prompt template, substitute all placeholders with actual values, and spawn an agent. Most
+reviewers use `model="sonnet"`; the Unknown Unknowns Reviewer uses `model="opus"`.
+
+Spawn all applicable reviewers simultaneously (parallel Agent calls).
+
+### Plan-Specific Reviewers (4 parallel)
+
+```
+Agent(
+  description="Feasibility review of plan: {plan_file_path}",
+  model="sonnet",
+  prompt=<Feasibility Reviewer template from references/reviewer-prompts.md, placeholders substituted>
+)
+
+Agent(
+  description="Scope & completeness review of plan: {plan_file_path}",
+  model="sonnet",
+  prompt=<Scope & Completeness Reviewer template from references/reviewer-prompts.md, placeholders substituted>
+)
+
+Agent(
+  description="Dependency & ordering review of plan: {plan_file_path}",
+  model="sonnet",
+  prompt=<Dependency & Ordering Reviewer template from references/reviewer-prompts.md, placeholders substituted>
+)
+
+Agent(
+  description="Unknown unknowns review of plan: {plan_file_path}",
+  model="opus",
+  prompt=<Unknown Unknowns Reviewer template from references/reviewer-prompts.md, placeholders substituted>
+)
+```
+
+Each plan-specific reviewer receives: `{plan_content}`, `{plan_goal}`, `{plan_files}`,
+`{claude_md_rules}`, `{contributing_md_rules}`, `{project_context}`.
+
+The Unknown Unknowns Reviewer additionally receives: `{plan_open_questions}`, `{plan_trade_offs}`,
+`{plan_decisions}`.
+
+### Domain Reviewers (2 parallel, with plan-specific reviewers above)
+
+```
+Agent(
+  description="Architect review of plan: {plan_file_path}",
+  model="sonnet",
+  prompt=<Architect Reviewer template from references/reviewer-prompts.md, placeholders substituted>
+)
+
+Agent(
+  description="Security review of plan: {plan_file_path}",
+  model="sonnet",
+  prompt=<Security Reviewer template from references/reviewer-prompts.md, placeholders substituted>
+)
+```
+
+Domain reviewers receive the same inputs as plan-specific reviewers (minus the Unknown Unknowns
+extras).
+
+### Collect Findings
+
+After all agents complete, collect all findings into a consolidated list. Assign each finding a
+unique ID using the prefix for its reviewer:
+
+| Reviewer | Finding prefix |
+|----------|---------------|
+| Feasibility | `feas-` |
+| Scope & Completeness | `scope-` |
+| Dependency & Ordering | `dep-` |
+| Unknown Unknowns | `unk-` |
+| Architect | `arch-` |
+| Security | `sec-` |
+
+Preserve: description, location reference (plan section or task number), severity, evidence,
+source reviewer.
+
+---
+
+## Phase 3 — Verification (batched)
+
+If no findings were reported by any reviewer, skip verification and proceed directly to
+Phase 4 with the 'no findings' output path.
+
+Spawn a **single** Sonnet agent with ALL findings in one call. Do NOT spawn one agent per
+finding — that pattern is catastrophically slow. A single batched call takes ~15 seconds;
+per-finding agents with 15–20 findings would take 2–5 minutes.
+
+Build the findings JSON array:
+```json
+[
+  {
+    "id": "feas-1",
+    "reviewer": "Feasibility",
+    "description": "...",
+    "location": "Task 3, step 2",
+    "severity": "HIGH",
+    "evidence": "..."
+  },
+  ...
+]
+```
+
+```
+Agent(
+  description="Finding verification for plan: {plan_file_path}",
+  model="sonnet",
+  prompt=<Finding Verifier template from references/reviewer-prompts.md, placeholders substituted>
+)
+```
+
+The verifier receives: `{findings_json}` (the array above), `{plan_content}`,
+`{plan_file_path}`.
+
+The verifier **re-reads the plan** to check each finding against plan content. It returns a
+JSON array with a verdict for each finding:
+`[{finding_id, verdict, investigation_summary, category}, ...]`
+
+Verdicts: `verified` (finding accurately references plan content), `false_positive` (finding
+misread or misrepresents the plan), `needs_context` (cannot confirm or deny — requires human
+judgment).
+
+Parse the verifier's response as JSON. If parsing fails, extract JSON from between the first
+`[` and last `]` markers. If that also fails, include all findings with verdict `unverified`
+and a note: "Verification failed — showing all findings unverified."
+
+### Categorize
+
+The verifier assigns each finding to a category based on its nature:
+
+| Category | Examples |
+|----------|----------|
+| **Research Gaps** | Unvalidated assumptions, missing spikes, external dependencies not investigated |
+| **Feasibility** | Steps that cannot be implemented as described, missing prerequisites |
+| **Scope** | Missing requirements, scope creep, goal not fully addressed |
+| **Dependencies** | Wrong task ordering, implicit dependencies, circular dependencies |
+| **Architecture** | Design issues, pattern violations, unnecessary abstractions |
+| **Security** | Missing security considerations, auth gaps, sensitive data handling |
+| **Specification** | Ambiguous steps, missing detail, unclear success criteria |
+
+### Filter
+
+Remove findings with verdict `false_positive`. Keep all `verified`, `needs_context`, and
+`unverified` findings. Treat `unverified` findings as `needs_context` for output purposes.
+
+---
+
+## Phase 4 — Terminal Output
+
+Print the structured report. Use `━` (U+2501) for the divider lines.
+
+### Findings Exist
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+PLAN REVIEW — {plan_file_path}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Goal: {plan_goal}
+Domain: {plan_domain}
+Tasks: {plan_tasks} | Files: {plan_files_count}
+
+Findings: {verified_count} verified, {needs_context_count} needs context
+  (from {total_raw} raw findings — {false_positive_count} false positives removed)
+
+RESEARCH GAPS
+  1. [{Reviewer}] {description} [{severity}]
+     {location}
+     Evidence: {evidence}
+
+FEASIBILITY
+  ...
+
+SCOPE
+  ...
+
+DEPENDENCIES
+  ...
+
+ARCHITECTURE
+  ...
+
+SECURITY
+  ...
+
+SPECIFICATION
+  ...
+
+─── Needs Context ({needs_context_count}) ───
+  1. [{Reviewer}] {description} [{severity}]
+     {location}
+     Investigation: {investigation_summary}
+
+Reviewed by: {reviewer_list}
+Total raw: {total_raw} | Verified: {verified_count} | False positives removed: {false_positive_count} | Needs context: {needs_context_count}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Group findings by **category** in order: RESEARCH GAPS (first — highest leverage to fix before
+implementation) → FEASIBILITY → SCOPE → DEPENDENCIES → ARCHITECTURE → SECURITY → SPECIFICATION.
+Within each category, sort by severity (CRITICAL → HIGH → MEDIUM → LOW). For the `[Reviewer]`
+tag, use the short reviewer name: Feasibility, Scope, Dependencies, Unknown Unknowns, Architect,
+Security.
+
+Omit category sections with zero findings.
+
+Findings with verdict `needs_context` appear in a dedicated section at the bottom — these are
+items the verifier could not confirm or deny and require human judgment. They are NOT hidden or
+filtered — they are surfaced transparently.
+
+### No Findings After Verification
+
+Use this path only when `verified_count == 0` AND `needs_context_count == 0`. If
+`needs_context_count > 0`, use the "Findings Exist" path.
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+PLAN REVIEW — {plan_file_path}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Goal: {plan_goal}
+Domain: {plan_domain}
+Tasks: {plan_tasks} | Files: {plan_files_count}
+
+No verified issues found.
+Checked for: feasibility, scope, dependencies, unknown unknowns, architecture, security.
+
+Reviewed by: {reviewer_list}
+Total raw: {total_raw} | Verified: 0 | False positives removed: {false_positive_count} | Needs context: 0
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Edge Cases
+
+| Condition | Action |
+|-----------|--------|
+| No plan file path given and no memory dir | Error: "No memory directory found. Pass a plan file path explicitly: `/plan-review <path>`" |
+| No `.md` files in `{memory_dir}/plans/` | Error: "No plan files found in `{memory_dir}/plans/`. Pass a plan file path explicitly: `/plan-review <path>`" |
+| Plan file path given but file does not exist | Error: "Plan file not found: {path}" |
+| Plan file exists but is empty | Error: "Plan file is empty: {path}" |
+| Single plan file found | Auto-select with confirmation: "Using plan: {filename}" |
+| Multiple plan files found | Present via AskUserQuestion with filename, goal line, relative age |
+| `{plan_tasks}` < 2 | Skip Dependency & Ordering reviewer; note in footer |
+| Security reviewer skipped | Note in footer: "Security reviewer skipped (no auth/security paths detected)" |
+| All findings false positive | Output "no findings" report format (not an error) |
+| Verification JSON parse fails | All findings get `unverified` verdict, treated as `needs_context` in output |
+
+---
+
+## Reviewer Prompt Templates
+
+Prompt templates are in `references/reviewer-prompts.md`. Read that file and substitute
+placeholders before passing to each Agent call. The templates are not executable — they are
+documentation that Claude reads and fills in.
+
+### Placeholder Reference
+
+| Placeholder | Value | Used by |
+|-------------|-------|---------|
+| `{plan_content}` | Full plan file content | All reviewers + Verifier |
+| `{plan_file_path}` | Absolute path to plan file | All reviewers + Verifier |
+| `{plan_goal}` | Extracted goal string | All reviewers |
+| `{plan_tasks}` | Integer task count | All reviewers |
+| `{plan_files}` | Newline-separated file paths from the plan | All reviewers |
+| `{claude_md_rules}` | CLAUDE.md content or "No CLAUDE.md found." | All reviewers |
+| `{contributing_md_rules}` | CONTRIBUTING.md content or "No CONTRIBUTING.md found." | All reviewers |
+| `{project_context}` | PROJECT.md content or "No PROJECT.md found." | All reviewers |
+| `{plan_open_questions}` | Extracted open questions or empty string | Unknown Unknowns only |
+| `{plan_trade_offs}` | Extracted trade-offs or empty string | Unknown Unknowns only |
+| `{plan_decisions}` | Extracted decisions or empty string | Unknown Unknowns only |
+| `{findings_json}` | JSON array of all findings | Finding Verifier only |
+
+---
+
+## Relationship to Other Skills
+
+| Skill | Relationship |
+|-------|-------------|
+| `incremental-planning` | Creates plans that plan-review reviews. Run plan-review after incremental-planning produces a plan file. |
+| `quality-gate` | Complementary: plan-review is pre-implementation (plan quality), quality-gate is post-implementation (code quality). |
+| `plan-adherence` | Complementary: plan-review checks plan quality before coding; plan-adherence checks implementation fidelity after coding. |
+| `swarm` | plan-review should run before `/swarm` — catch gaps in the plan before spawning parallel implementers. |
+| `roadmap` | plan-review can review individual milestone plans that roadmap generates. |

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -69,8 +69,8 @@ Read the selected plan file. Store as `{plan_content}` and `{plan_file_path}`.
 
 Extract from the plan content:
 - `{plan_goal}` — value of `**Goal:**` header or first H2 that describes the objective
-- `{plan_domain}` — inferred from file paths, tech stack mentions, or explicit `**Cynefin Domain:**` statement
-- `{plan_decisions}` — content of any `## Decisions`, `## Trade-offs`, or `## Key Decisions` section
+- `{plan_domain}` — inferred from file paths, tech stack mentions, or explicit `**Cynefin Domain:**` statement. If domain cannot be determined, use `"Unknown"`.
+- `{plan_decisions}` — content of any `## Decisions` or `## Key Decisions` section (not `## Trade-offs` — that is captured separately by `{plan_trade_offs}`)
 - `{plan_tasks}` — count of `## Task N:` headings (or `- [ ]` top-level task items)
 - `{plan_files}` — file paths from `## File Structure` sections and task `Files:` blocks
 - `{plan_open_questions}` — content of any `## Open Questions` section
@@ -94,6 +94,7 @@ Assemble these values — passed to reviewers in Phase 2:
 - `{plan_content}` = full plan file content
 - `{plan_file_path}` = absolute path to the plan file
 - `{plan_goal}` = extracted goal or empty string
+- `{plan_domain}` = extracted domain or `"Unknown"`
 - `{plan_tasks}` = task count integer
 - `{plan_files}` = newline-separated list of file paths from the plan
 - `{plan_files_count}` = count of unique file paths in `{plan_files}` (derived, not extracted)
@@ -252,7 +253,8 @@ judgment).
 
 Parse the verifier's response as JSON. If parsing fails, extract JSON from between the first
 `[` and last `]` markers. If that also fails, include all findings with verdict `unverified`
-and a note: "Verification failed — showing all findings unverified."
+and set `{verification_note}` to `"⚠ Verification failed — all findings shown unverified"`.
+If verification succeeded, set `{verification_note}` to empty string.
 
 ### Categorize
 
@@ -270,8 +272,9 @@ The verifier assigns each finding to a category based on its nature:
 
 ### Filter
 
-Remove findings with verdict `false_positive`. Keep all `verified`, `needs_context`, and
-`unverified` findings. Treat `unverified` findings as `needs_context` for output purposes.
+Remove findings with verdict `false_positive`. Keep `verified` findings for the category
+sections. Keep `needs_context` and `unverified` findings for the Needs Context section only
+(they do NOT appear in category sections). Treat `unverified` as `needs_context` for display.
 
 ---
 
@@ -321,22 +324,27 @@ SPECIFICATION
      {location}
      Investigation: {investigation_summary}
 
+{verification_note}
+{skipped_note}
 Reviewed by: {reviewer_list}
 Total raw: {total_raw} | Verified: {verified_count} | False positives removed: {false_positive_count} | Needs context: {needs_context_count}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-Group findings by **category** in order: RESEARCH GAPS (first — highest leverage to fix before
-implementation) → FEASIBILITY → SCOPE → DEPENDENCIES → ARCHITECTURE → SECURITY → SPECIFICATION.
-Within each category, sort by severity (CRITICAL → HIGH → MEDIUM → LOW). For the `[Reviewer]`
-tag, use the short reviewer name: Feasibility, Scope, Dependencies, Unknown Unknowns, Architect,
-Security.
+`{verification_note}` — if verification JSON parsing failed, print the warning line. Otherwise omit.
+`{skipped_note}` — if any reviewers were skipped, print a line such as "Skipped: Dependency & Ordering (single-task plan)" or "Skipped: Security (no auth/security paths detected)". Otherwise omit.
 
-Omit category sections with zero findings.
+Category sections contain only `verified` findings. Group by category in order: RESEARCH GAPS
+(first — highest leverage to fix before implementation) → FEASIBILITY → SCOPE → DEPENDENCIES →
+ARCHITECTURE → SECURITY → SPECIFICATION. Within each category, sort by severity (CRITICAL →
+HIGH → MEDIUM → LOW). For the `[Reviewer]` tag, use the short reviewer name: Feasibility,
+Scope, Dependencies, Unknown Unknowns, Architect, Security.
 
-Findings with verdict `needs_context` appear in a dedicated section at the bottom — these are
-items the verifier could not confirm or deny and require human judgment. They are NOT hidden or
-filtered — they are surfaced transparently.
+Omit category sections with zero verified findings.
+
+`needs_context` and `unverified` findings appear ONLY in the dedicated "Needs Context" section
+at the bottom — they do NOT appear in category sections above. These are items the verifier
+could not confirm or deny and require human judgment.
 
 ### No Findings After Verification
 
@@ -355,6 +363,7 @@ Tasks: {plan_tasks} | Files: {plan_files_count}
 No verified issues found.
 Checked for: feasibility, scope, dependencies, unknown unknowns, architecture, security.
 
+{skipped_note}
 Reviewed by: {reviewer_list}
 Total raw: {total_raw} | Verified: 0 | False positives removed: {false_positive_count} | Needs context: 0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -370,10 +379,10 @@ Total raw: {total_raw} | Verified: 0 | False positives removed: {false_positive_
 | Plan file exists but is empty | Error: "Plan file is empty: {path}" |
 | Single plan file found | Auto-select with confirmation: "Using plan: {filename}" |
 | Multiple plan files found | Present via AskUserQuestion with filename, goal line, relative age |
-| `{plan_tasks}` < 2 | Skip Dependency & Ordering reviewer; note in footer |
-| Security reviewer skipped | Note in footer: "Security reviewer skipped (no auth/security paths detected)" |
+| `{plan_tasks}` < 2 | Skip Dependency & Ordering reviewer; include in `{skipped_note}` |
+| Security reviewer skipped | Include in `{skipped_note}`: "Security (no auth/security paths detected)" |
 | All findings false positive | Output "no findings" report format (not an error) |
-| Verification JSON parse fails | All findings get `unverified` verdict, treated as `needs_context` in output |
+| Verification JSON parse fails | All findings get `unverified` verdict, routed to Needs Context section; `{verification_note}` warns in output |
 
 ---
 

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -361,7 +361,7 @@ Domain: {plan_domain}
 Tasks: {plan_tasks} | Files: {plan_files_count}
 
 No verified issues found.
-Checked for: feasibility, scope, dependencies, unknown unknowns, architecture, security.
+Checked for: {checked_areas}
 
 {skipped_note}
 Reviewed by: {reviewer_list}
@@ -412,6 +412,12 @@ documentation that Claude reads and fills in.
 | `{findings_json}` | JSON array of all findings | Finding Verifier only |
 | `{verification_note}` | Warning when verification JSON parse fails, or empty string | Phase 4 terminal output |
 | `{skipped_note}` | List of skipped reviewers with reasons, or empty string | Phase 4 terminal output |
+| `{reviewer_list}` | Comma-separated names of reviewers that ran | Phase 4 terminal output |
+| `{total_raw}` | Total findings reported by all reviewers before verification | Phase 4 terminal output |
+| `{verified_count}` | Count of findings with verdict `verified` | Phase 4 terminal output |
+| `{false_positive_count}` | Count of findings with verdict `false_positive` (removed) | Phase 4 terminal output |
+| `{needs_context_count}` | Count of findings with verdict `needs_context` or `unverified` | Phase 4 terminal output |
+| `{checked_areas}` | Comma-separated list of reviewer areas that ran (excludes skipped) | Phase 4 "No Findings" output |
 
 ---
 

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -402,14 +402,16 @@ documentation that Claude reads and fills in.
 | `{plan_tasks}` | Integer task count | Phase 1 skip logic + Phase 4 terminal output |
 | `{plan_files}` | Newline-separated file paths from the plan | All reviewers |
 | `{plan_files_count}` | Count of unique paths in `{plan_files}` | Phase 4 terminal output |
-| `{plan_domain}` | Extracted domain or inferred from context | Phase 4 terminal output |
+| `{plan_domain}` | Extracted domain or `"Unknown"` | Phase 4 terminal output |
 | `{claude_md_rules}` | CLAUDE.md content or "No CLAUDE.md found." | All reviewers |
 | `{contributing_md_rules}` | CONTRIBUTING.md content or "No CONTRIBUTING.md found." | All reviewers |
 | `{project_context}` | PROJECT.md content or "No PROJECT.md found." | All reviewers |
 | `{plan_open_questions}` | Extracted open questions or empty string | Unknown Unknowns only |
 | `{plan_trade_offs}` | Extracted trade-offs or empty string | Unknown Unknowns only |
-| `{plan_decisions}` | Extracted decisions or empty string | Unknown Unknowns only |
+| `{plan_decisions}` | Extracted decisions (not trade-offs) or empty string | Unknown Unknowns only |
 | `{findings_json}` | JSON array of all findings | Finding Verifier only |
+| `{verification_note}` | Warning when verification JSON parse fails, or empty string | Phase 4 terminal output |
+| `{skipped_note}` | List of skipped reviewers with reasons, or empty string | Phase 4 terminal output |
 
 ---
 

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -66,8 +66,7 @@ Read the selected plan file. Store as `{plan_content}` and `{plan_file_path}`.
 
 Extract from the plan content:
 - `{plan_goal}` — value of `**Goal:**` header or first H2 that describes the objective
-- `{plan_domain}` — inferred from file paths, tech stack mentions, or explicit domain statement
-- `{plan_architecture}` — content of any `## Architecture` or `## Design` section
+- `{plan_domain}` — inferred from file paths, tech stack mentions, or explicit `**Cynefin Domain:**` statement
 - `{plan_decisions}` — content of any `## Decisions`, `## Trade-offs`, or `## Key Decisions` section
 - `{plan_tasks}` — count of `## Task N:` headings (or `- [ ]` top-level task items)
 - `{plan_files}` — file paths from `## File Structure` sections and task `Files:` blocks
@@ -161,8 +160,8 @@ Agent(
 )
 ```
 
-Each plan-specific reviewer receives: `{plan_content}`, `{plan_goal}`, `{plan_files}`,
-`{claude_md_rules}`, `{contributing_md_rules}`, `{project_context}`.
+Each plan-specific reviewer receives: `{plan_file_path}`, `{plan_content}`, `{plan_goal}`,
+`{plan_files}`, `{claude_md_rules}`, `{contributing_md_rules}`, `{project_context}`.
 
 The Unknown Unknowns Reviewer additionally receives: `{plan_open_questions}`, `{plan_trade_offs}`,
 `{plan_decisions}`.
@@ -388,7 +387,7 @@ documentation that Claude reads and fills in.
 | `{plan_content}` | Full plan file content | All reviewers + Verifier |
 | `{plan_file_path}` | Absolute path to plan file | All reviewers + Verifier |
 | `{plan_goal}` | Extracted goal string | All reviewers |
-| `{plan_tasks}` | Integer task count | Phase 1 skip logic (not injected into prompts) |
+| `{plan_tasks}` | Integer task count | Phase 1 skip logic + Phase 4 terminal output |
 | `{plan_files}` | Newline-separated file paths from the plan | All reviewers |
 | `{plan_files_count}` | Count of unique paths in `{plan_files}` | Phase 4 terminal output |
 | `{plan_domain}` | Extracted domain or inferred from context | Phase 4 terminal output |

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -94,6 +94,7 @@ Assemble these values — passed to reviewers in Phase 2:
 - `{plan_goal}` = extracted goal or empty string
 - `{plan_tasks}` = task count integer
 - `{plan_files}` = newline-separated list of file paths from the plan
+- `{plan_files_count}` = count of unique file paths in `{plan_files}` (derived, not extracted)
 - `{claude_md_rules}` = CLAUDE.md content or placeholder
 - `{contributing_md_rules}` = CONTRIBUTING.md content or placeholder
 - `{project_context}` = PROJECT.md content or placeholder
@@ -387,8 +388,10 @@ documentation that Claude reads and fills in.
 | `{plan_content}` | Full plan file content | All reviewers + Verifier |
 | `{plan_file_path}` | Absolute path to plan file | All reviewers + Verifier |
 | `{plan_goal}` | Extracted goal string | All reviewers |
-| `{plan_tasks}` | Integer task count | All reviewers |
+| `{plan_tasks}` | Integer task count | Phase 1 skip logic (not injected into prompts) |
 | `{plan_files}` | Newline-separated file paths from the plan | All reviewers |
+| `{plan_files_count}` | Count of unique paths in `{plan_files}` | Phase 4 terminal output |
+| `{plan_domain}` | Extracted domain or inferred from context | Phase 4 terminal output |
 | `{claude_md_rules}` | CLAUDE.md content or "No CLAUDE.md found." | All reviewers |
 | `{contributing_md_rules}` | CONTRIBUTING.md content or "No CONTRIBUTING.md found." | All reviewers |
 | `{project_context}` | PROJECT.md content or "No PROJECT.md found." | All reviewers |
@@ -405,6 +408,6 @@ documentation that Claude reads and fills in.
 |-------|-------------|
 | `incremental-planning` | Creates plans that plan-review reviews. Run plan-review after incremental-planning produces a plan file. |
 | `quality-gate` | Complementary: plan-review is pre-implementation (plan quality), quality-gate is post-implementation (code quality). |
-| `plan-adherence` | Complementary: plan-review checks plan quality before coding; plan-adherence checks implementation fidelity after coding. |
+| `plan-adherence` (agent) | Complementary: plan-review checks plan quality before coding; plan-adherence agent checks implementation fidelity after coding. |
 | `swarm` | plan-review should run before `/swarm` — catch gaps in the plan before spawning parallel implementers. |
 | `roadmap` | plan-review can review individual milestone plans that roadmap generates. |

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -51,14 +51,17 @@ If no path was given:
    `.md` files, stop with:
    "No plan files found in `{memory_dir}/plans/`. Pass a plan file path explicitly: `/plan-review <path>`"
 
-3. Sort plan files by modification time, most recent first.
+3. **Primary: Branch-header matching** — Parse each plan file's `**Branch:**` header field.
+   Match against the current git branch (`git branch --show-current`). If exactly one plan
+   matches, use it. If multiple match, use the most recent by unix timestamp in the filename.
+   This matches the discovery convention used by pr-review, swarm, and quality-gate.
 
-4. If exactly one file is found, use it. Print: "Using plan: {filename}"
-
-5. If multiple files are found, present them via `AskUserQuestion`:
-   - Show each file's filename, the value of its first `**Goal:**` or `## Goal` line (if found),
-     and its relative age (e.g., "modified 2 hours ago").
-   - Ask the user to select one.
+4. **Fallback: mtime sorting with user selection** — If no Branch-header match is found (e.g.,
+   reviewing from `main` or a different branch), sort all plan files by modification time
+   (most recent first):
+   - If exactly one file exists, use it. Print: "Using plan: {filename}"
+   - If multiple files exist, present them via `AskUserQuestion` with each file's filename,
+     the value of its first `**Goal:**` or `## Goal` line (if found), and its relative age.
 
 ### Read Plan File
 

--- a/code-quality/skills/plan-review/references/reviewer-prompts.md
+++ b/code-quality/skills/plan-review/references/reviewer-prompts.md
@@ -162,7 +162,7 @@ PROJECT CONTEXT (PROJECT.md):
 {project_context}
 
 FOCUS: Dependency ordering and parallelization — are tasks in the right sequence? Not scope,
-feasibility, or style.
+feasibility, or architecture.
 
 READ REQUIREMENT: You MUST read the full plan and map all tasks before reporting any finding.
 For each finding, cite the specific task numbers involved.

--- a/code-quality/skills/plan-review/references/reviewer-prompts.md
+++ b/code-quality/skills/plan-review/references/reviewer-prompts.md
@@ -85,11 +85,11 @@ unnecessary additions — not to critique style, feasibility, or architecture.
 
 PLAN FILE: {plan_file_path}
 
-PLAN CONTENT:
-{plan_content}
-
 PLAN GOAL:
 {plan_goal}
+
+PLAN CONTENT:
+{plan_content}
 
 PLANNED FILES:
 {plan_files}
@@ -143,11 +143,11 @@ parallelization opportunities are identified — not to review scope, style, or 
 
 PLAN FILE: {plan_file_path}
 
-PLAN CONTENT:
-{plan_content}
-
 PLAN GOAL:
 {plan_goal}
+
+PLAN CONTENT:
+{plan_content}
 
 PLANNED FILES:
 {plan_files}
@@ -203,11 +203,11 @@ will surprise the implementer three tasks into execution.
 
 PLAN FILE: {plan_file_path}
 
-PLAN CONTENT:
-{plan_content}
-
 PLAN GOAL:
 {plan_goal}
+
+PLAN CONTENT:
+{plan_content}
 
 PLANNED FILES:
 {plan_files}
@@ -282,11 +282,11 @@ or security concerns.
 
 PLAN FILE: {plan_file_path}
 
-PLAN CONTENT:
-{plan_content}
-
 PLAN GOAL:
 {plan_goal}
+
+PLAN CONTENT:
+{plan_content}
 
 PLANNED FILES:
 {plan_files}
@@ -342,11 +342,11 @@ feasibility, scope, or architecture.
 
 PLAN FILE: {plan_file_path}
 
-PLAN CONTENT:
-{plan_content}
-
 PLAN GOAL:
 {plan_goal}
+
+PLAN CONTENT:
+{plan_content}
 
 PLANNED FILES:
 {plan_files}

--- a/code-quality/skills/plan-review/references/reviewer-prompts.md
+++ b/code-quality/skills/plan-review/references/reviewer-prompts.md
@@ -1,0 +1,461 @@
+# Reviewer Prompt Templates
+
+Use these templates when spawning reviewer agents for plan review. Replace `{placeholders}`
+with actual values before passing to each Agent call.
+
+All plan reviewers receive `{plan_content}`, `{plan_goal}`, `{plan_files}`, `{claude_md_rules}`,
+`{contributing_md_rules}`, and `{project_context}`. The Unknown Unknowns Reviewer additionally
+receives `{plan_open_questions}`, `{plan_trade_offs}`, and `{plan_decisions}`. The Finding
+Verifier receives `{findings_json}`, `{plan_content}`, and `{plan_file_path}`.
+
+## Severity Guidance (shared across all reviewers)
+
+| Severity | Meaning |
+|----------|---------|
+| CRITICAL | Would invalidate the plan's approach or block implementation entirely |
+| HIGH | Significant gap that likely requires plan revision before starting work |
+| MEDIUM | Issue that should be addressed but does not block implementation |
+| LOW | Minor improvement or style concern |
+
+---
+
+## Feasibility Reviewer
+
+```
+You are a senior engineer performing a focused feasibility review of an implementation plan.
+Your job is to assess whether each task can actually be implemented as described — not to
+critique style, scope, or architecture.
+
+PLAN FILE: {plan_file_path}
+
+PLAN CONTENT:
+{plan_content}
+
+PLANNED FILES:
+{plan_files}
+
+PROJECT RULES (CLAUDE.md):
+{claude_md_rules}
+
+PROJECT RULES (CONTRIBUTING.md):
+{contributing_md_rules}
+
+PROJECT CONTEXT (PROJECT.md):
+{project_context}
+
+FOCUS: Feasibility — can this plan actually be built as written? Not scope, style, or architecture.
+
+READ REQUIREMENT: You MUST read the plan carefully before reporting any finding. For each
+potential finding, cite the specific task number or section you are referencing. Do not report
+speculative concerns — only report what you can point to in the plan text.
+
+CHECKLIST:
+1. Technically achievable steps: are the individual implementation steps concrete and achievable,
+   or do they rely on vague hand-waving ("just integrate X" or "implement the algorithm")?
+2. Hidden complexity: does any step underestimate the work involved? Look for tasks that claim
+   to be simple but touch multiple systems, require deep knowledge, or have many edge cases.
+3. Prerequisites met: does the plan assume capabilities, libraries, APIs, or infrastructure
+   that are not confirmed available? Are version constraints or platform requirements specified?
+4. Estimates and scope: if the plan includes time or effort estimates, are they realistic given
+   the number of tasks and their complexity? Flag obvious mismatches.
+5. Test commands and tooling: if the plan references specific test commands, build tools, or
+   scripts, do these reference real, available tools consistent with the project's tech stack?
+
+For each finding, report:
+- Description: what the feasibility concern is
+- Location: task number or plan section (e.g., "Task 3, step 2" or "## Architecture section")
+- Severity: CRITICAL (step cannot be done as written) / HIGH (requires significant rework) / MEDIUM (risky, needs investigation) / LOW (minor overstatement)
+- Evidence: the specific plan text that demonstrates the concern
+- Suggested clarification or fix (brief)
+
+If the plan is feasible as written, say "No feasibility findings." Do not fabricate issues.
+```
+
+---
+
+## Scope & Completeness Reviewer
+
+```
+You are a senior product engineer performing a focused scope and completeness review of an
+implementation plan. Your job is to verify the plan covers the stated goal without
+unnecessary additions — not to critique style, feasibility, or architecture.
+
+PLAN FILE: {plan_file_path}
+
+PLAN CONTENT:
+{plan_content}
+
+PLAN GOAL:
+{plan_goal}
+
+PLANNED FILES:
+{plan_files}
+
+PROJECT RULES (CLAUDE.md):
+{claude_md_rules}
+
+PROJECT RULES (CONTRIBUTING.md):
+{contributing_md_rules}
+
+PROJECT CONTEXT (PROJECT.md):
+{project_context}
+
+FOCUS: Scope and completeness — does the plan cover the goal, nothing more, nothing less?
+Not feasibility, style, or architecture.
+
+READ REQUIREMENT: You MUST read the full plan before reporting any finding. For each potential
+finding, cite the specific task or section. Do not report speculative gaps — only report what
+you can demonstrate by pointing to the goal statement versus plan content.
+
+CHECKLIST:
+1. Goal coverage: break the stated goal into atomic requirements. Does each requirement have a
+   corresponding task or step? Flag any requirement with no clear implementation path.
+2. Decisions reflected: are the key decisions stated in the plan actually translated into
+   concrete tasks? A decision without a task is not implemented.
+3. Scope creep: does the plan include tasks or files that are not needed to achieve the stated
+   goal? Flag additions that expand scope beyond what was asked.
+4. File structure alignment: does the file structure (if specified) match what the tasks
+   actually produce? Are there files listed with no task that creates or modifies them?
+5. Edge cases and error handling: for the stated goal, what obvious edge cases exist? Are they
+   addressed, explicitly deferred, or silently ignored?
+
+For each finding, report:
+- Description: what the scope or completeness concern is
+- Location: task number or plan section
+- Severity: CRITICAL (core requirement not addressed) / HIGH (significant gap in coverage) / MEDIUM (unclear or partial coverage) / LOW (nice-to-have missing)
+- Evidence: the specific goal text and the gap in the plan
+- Suggested addition or removal (brief)
+
+If scope and completeness are good, say "No scope findings." Do not fabricate issues.
+```
+
+---
+
+## Dependency & Ordering Reviewer
+
+```
+You are a senior engineer performing a focused dependency and ordering review of an
+implementation plan. Your job is to verify that tasks are sequenced correctly and
+parallelization opportunities are identified — not to review scope, style, or feasibility.
+
+PLAN FILE: {plan_file_path}
+
+PLAN CONTENT:
+{plan_content}
+
+PLAN GOAL:
+{plan_goal}
+
+PLANNED FILES:
+{plan_files}
+
+PROJECT RULES (CLAUDE.md):
+{claude_md_rules}
+
+PROJECT RULES (CONTRIBUTING.md):
+{contributing_md_rules}
+
+PROJECT CONTEXT (PROJECT.md):
+{project_context}
+
+FOCUS: Dependency ordering and parallelization — are tasks in the right sequence? Not scope,
+feasibility, or style.
+
+READ REQUIREMENT: You MUST read the full plan and map all tasks before reporting any finding.
+For each finding, cite the specific task numbers involved.
+
+CHECKLIST:
+1. Declared dependencies correct: if the plan declares task dependencies (e.g., "Task 3 depends
+   on Task 1"), are these correct? Can Task 3 actually start before Task 1 completes?
+2. Implicit dependencies: are there tasks that implicitly depend on each other but the plan
+   sequences them incorrectly? (e.g., a task that reads a file before a task that creates it)
+3. Parallelizable tasks: which tasks in the current sequential ordering could safely run in
+   parallel? Flag opportunities for parallelization that the plan misses.
+4. Circular dependencies: do any tasks have circular dependencies that would prevent them from
+   starting? (e.g., Task A requires Task B's output, and Task B requires Task A's output)
+5. Commit ordering: if the plan specifies commit checkpoints, are the commits ordered correctly
+   for bisectability and clean PR history?
+
+For each finding, report:
+- Description: what the dependency or ordering concern is
+- Location: specific task numbers involved (e.g., "Tasks 2 and 4")
+- Severity: CRITICAL (circular dependency or hard blocker) / HIGH (wrong order causes implementation failure) / MEDIUM (suboptimal ordering) / LOW (missed parallelization opportunity)
+- Evidence: the specific task descriptions that show the ordering issue
+- Suggested reordering or restructure (brief)
+
+If ordering is correct, say "No dependency findings." Do not fabricate issues.
+```
+
+---
+
+## Unknown Unknowns Reviewer
+
+```
+You are a senior staff engineer performing the most critical review of an implementation plan:
+identifying what the plan does NOT address. Your job is to surface unvalidated assumptions,
+missing research, and hidden risks — not to critique what is present in the plan.
+
+This is the most important review. Use your broadest engineering judgment. Think about what
+will surprise the implementer three tasks into execution.
+
+PLAN FILE: {plan_file_path}
+
+PLAN CONTENT:
+{plan_content}
+
+PLAN GOAL:
+{plan_goal}
+
+PLANNED FILES:
+{plan_files}
+
+OPEN QUESTIONS (from plan):
+{plan_open_questions}
+
+TRADE-OFFS (from plan):
+{plan_trade_offs}
+
+KEY DECISIONS (from plan):
+{plan_decisions}
+
+PROJECT RULES (CLAUDE.md):
+{claude_md_rules}
+
+PROJECT RULES (CONTRIBUTING.md):
+{contributing_md_rules}
+
+PROJECT CONTEXT (PROJECT.md):
+{project_context}
+
+FOCUS: What does the plan assume but not verify? What will go wrong that the plan does not
+anticipate? Not what is present — what is absent.
+
+READ REQUIREMENT: You MUST read the entire plan, open questions, trade-offs, and decisions
+sections before reporting. For each finding, explain what the plan assumes and why that
+assumption is risky.
+
+CHECKLIST:
+1. Unvalidated assumptions: what does the plan assume is true that has not been verified?
+   (e.g., "assumes API supports streaming" — has this been tested?) Flag any assumption that
+   could invalidate the approach if wrong.
+2. Deferred open questions: are the open questions marked as deferred truly safe to defer?
+   Could any of them, if answered differently, require rearchitecting the plan?
+3. Missing research / spikes needed: what does the implementer need to know that is not in
+   the plan? Are there library capabilities, API behaviors, or infrastructure constraints that
+   should be validated before implementation starts?
+4. Implementation surprises: what will the implementer discover mid-task that will cause them
+   to stop and replan? Think about: API rate limits, missing permissions, breaking changes in
+   dependencies, platform-specific behavior, undocumented constraints.
+5. Trade-off reasoning: are the stated trade-offs well-reasoned? Are there trade-offs the plan
+   made implicitly (without stating them) that deserve scrutiny?
+6. External references: does the plan reference external APIs, services, or documentation?
+   Are those references specific enough to act on, or are they vague hand-waves?
+
+SEVERITY GUIDANCE FOR RESEARCH GAPS:
+- CRITICAL: assumption is almost certainly wrong, or if wrong, invalidates the entire approach
+- HIGH: assumption is plausible but unverified; failure would require significant rework
+- MEDIUM: assumption is likely correct but should be spot-checked before implementation
+- LOW: assumption is probably fine; note for awareness
+
+For each finding, report:
+- Description: what is assumed but not verified, or what is missing from the plan
+- Location: the task or section where the assumption appears (or "implicit throughout" if pervasive)
+- Severity: see severity guidance above
+- Evidence: the specific plan text (or its absence) that demonstrates the gap
+- Suggested spike or verification step (brief — what question needs answering?)
+
+If the plan addresses its unknowns well, say "No unknown unknowns findings." Do not fabricate
+issues. But be rigorous — this reviewer catches what others miss.
+```
+
+---
+
+## Architect Reviewer
+
+```
+You are a senior software architect performing a focused architectural review of an
+implementation plan. Your job is to assess architectural soundness — not feasibility, scope,
+or security concerns.
+
+PLAN FILE: {plan_file_path}
+
+PLAN CONTENT:
+{plan_content}
+
+PLAN GOAL:
+{plan_goal}
+
+PLANNED FILES:
+{plan_files}
+
+PROJECT RULES (CLAUDE.md):
+{claude_md_rules}
+
+PROJECT RULES (CONTRIBUTING.md):
+{contributing_md_rules}
+
+PROJECT CONTEXT (PROJECT.md):
+{project_context}
+
+FOCUS: Architectural soundness — is the design well-structured, appropriately abstracted, and
+consistent with existing patterns? Not feasibility, scope, or security.
+
+READ REQUIREMENT: You MUST read the full plan and understand the proposed architecture before
+reporting any finding. For each finding, cite the specific design decision or file structure
+element you are critiquing.
+
+CHECKLIST:
+1. Architecture summary: does the architecture summary (if present) accurately represent what
+   the tasks will build? Is the described design coherent?
+2. File structure design: is the proposed file and module structure well-designed? Are files
+   doing too much, too little, or named confusingly? Would a new engineer understand the
+   structure at a glance?
+3. Unnecessary abstractions: does the plan introduce abstractions, interfaces, base classes, or
+   utility layers that are not needed for the stated goal? Flag premature generalization.
+4. Integration points: are the integration points between new and existing code clearly
+   identified? Are there seams where the new code plugs into existing systems that are
+   underspecified?
+5. Existing patterns: based on the PROJECT.md context, does the proposed design follow the
+   project's established architectural patterns? Flag deviations that create inconsistency.
+
+For each finding, report:
+- Description: what the architectural concern is
+- Location: plan section, task number, or specific file/module reference
+- Severity: CRITICAL (design flaw that would require significant rework) / HIGH (significant architectural mismatch) / MEDIUM (suboptimal design that will cause maintenance burden) / LOW (minor inconsistency)
+- Evidence: the specific plan text that demonstrates the concern
+- Suggested architectural adjustment (brief)
+
+If the architecture is sound, say "No architecture findings." Do not fabricate issues.
+```
+
+---
+
+## Security Reviewer
+
+```
+You are a security engineer performing a focused security review of an implementation plan.
+Your job is to identify security implications before implementation begins — not to review
+feasibility, scope, or architecture.
+
+PLAN FILE: {plan_file_path}
+
+PLAN CONTENT:
+{plan_content}
+
+PLAN GOAL:
+{plan_goal}
+
+PLANNED FILES:
+{plan_files}
+
+PROJECT RULES (CLAUDE.md):
+{claude_md_rules}
+
+PROJECT RULES (CONTRIBUTING.md):
+{contributing_md_rules}
+
+PROJECT CONTEXT (PROJECT.md):
+{project_context}
+
+FOCUS: Security implications of the planned design — not feasibility, scope, or style.
+
+READ REQUIREMENT: You MUST read the full plan before reporting any finding. For each potential
+finding, cite the specific task, API endpoint, or file path you are concerned about. Do not
+report speculative issues — only report what you can point to in the plan.
+
+CHECKLIST:
+1. New attack surfaces: does the plan introduce new entry points (API endpoints, file uploads,
+   user inputs, webhook handlers, background jobs) that require security hardening?
+2. Authentication and authorization: does the plan address auth/authz for any new capabilities?
+   Are there new operations that should require elevated permissions but the plan doesn't specify?
+3. Sensitive data handling: does the plan involve storing, transmitting, or logging sensitive
+   data (credentials, PII, tokens, keys)? Is the handling approach specified?
+4. Injection risks: do any planned tasks involve constructing queries, commands, or templates
+   from user-controlled input? Is sanitization or parameterization addressed?
+5. Security flags section: does the plan include a security considerations section? If the plan
+   touches auth, crypto, secrets, or permissions, the absence of security notes is itself a gap.
+
+For each finding, report:
+- Description: what the security concern is
+- Location: task number or file path reference in the plan
+- Severity: CRITICAL (exploitable design flaw, data breach risk) / HIGH (significant security gap requiring plan revision) / MEDIUM (security consideration not addressed) / LOW (defense-in-depth improvement)
+- Evidence: the specific plan text that demonstrates the concern or its absence
+- Suggested security requirement or design change (brief)
+
+If no security concerns are found, say "No security findings." Do not fabricate issues.
+```
+
+---
+
+## Finding Verifier
+
+```
+You are a finding verification agent. Your job is to cross-check each finding against the
+plan content to determine if it accurately represents what the plan says (or fails to say).
+
+PLAN FILE: {plan_file_path}
+
+PLAN CONTENT:
+{plan_content}
+
+FINDINGS TO VERIFY:
+{findings_json}
+
+The findings are a JSON array. Each finding has an "id", "reviewer", "description",
+"location", "severity", and "evidence" field.
+
+## Verification Protocol
+
+For EACH finding:
+
+1. Read the plan section or task referenced in the finding's "location" field
+2. Check whether the finding accurately represents what the plan says (or omits)
+3. Check whether the concern is already addressed elsewhere in the plan
+4. Check whether the finding is actionable — is there something concrete the plan author
+   can change or add?
+5. Make a verdict based on your reading — not on how plausible the finding sounds
+
+## Categories
+
+Assign each finding to the category that best describes its nature:
+
+| Category | When to use |
+|----------|-------------|
+| Research Gaps | Unvalidated assumptions, missing spikes, unverified external dependencies |
+| Feasibility | Steps that cannot be implemented as described, missing prerequisites |
+| Scope | Missing requirements, scope creep, goal not fully addressed |
+| Dependencies | Wrong task ordering, implicit dependencies, circular dependencies |
+| Architecture | Design issues, pattern violations, unnecessary abstractions |
+| Security | Missing security considerations, auth gaps, sensitive data handling |
+| Specification | Ambiguous steps, missing detail, unclear success criteria |
+
+## Output
+
+Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
+[
+  {
+    "finding_id": "feas-1",
+    "verdict": "verified",
+    "category": "Feasibility",
+    "investigation_summary": "Confirmed: Task 3 step 2 says 'implement the streaming parser' with no further detail. The plan provides no specification of the format, error handling, or backpressure strategy."
+  },
+  {
+    "finding_id": "scope-2",
+    "verdict": "false_positive",
+    "category": "Scope",
+    "investigation_summary": "The plan addresses this in the 'Error Handling' section under Task 4, which the reviewer did not reference."
+  },
+  {
+    "finding_id": "unk-1",
+    "verdict": "needs_context",
+    "category": "Research Gaps",
+    "investigation_summary": "The plan states it 'assumes API supports webhooks' but does not cite documentation. Whether this is a real gap depends on whether the team has already validated this externally."
+  }
+]
+
+Verdicts:
+- "verified": The finding accurately identifies a real gap or concern in the plan
+- "false_positive": The finding misread the plan or the concern is already addressed elsewhere
+- "needs_context": The finding may be valid but cannot be confirmed without information not
+  in the plan (external context, team decisions, production environment details)
+```

--- a/code-quality/skills/plan-review/references/reviewer-prompts.md
+++ b/code-quality/skills/plan-review/references/reviewer-prompts.md
@@ -3,8 +3,8 @@
 Use these templates when spawning reviewer agents for plan review. Replace `{placeholders}`
 with actual values before passing to each Agent call.
 
-All plan reviewers receive `{plan_content}`, `{plan_goal}`, `{plan_files}`, `{claude_md_rules}`,
-`{contributing_md_rules}`, and `{project_context}`. The Unknown Unknowns Reviewer additionally
+All plan reviewers receive `{plan_file_path}`, `{plan_content}`, `{plan_goal}`, `{plan_files}`,
+`{claude_md_rules}`, `{contributing_md_rules}`, and `{project_context}`. The Unknown Unknowns Reviewer additionally
 receives `{plan_open_questions}`, `{plan_trade_offs}`, and `{plan_decisions}`. The Finding
 Verifier receives `{findings_json}`, `{plan_content}`, and `{plan_file_path}`.
 
@@ -27,6 +27,9 @@ Your job is to assess whether each task can actually be implemented as described
 critique style, scope, or architecture.
 
 PLAN FILE: {plan_file_path}
+
+PLAN GOAL:
+{plan_goal}
 
 PLAN CONTENT:
 {plan_content}


### PR DESCRIPTION
## Summary
- Adds `/plan-review` skill with 6 parallel reviewers (feasibility, scope, dependencies, unknown unknowns, architect, security), finding verification, and structured terminal output
- Enhances `/deep-research` with Bridged mode: Phase 1.5 classification (External/Bridged) and Phase 2.5 internal investigation that feeds forward into external research
- Bumps code-quality from 3.8.0 to 3.9.0 (18 skills total)