### PR TITLE
feat(code-quality): finding classification anti-deferral system

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.9.0",
+      "version": "3.10.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/agents/architect.md
+++ b/code-quality/agents/architect.md
@@ -67,6 +67,9 @@ Expert software architect with deep experience in distributed systems, microserv
    - Prefer removal over addition — if the new design replaces existing code,
      explicitly flag the old code for deletion in the plan
 
+## Finding Classification
+Use the classification and anti-deferral principle from `code-quality/references/finding-classification.md`.
+
 ## Output Format
 
 When providing architecture recommendations:

--- a/code-quality/agents/code-reviewer.md
+++ b/code-quality/agents/code-reviewer.md
@@ -10,6 +10,9 @@ tools: Read, Glob, Grep, LSP
 You are a senior engineer performing a holistic code quality review — style, maintainability,
 readability, plan alignment, and project convention compliance.
 
+## Finding Classification
+Use the classification and anti-deferral principle from `code-quality/references/finding-classification.md`.
+
 When reviewing completed work, you will:
 
 1. **Plan Alignment Analysis**:
@@ -37,10 +40,10 @@ When reviewing completed work, you will:
    - For any doc changes, assume the docs are wrong. Verify every documented claim against the
      actual codebase — use Read and Glob to check on-disk reality, not just what appears in the
      diff. If docs say "15 skills" — run `Glob("skills/*/SKILL.md")` and count.
-   - Documentation that matches the plan but not the implementation is a HIGH severity finding.
+   - Documentation that matches the plan but not the implementation is a needs-fix finding.
 
 5. **Issue Identification and Recommendations**:
-   - Categorize issues as: Critical (must fix), Important (should fix), or Suggestions (nice to have)
+   - Classify findings per `code-quality/references/finding-classification.md`: each finding is either needs-fix or needs-input.
    - For each issue, provide specific examples and actionable recommendations
    - When you identify plan deviations, explain whether they're problematic or beneficial
    - Suggest specific improvements with code examples when helpful

--- a/code-quality/agents/code-simplifier.md
+++ b/code-quality/agents/code-simplifier.md
@@ -14,6 +14,9 @@ behavior. You prioritize readable, explicit code over compact solutions.
 you encounter complexity, your first question is "can this be deleted?" — not "how can this
 be refactored?" Deletion is always simpler than refactoring.
 
+## Finding Classification
+Use the classification and anti-deferral principle from `code-quality/references/finding-classification.md`.
+
 ## Preserve Functionality
 
 Never change what the code does — only how it does it. All original features, outputs, and

--- a/code-quality/agents/performance.md
+++ b/code-quality/agents/performance.md
@@ -20,6 +20,9 @@ Performance engineering specialist focused on profiling, optimization, and bottl
 - Network optimization
 - Algorithm optimization
 
+## Finding Classification
+Use the classification and anti-deferral principle from `code-quality/references/finding-classification.md`.
+
 ## Core Principles
 
 1. **Measure first**: Never optimize without profiling data
@@ -158,7 +161,7 @@ Performance engineering specialist focused on profiling, optimization, and bottl
    - Solution: [Approach]
    - Expected improvement: [Metrics]
 
-### Low Priority
+### Other Optimizations
 1. [Micro-optimization that may not be worth it]
 
 ## Trade-offs

--- a/code-quality/agents/plan-adherence.md
+++ b/code-quality/agents/plan-adherence.md
@@ -10,6 +10,9 @@ tools: Read, Glob, Grep, Bash, LSP, AskUserQuestion, SendMessage
 
 Dedicated plan adherence verification agent. Given a plan file and implementation artifacts, you extract every task and checkbox from the plan, verify each against the actual implementation, and escalate any unverified or unchecked items.
 
+## Finding Classification
+Use the classification and anti-deferral principle from `code-quality/references/finding-classification.md`.
+
 ## Input
 
 You receive the following when invoked:
@@ -31,7 +34,7 @@ Read the plan file and extract all task sections. Plans may use various structur
 - `- [ ]` checkbox steps under task headings
 - `- [x]` checkbox steps that are already marked complete
 
-If no task sections or checkboxes are extractable from the plan file, report this as a HIGH finding: "Plan file found but no parseable tasks detected" — do NOT silently pass.
+If no task sections or checkboxes are extractable from the plan file, report this as a needs-fix finding: "Plan file found but no parseable tasks detected" — do NOT silently pass.
 
 ### Step 2: Verify Each Task and Step
 
@@ -70,7 +73,7 @@ For each task or step that is UNVERIFIED or NOT FOUND, immediately use AskUserQu
 Do this per unverified item — do not batch into a single question unless tasks are clearly dependent.
 
 **Non-interactive fallback:** If AskUserQuestion is unavailable (e.g., non-interactive context,
-swarm Phase 4, or permission mode blocks it), report all UNVERIFIED items as CRITICAL findings in
+swarm Phase 4, or permission mode blocks it), report all UNVERIFIED items as needs-fix findings in
 the output report instead of escalating interactively.
 
 ## Output Format
@@ -125,5 +128,5 @@ Tasks completed but checkbox not checked: [list] — orchestrator should update 
 
 - **Completed but checkbox not checked**: If you find strong evidence an item is implemented but the plan still shows `- [ ]`, report it in the "Agent Note" section for the orchestrator to update. Do NOT write to the plan file yourself.
 - **Partial completion**: Report exactly which sub-steps are done and which are missing.
-- **Unparseable plan**: No task sections or no checkboxes found → HIGH finding, not a silent pass.
+- **Unparseable plan**: No task sections or no checkboxes found → needs-fix finding, not a silent pass.
 - **Missing plan file**: If the plan file path does not exist or is unreadable, report as CRITICAL: "Plan file not found at [path]" and halt verification.

--- a/code-quality/agents/qa.md
+++ b/code-quality/agents/qa.md
@@ -61,6 +61,9 @@ Senior QA engineer and code quality specialist focused on test strategy, maintai
 - **Slow tests** (impacting development velocity)
 - **Test smells** (duplicated setup, assertion-free tests)
 
+## Finding Classification
+Use the classification and anti-deferral principle from `code-quality/references/finding-classification.md`.
+
 ## Review Approach
 
 1. **Holistic review**
@@ -71,9 +74,9 @@ Senior QA engineer and code quality specialist focused on test strategy, maintai
    - Suggest improvements, not just criticisms
    - Provide examples of better approaches
 
-3. **Prioritize issues**
-   - Critical bugs > maintainability > style
-   - Focus on what matters most
+3. **Process all findings**
+   - All findings are classified as needs-fix or needs-input — no deprioritization by category
+   - Focus on actionable, specific feedback
 
 ## Output Format
 
@@ -96,10 +99,7 @@ Senior QA engineer and code quality specialist focused on test strategy, maintai
 
 ## Issues Found
 
-### Critical
-None found.
-
-### Major
+### Needs Fix
 1. **[Issue Title]** - `file.py:45`
    - Problem: [Description]
    - Impact: [Why it matters]
@@ -111,14 +111,10 @@ None found.
    ...
    ```
 
-### Minor
+### Needs Input
 1. **[Issue Title]** - `file.py:78`
    - Problem: [Description]
-   - Suggestion: [How to fix]
-
-### Suggestions
-1. Consider extracting [function] to improve testability
-2. Add docstrings to public methods
+   - Question: [What decision is needed]
 
 ## Test Coverage Assessment
 
@@ -189,10 +185,8 @@ None found.
     "performance": 5
   },
   "issues": {
-    "critical": 0,
-    "major": 2,
-    "minor": 5,
-    "suggestions": 3
+    "needs_fix_count": 2,
+    "needs_input_count": 5
   },
   "technical_debt_items": 2,
   "recommendations": [

--- a/code-quality/agents/security.md
+++ b/code-quality/agents/security.md
@@ -20,6 +20,9 @@ Senior application security engineer specializing in secure coding practices, vu
 - Input validation and output encoding
 - Security headers and configurations
 
+## Finding Classification
+Use the classification and anti-deferral principle from `code-quality/references/finding-classification.md`.
+
 ## Security Review Approach
 
 1. **Threat modeling**
@@ -94,8 +97,8 @@ Senior application security engineer specializing in secure coding practices, vu
 ```markdown
 # Security Finding: [Title]
 
-## Risk Level
-**Critical** | **High** | **Medium** | **Low** | **Info**
+## Classification
+**needs-fix** | **needs-input**
 
 ## Finding
 [Description of the vulnerability]
@@ -134,16 +137,6 @@ cursor.execute(query, (user_id,))
 - [CWE Link]
 ```
 
-## Risk Ratings
-
-| Level | Criteria | Examples |
-|-------|----------|----------|
-| **Critical** | Remote code execution, auth bypass, data breach | SQL injection, RCE, auth bypass |
-| **High** | Significant data exposure, privilege escalation | Stored XSS, IDOR, session hijacking |
-| **Medium** | Limited data exposure, requires user interaction | Reflected XSS, CSRF, info disclosure |
-| **Low** | Minor impact, requires specific conditions | Verbose errors, missing headers |
-| **Info** | Best practice recommendations | Hardening suggestions |
-
 ## Common Secure Patterns
 
 ### Input Validation
@@ -181,17 +174,12 @@ api_key = os.environ.get('API_KEY')
 {
   "status": "success",
   "total_findings": 5,
-  "by_severity": {
-    "critical": 0,
-    "high": 1,
-    "medium": 2,
-    "low": 1,
-    "info": 1
-  },
+  "needs_fix_count": 1,
+  "needs_input_count": 4,
   "findings": [
     {
       "title": "SQL Injection in user lookup",
-      "severity": "high",
+      "classification": "needs-fix",
       "file": "src/api/users.py",
       "line": 45,
       "cwe": "CWE-89"

--- a/code-quality/agents/test-runner.md
+++ b/code-quality/agents/test-runner.md
@@ -8,6 +8,9 @@ color: green
 
 You are a specialized test execution agent focused on running pytest and pre-commit workflows efficiently. Your primary goal is to minimize wasted time by using sequential execution and targeted re-runs.
 
+## Finding Classification
+Use the classification and anti-deferral principle from `code-quality/references/finding-classification.md`.
+
 ## Scope
 
 **This agent RUNS tests, it does NOT fix code.**

--- a/code-quality/references/finding-classification.md
+++ b/code-quality/references/finding-classification.md
@@ -1,0 +1,135 @@
+# Finding Classification
+
+Canonical reference for finding classification, LoE estimation, and Fixer protocol. Referenced by
+the quality-gate (Rounds 2–4), swarm Fixer phase, unfuck implementation agents, and orchestration
+verification.
+
+## Anti-Deferral Principle
+
+Every finding is work that needs doing. You do not self-prioritize. When given findings, you process
+ALL of them. Your assessment of a finding's importance is not a valid reason to defer. The only
+valid reasons to not address a finding are: (1) a specific, documented technical blocker you cannot
+resolve, or (2) the user explicitly excluded it via AskUserQuestion.
+
+## Finding Classification
+
+Two-tier taxonomy:
+
+- `needs-fix`: The reviewer has sufficient context to describe the problem AND the fix is within the
+  agent's capability to resolve independently. No user decision required.
+- `needs-input`: The fix requires a decision the agent cannot make alone — architectural choice,
+  scope decision, external dependency, user preference, or the fix would change behavior in ways the
+  user should approve. The agent reports the finding with an LoE estimate; the user decides.
+
+**Classification guidance for reviewers:**
+
+- Default to `needs-fix`. Only use `needs-input` when you genuinely cannot determine the correct
+  resolution.
+- "I'm not sure if this is worth fixing" is NOT `needs-input` — it's `needs-fix`. Your opinion of
+  worth is irrelevant.
+- "This requires an architectural decision" IS `needs-input`.
+- "This is stylistic" is `needs-fix` — apply the project's conventions.
+
+## Level of Effort (LoE) Scale
+
+Required for Fixer-pipeline skills (swarm, quality-gate, unfuck). Optional for advisory skills.
+
+- `trivial`: One-liner or mechanical change. No judgment required. (e.g., rename, add import, fix
+  typo)
+- `moderate`: Multi-file or requires reading context. Some judgment. (e.g., refactor function, add
+  error handling, write test)
+- `significant`: Architectural impact or cross-cutting concern. Substantial judgment. (e.g.,
+  redesign interface, add new module, change data flow)
+
+## ReviewFindings Schema
+
+Canonical JSON schema for reviewer output:
+
+```json
+{
+  "schema": "ReviewFindings",
+  "reviewer": "string",
+  "timestamp": "string — ISO 8601",
+  "summary": {
+    "total_findings": "integer",
+    "needs_fix_count": "integer",
+    "needs_input_count": "integer",
+    "verdict": "clean | findings"
+  },
+  "findings": [
+    {
+      "id": "string — unique ID with reviewer prefix",
+      "classification": "needs-fix | needs-input",
+      "loe": "trivial | moderate | significant — required for Fixer-pipeline, optional for advisory",
+      "category": "string",
+      "file": "string",
+      "line": "integer | null",
+      "description": "string",
+      "evidence": "string",
+      "suggested_fix": "string",
+      "risk": "string — what could go wrong if not addressed",
+      "input_needed": "string | null — what decision the user must make (required when classification is needs-input)"
+    }
+  ]
+}
+```
+
+## FixSummary Schema
+
+Canonical JSON schema for Fixer output:
+
+```json
+{
+  "schema": "FixSummary",
+  "findings_fixed": ["string — finding IDs"],
+  "needs_input_items": [
+    {
+      "id": "string",
+      "loe": "trivial | moderate | significant",
+      "description": "string",
+      "input_needed": "string — what decision the user must make",
+      "suggested_action": "string — what the Fixer recommends"
+    }
+  ],
+  "user_deferred": [
+    {
+      "id": "string",
+      "reason": "string — user's stated reason for deferral"
+    }
+  ],
+  "fixes": [
+    {
+      "finding_id": "string",
+      "description": "string",
+      "file": "string",
+      "line_range": "string | null"
+    }
+  ],
+  "files_modified": ["string"]
+}
+```
+
+## Fixer Protocol
+
+How the Fixer processes findings:
+
+1. Process all `needs-fix` findings (in file order to minimize context switching)
+2. Collect all `needs-input` findings into `needs_input_items` in the FixSummary
+3. Emit FixSummary via SendMessage to the Lead (the Fixer does NOT have AskUserQuestion — only
+   Read, Write, Edit, Glob, Grep, Bash)
+4. The **Lead** (not the Fixer) handles user triage:
+   - Present needs-input items via multiSelect AskUserQuestion with one option per finding
+   - Each option: label = Finding ID, description = "LoE: [X]. [Description]. Suggested: [action]"
+   - User checks items to fix, leaves unchecked items to skip
+   - Checked items: Lead sends back to Fixer (or fixes inline if trivial), adds to `findings_fixed`
+   - Unchecked items: recorded in `user_deferred` with reason "User declined via triage"
+5. After user triage complete: Lead updates the final FixSummary with `user_deferred` entries
+
+## Verification Protocol
+
+Structural enforcement after Fixer completes and user triage is done:
+
+- Count findings-in vs (findings_fixed + user_deferred). Note: user-approved needs-input items
+  appear in `findings_fixed` after the Fixer processes them, so this formula covers all outcomes.
+- Delta > 0 → findings were silently dropped → escalate via AskUserQuestion
+- Delta == 0 → all findings accounted for → proceed

--- a/code-quality/skills/bug-investigation/SKILL.md
+++ b/code-quality/skills/bug-investigation/SKILL.md
@@ -47,6 +47,11 @@ Read {memory_dir}/BUGS.md
 
 ### BUGS.md Template
 
+> **Note on Impact vs Classification:** The `Impact` field (Critical/High/Medium/Low) describes
+> the bug's effect on users — it is NOT finding classification. All bugs are `needs-fix` by
+> definition; Impact conveys urgency and scope. See
+> `code-quality/references/finding-classification.md` for the classification taxonomy.
+
 ```markdown
 # Bug Investigation & Resolution Tracking
 
@@ -61,7 +66,7 @@ and documented here with root cause analysis and resolution plan.
 
 **Status:** Investigating | Root Cause Found | Fix Ready | Fixed
 **Reported:** YYYY-MM-DD
-**Severity:** Critical | High | Medium | Low
+**Impact:** Critical | High | Medium | Low
 
 ### Problem
 <What the user observed — plain language>
@@ -135,7 +140,7 @@ existing BUG entry). Use this exact format:
 
 **Status:** Root Cause Found
 **Reported:** [today's date]
-**Severity:** Critical | High | Medium | Low
+**Impact:** Critical | High | Medium | Low
 
 ### Problem
 <What the user observed — plain language>
@@ -185,7 +190,7 @@ The user wants to keep reporting bugs. Stay out of their way.
 When a background agent completes, summarize in 1-2 sentences:
 
 ```
-BUG-014 complete — [severity]. Root cause: [one sentence]. See BUGS.md for details.
+BUG-014 complete — [impact]. Root cause: [one sentence]. See BUGS.md for details.
 ```
 
 Do NOT dump the full agent report into the conversation.
@@ -196,7 +201,7 @@ When the user is done reporting bugs or asks to review status:
 
 1. Read `{memory_dir}/BUGS.md` and summarize:
    - Total bugs documented
-   - Breakdown by severity (Critical/High/Medium/Low)
+   - Breakdown by impact (Critical/High/Medium/Low)
    - Breakdown by status (Investigating/Root Cause Found/Fix Ready/Fixed)
    - Any agents still running
 
@@ -276,7 +281,7 @@ Mitigation strategies:
 
 ### Completion
 ```
-1. Summarize: "BUG-NNN complete — [severity]. Root cause: [one sentence]"
+1. Summarize: "BUG-NNN complete — [impact]. Root cause: [one sentence]"
 2. Don't dump full report
 ```
 

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -123,7 +123,7 @@ IF total_files <= 20 (or /map-reduce unavailable):
 2. Generate summary statistics:
    - Total files analyzed
    - Issues by category (unused_code, incorrect_usage, duplication, documentation_drift)
-   - Issues by severity (error, warning, info)
+   - Issues by diagnostic level (error, warning, info)
 3. Generate consolidated TODO list
 4. Write {memory_dir}/file-audit/inventory.json
 ```
@@ -205,7 +205,7 @@ Project Memory:
     {
       "type": "unused_code|incorrect_usage|documentation_drift",
       "subtype": "unreferenced_function|deprecated_api|code_doc_mismatch|...",
-      "severity": "error|warning|info",
+      "diagnostic_level": "error|warning|info",
       "location": {"line": 45, "end_line": 67},
       "description": "Human-readable description",
       "evidence": "What evidence supports this (LSP output, Context7 docs, etc)",
@@ -260,7 +260,7 @@ IMPORTANT:
   "summary": {
     "total_files": 150,
     "total_symbols": 1234,
-    "issues_by_severity": {"error": 5, "warning": 23, "info": 45},
+    "issues_by_diagnostic_level": {"error": 5, "warning": 23, "info": 45},
     "issues_by_type": {
       "unused_code": 12,
       "incorrect_usage": 8,
@@ -282,7 +282,7 @@ IMPORTANT:
       "file": "src/auth/login.py",
       "issue_type": "unused_code",
       "action": "Remove `legacy_auth` function",
-      "priority": "medium"
+      "classification": "needs-fix"
     }
   ]
 }
@@ -313,13 +313,13 @@ IMPORTANT:
 
 ---
 
-## Severity Levels
+## Diagnostic Levels
 
-| Severity | Criteria | Action |
-|----------|----------|--------|
-| **error** | Broken code, security vulnerability | Fix immediately |
-| **warning** | Deprecated API, unused code, duplicates | Fix soon |
-| **info** | Style issue, minor optimization | Nice to fix |
+| Diagnostic Level | Criteria | Classification |
+|-----------------|----------|---------------|
+| **error** | Broken code, security vulnerability | Requires immediate action (needs-fix) |
+| **warning** | Deprecated API, unused code, duplicates | Requires action (needs-fix) |
+| **info** | Style issue, minor optimization | Review and decide (needs-input if architectural, needs-fix if stylistic) |
 
 ---
 
@@ -350,7 +350,7 @@ When LSP is unavailable for a file type:
 
 1. **Run incrementally**: For large codebases, audit in directory chunks
 2. **Check queue status**: Use `/file-audit --status` to monitor progress
-3. **Review todos first**: Generated TODOs are prioritized by severity
+3. **Review todos first**: Generated TODOs are ordered by classification (needs-fix before needs-input)
 4. **Trust but verify**: Issues are evidence-based but review before bulk fixes
 5. **Update project memory**: If drift detected, decide whether to update code or docs
 6. **Large projects**: For 20+ files, /map-reduce provides structured chunk tracking, retry-on-failure

--- a/code-quality/skills/file-audit/references/analyzer-prompt.md
+++ b/code-quality/skills/file-audit/references/analyzer-prompt.md
@@ -236,7 +236,7 @@ Return a single JSON object with this exact structure:
       "id": "issue-001",
       "type": "unused_code",
       "subtype": "unreferenced_function",
-      "severity": "warning",
+      "diagnostic_level": "warning",
       "location": {"line": 120, "end_line": 145},
       "symbol": "legacy_authenticate",
       "description": "Function `legacy_authenticate` has zero references in the codebase",

--- a/code-quality/skills/file-audit/references/inventory-schema.json
+++ b/code-quality/skills/file-audit/references/inventory-schema.json
@@ -21,7 +21,7 @@
       "properties": {
         "total_files": { "type": "integer", "minimum": 0 },
         "total_symbols": { "type": "integer", "minimum": 0 },
-        "issues_by_severity": {
+        "issues_by_diagnostic_level": {
           "type": "object",
           "properties": {
             "error": { "type": "integer", "minimum": 0 },
@@ -204,7 +204,7 @@
     },
     "issue": {
       "type": "object",
-      "required": ["type", "severity", "description"],
+      "required": ["type", "diagnostic_level", "description"],
       "properties": {
         "id": {
           "type": "string",
@@ -241,10 +241,10 @@
           ],
           "description": "Specific issue type"
         },
-        "severity": {
+        "diagnostic_level": {
           "type": "string",
           "enum": ["error", "warning", "info"],
-          "description": "Issue severity"
+          "description": "LSP-style diagnostic level (error/warning/info) — distinct from finding classification"
         },
         "location": {
           "type": "object",
@@ -386,7 +386,7 @@
     },
     "todoItem": {
       "type": "object",
-      "required": ["file", "issue_type", "action", "priority"],
+      "required": ["file", "issue_type", "action", "classification"],
       "properties": {
         "file": {
           "type": "string",
@@ -404,10 +404,10 @@
           "type": "string",
           "description": "What action to take"
         },
-        "priority": {
+        "classification": {
           "type": "string",
-          "enum": ["critical", "high", "medium", "low"],
-          "description": "Priority based on severity"
+          "enum": ["needs-fix", "needs-input"],
+          "description": "Finding actionability per code-quality/references/finding-classification.md"
         },
         "category": {
           "type": "string",

--- a/code-quality/skills/file-audit/references/issue-types.md
+++ b/code-quality/skills/file-audit/references/issue-types.md
@@ -10,7 +10,7 @@ Issues related to code that is never used or referenced.
 
 ### unreferenced_function
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** LSP `findReferences` returns zero external references.
 
@@ -30,7 +30,7 @@ Issues related to code that is never used or referenced.
 {
   "type": "unused_code",
   "subtype": "unreferenced_function",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 45, "end_line": 67},
   "symbol": "legacy_authenticate",
   "description": "Function `legacy_authenticate` has zero references in the codebase",
@@ -43,7 +43,7 @@ Issues related to code that is never used or referenced.
 
 ### unreferenced_variable
 
-**Severity:** info
+**Diagnostic Level:** info
 
 **Detection:** LSP `findReferences` returns only the definition, no reads.
 
@@ -62,7 +62,7 @@ Issues related to code that is never used or referenced.
 {
   "type": "unused_code",
   "subtype": "unreferenced_variable",
-  "severity": "info",
+  "diagnostic_level": "info",
   "location": {"line": 23},
   "symbol": "DEBUG_MODE",
   "description": "Variable `DEBUG_MODE` is assigned but never read",
@@ -75,7 +75,7 @@ Issues related to code that is never used or referenced.
 
 ### unreferenced_class
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** LSP `findReferences` returns zero instantiations or subclasses.
 
@@ -89,7 +89,7 @@ Issues related to code that is never used or referenced.
 {
   "type": "unused_code",
   "subtype": "unreferenced_class",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 100, "end_line": 150},
   "symbol": "LegacyUserModel",
   "description": "Class `LegacyUserModel` is never instantiated or extended",
@@ -101,7 +101,7 @@ Issues related to code that is never used or referenced.
 
 ### dead_import
 
-**Severity:** info
+**Diagnostic Level:** info
 
 **Detection:** Import statement exists but imported symbol is never used in file.
 
@@ -119,7 +119,7 @@ Issues related to code that is never used or referenced.
 {
   "type": "unused_code",
   "subtype": "dead_import",
-  "severity": "info",
+  "diagnostic_level": "info",
   "location": {"line": 5},
   "symbol": "unused_helper",
   "description": "Import `unused_helper` is not used in this file",
@@ -131,7 +131,7 @@ Issues related to code that is never used or referenced.
 
 ### unreachable_code
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** Code appears after unconditional return, raise, break, or continue.
 
@@ -145,7 +145,7 @@ Issues related to code that is never used or referenced.
 {
   "type": "unused_code",
   "subtype": "unreachable_code",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 78, "end_line": 82},
   "description": "Code after return statement is unreachable",
   "suggested_fix": "Remove unreachable code or fix control flow"
@@ -160,7 +160,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 
 ### deprecated_api
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** Context7 docs indicate the API is deprecated.
 
@@ -174,7 +174,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 {
   "type": "incorrect_usage",
   "subtype": "deprecated_api",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 67},
   "description": "Using deprecated @validator decorator from Pydantic",
   "evidence": "Context7 docs: '@validator is deprecated since Pydantic v2, use @field_validator'",
@@ -188,7 +188,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 
 ### wrong_signature
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** Context7 docs show different expected parameters.
 
@@ -203,7 +203,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 {
   "type": "incorrect_usage",
   "subtype": "wrong_signature",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 34},
   "description": "bcrypt.hashpw() called with wrong argument order",
   "evidence": "Context7 docs: 'hashpw(password, salt)' but code has 'hashpw(salt, password)'",
@@ -215,7 +215,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 
 ### missing_error_handling
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** Context7 docs show function raises exceptions not caught.
 
@@ -229,7 +229,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 {
   "type": "incorrect_usage",
   "subtype": "missing_error_handling",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 89},
   "description": "requests.get() called without handling ConnectionError, Timeout",
   "evidence": "Context7 docs list Timeout, ConnectionError as common exceptions",
@@ -241,7 +241,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 
 ### type_mismatch
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** LSP hover shows type incompatibility.
 
@@ -255,7 +255,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 {
   "type": "incorrect_usage",
   "subtype": "type_mismatch",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 56},
   "description": "Passing str to function expecting int",
   "evidence": "LSP hover: process_count(count: int) but called with string",
@@ -267,7 +267,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 
 ### security_issue
 
-**Severity:** error
+**Diagnostic Level:** error
 
 **Detection:** Known insecure patterns or Context7 security warnings.
 
@@ -283,7 +283,7 @@ Issues related to incorrect or suboptimal use of libraries and APIs.
 {
   "type": "incorrect_usage",
   "subtype": "security_issue",
-  "severity": "error",
+  "diagnostic_level": "error",
   "location": {"line": 123},
   "description": "SQL query uses string formatting instead of parameterized query",
   "evidence": "f\"SELECT * FROM users WHERE id = {user_id}\" is vulnerable to injection",
@@ -299,7 +299,7 @@ Issues related to duplicated code patterns across files.
 
 ### exact_duplicate
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** Content hash of normalized code matches another file exactly.
 
@@ -312,7 +312,7 @@ Issues related to duplicated code patterns across files.
 {
   "type": "duplication",
   "subtype": "exact_duplicate",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 34, "end_line": 34},
   "description": "Email validation regex duplicated from src/utils/validators.py",
   "evidence": "Identical pattern: ^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
@@ -324,7 +324,7 @@ Issues related to duplicated code patterns across files.
 
 ### near_duplicate
 
-**Severity:** info
+**Diagnostic Level:** info
 
 **Detection:** Structural hash matches with >80% content similarity.
 
@@ -338,7 +338,7 @@ Issues related to duplicated code patterns across files.
 {
   "type": "duplication",
   "subtype": "near_duplicate",
-  "severity": "info",
+  "diagnostic_level": "info",
   "location": {"line": 50, "end_line": 65},
   "description": "Function structurally similar to validate_email in src/auth/validators.py",
   "evidence": "Same AST structure, 85% content similarity",
@@ -350,7 +350,7 @@ Issues related to duplicated code patterns across files.
 
 ### pattern_duplicate
 
-**Severity:** info
+**Diagnostic Level:** info
 
 **Detection:** Same algorithm/pattern implemented in multiple places.
 
@@ -365,7 +365,7 @@ Issues related to duplicated code patterns across files.
 {
   "type": "duplication",
   "subtype": "pattern_duplicate",
-  "severity": "info",
+  "diagnostic_level": "info",
   "location": {"line": 78, "end_line": 95},
   "description": "Retry-with-backoff pattern duplicated from src/api/client.py",
   "suggested_fix": "Use shared retry decorator from src/utils/retry.py"
@@ -380,7 +380,7 @@ Issues where code behavior differs from documented behavior in project memory fi
 
 ### code_doc_mismatch
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** Comparison of actual code behavior vs PROJECT.md claims.
 
@@ -393,7 +393,7 @@ Issues where code behavior differs from documented behavior in project memory fi
 {
   "type": "documentation_drift",
   "subtype": "code_doc_mismatch",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 1, "end_line": 100},
   "description": "PROJECT.md claims rate limiting on all endpoints, but this file has none",
   "code_behavior": "No rate limiting middleware or decorator detected",
@@ -406,7 +406,7 @@ Issues where code behavior differs from documented behavior in project memory fi
 
 ### missing_feature
 
-**Severity:** warning
+**Diagnostic Level:** warning
 
 **Detection:** Feature marked done in TODO.md but not implemented in code.
 
@@ -420,7 +420,7 @@ Issues where code behavior differs from documented behavior in project memory fi
 {
   "type": "documentation_drift",
   "subtype": "missing_feature",
-  "severity": "warning",
+  "diagnostic_level": "warning",
   "location": {"line": 1},
   "description": "TODO.md claims 'password reset flow complete' but no reset endpoint found",
   "documented_behavior": "Password reset flow ({memory_dir}/TODO.md:23, marked complete)",
@@ -433,7 +433,7 @@ Issues where code behavior differs from documented behavior in project memory fi
 
 ### undocumented_feature
 
-**Severity:** info
+**Diagnostic Level:** info
 
 **Detection:** Significant functionality exists without documentation.
 
@@ -447,7 +447,7 @@ Issues where code behavior differs from documented behavior in project memory fi
 {
   "type": "documentation_drift",
   "subtype": "undocumented_feature",
-  "severity": "info",
+  "diagnostic_level": "info",
   "location": {"line": 200, "end_line": 350},
   "symbol": "AdminDashboard",
   "description": "AdminDashboard class (150 lines) not documented in PROJECT.md",
@@ -460,11 +460,11 @@ Issues where code behavior differs from documented behavior in project memory fi
 
 ## Category: style
 
-Style and quality issues (lower priority).
+Style and quality issues. See `code-quality/references/finding-classification.md` for classification guidance.
 
 ### naming_convention
 
-**Severity:** info
+**Diagnostic Level:** info
 
 **Detection:** Symbol name doesn't match language conventions.
 
@@ -477,7 +477,7 @@ Style and quality issues (lower priority).
 
 ### complexity
 
-**Severity:** info
+**Diagnostic Level:** info
 
 **Detection:** Function exceeds complexity thresholds.
 
@@ -490,7 +490,7 @@ Style and quality issues (lower priority).
 
 ### missing_docstring
 
-**Severity:** info
+**Diagnostic Level:** info
 
 **Detection:** Public API without documentation.
 
@@ -503,7 +503,7 @@ Style and quality issues (lower priority).
 
 ### magic_number
 
-**Severity:** info
+**Diagnostic Level:** info
 
 **Detection:** Unexplained numeric/string literals in code.
 
@@ -514,13 +514,13 @@ Style and quality issues (lower priority).
 
 ---
 
-## Severity Reference
+## Diagnostic Level Reference
 
-| Severity | Priority | When to Use |
-|----------|----------|-------------|
-| **error** | Critical | Security issues, broken code, data loss risk |
-| **warning** | High | Deprecated APIs, unused code, duplicates, drift |
-| **info** | Low | Style issues, minor improvements, suggestions |
+| Diagnostic Level | When to Use | Classification |
+|-----------------|-------------|---------------|
+| **error** | Security issues, broken code, data loss risk | needs-fix |
+| **warning** | Deprecated APIs, unused code, duplicates, drift | needs-fix |
+| **info** | Style issues, minor improvements, suggestions | needs-input if architectural; needs-fix if stylistic |
 
 ---
 

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -152,12 +152,12 @@ LEAD (you)
 2. **For analysis workloads:** present the synthesized summary and findings to the user.
    Offer to write a detailed report or create actionable TODO items.
 
-3. **For implementation workloads:** apply changes in priority order (by severity), run tests
-   after each batch, verify nothing regressed. Roll back on test failure.
+3. **For implementation workloads:** apply changes in priority order (needs-fix first, then
+   needs-input), run tests after each batch, verify nothing regressed. Roll back on test failure.
 
 4. **Write final report** to `{run_dir}/map-reduce-report.md` with:
    - Summary statistics (files analyzed, total findings, deduplicated, invalidated)
-   - Per-severity breakdown
+   - Per-classification breakdown (needs-fix / needs-input)
    - Cross-chunk issues (if any)
    - Fidelity warnings (if any)
    - Chunk failure list (if any chunks failed)

--- a/code-quality/skills/map-reduce/references/agent-prompts.md
+++ b/code-quality/skills/map-reduce/references/agent-prompts.md
@@ -79,9 +79,15 @@ For each file in your chunk:
 2. Perform the requested analysis or transformation
 3. Collect findings
 
-### Step 3: Classify Every Finding with a Confidence Level
+### Step 3: Classify Every Finding
 
-This is critical for result quality. Every finding MUST have a `confidence` field:
+This is critical for result quality. Every finding MUST have both a `classification` and a
+`confidence` field.
+
+> **Field distinction:**
+> - `classification` = finding actionability per `code-quality/references/finding-classification.md`.
+>   `needs-fix` = fix is clear and within agent capability. `needs-input` = requires user decision.
+> - `confidence` = mapper certainty given chunk-local view. Independent of classification.
 
 **Use `confidence: "verified"` when:**
 - The finding is entirely self-contained within your chunk
@@ -122,7 +128,7 @@ Format:
   "findings": [
     {
       "id": "MAP-{chunk_id}-001",
-      "severity": "critical | high | medium | low | informational",
+      "classification": "needs-fix | needs-input",
       "confidence": "verified | chunk-local",
       "file": "path/to/file.py",
       "line": 42,
@@ -142,7 +148,7 @@ Format:
 
 After writing your ChunkResult, send a brief summary to the lead via SendMessage:
 ```
-Chunk {chunk_id} complete. Status: complete. Found {N} findings ({X} verified, {Y} chunk-local).
+Chunk {chunk_id} complete. Status: complete. Found {N} findings ({X} needs-fix, {Y} needs-input; {Z} verified, {W} chunk-local).
 Output written to {output_path}. turn_count: {N}
 ```
 
@@ -216,7 +222,7 @@ For every finding with `confidence: "chunk-local"` and description related to a 
 For findings that appear in multiple chunks (same file, same line, same issue type):
 - Merge into a single finding
 - Combine evidence strings from all sources (keep both, separated by " | ")
-- Keep the highest severity across all instances
+- For classification conflicts, prefer `needs-fix` over `needs-input` (more actionable)
 - Record all source chunk_ids in `source_chunks`
 - Never silently drop a finding — if merging loses detail, keep the fuller description
 
@@ -228,10 +234,10 @@ symbol X in its evidence):
 - Record the conflict resolution in `fidelity_warnings`
 - Do NOT report the symbol as unused
 
-### Step 3: Rank by Severity
+### Step 3: Rank by Classification
 
-Sort final findings: critical → high → medium → low → informational. Within each severity
-level, sort by file path for consistency.
+Sort final findings: needs-fix first, then needs-input. Within each classification group,
+sort by file path for consistency.
 
 ### Step 4: Check Cross-Chunk Consistency (implementation workloads)
 
@@ -252,17 +258,12 @@ Format:
   "total_findings": {raw_count_before_dedup},
   "deduplicated_findings": {count_after_dedup},
   "invalidated_findings": {count_of_invalidated_chunk_local},
-  "by_severity": {
-    "critical": 0,
-    "high": 0,
-    "medium": 0,
-    "low": 0,
-    "informational": 0
-  },
+  "needs_fix_count": 0,
+  "needs_input_count": 0,
   "findings": [
     {
       "id": "MAP-chunk-1-001 or MERGED-001",
-      "severity": "critical | high | medium | low | informational",
+      "classification": "needs-fix | needs-input",
       "confidence": "verified",
       "file": "path/to/file.py",
       "line": 42,
@@ -291,7 +292,7 @@ After writing your ReductionResult, send a summary to the lead via SendMessage:
 ```
 Reduction complete. Status: complete.
 Raw findings: {total}, After dedup: {deduplicated}, Invalidated: {invalidated}.
-By severity: critical={N}, high={N}, medium={N}, low={N}, informational={N}.
+By classification: needs-fix={N}, needs-input={N}.
 Fidelity warnings: {count}. Cross-chunk issues: {count}.
 Output written to {output_path}.
 ```

--- a/code-quality/skills/map-reduce/references/communication-schema.md
+++ b/code-quality/skills/map-reduce/references/communication-schema.md
@@ -59,7 +59,7 @@ summary to the Lead via SendMessage when complete.
   "findings": [
     {
       "id": "string — MAP-{chunk_id}-NNN (e.g. MAP-chunk-1-001)",
-      "severity": "critical | high | medium | low | informational",
+      "classification": "needs-fix | needs-input",
       "confidence": "verified | chunk-local",
       "file": "string — file path",
       "line": "integer | null — line number if applicable",
@@ -75,14 +75,17 @@ summary to the Lead via SendMessage when complete.
 }
 ```
 
-**Confidence field semantics:**
-- `verified`: the finding is self-contained within this chunk. No cross-chunk context needed
-  to confirm it. Examples: syntax errors, style violations, security vulnerabilities in internal
-  logic, unused local variables.
-- `chunk-local`: the finding's validity depends on context outside this chunk. The reducer
-  MUST cross-validate before treating it as confirmed. Examples: exported symbol with no
-  references (might be used in another chunk), import from a path not in this chunk (might
-  exist in another chunk).
+**Field semantics:**
+- `classification`: finding actionability per `code-quality/references/finding-classification.md`.
+  `needs-fix` = fix is clear and within agent capability. `needs-input` = requires user decision.
+- `confidence` = mapper certainty given chunk-local view. Distinct from `classification`.
+  - `verified`: the finding is self-contained within this chunk. No cross-chunk context needed
+    to confirm it. Examples: syntax errors, style violations, security vulnerabilities in internal
+    logic, unused local variables.
+  - `chunk-local`: the finding's validity depends on context outside this chunk. The reducer
+    MUST cross-validate before treating it as confirmed. Examples: exported symbol with no
+    references (might be used in another chunk), import from a path not in this chunk (might
+    exist in another chunk).
 
 **Status semantics:**
 - `complete`: mapper processed all assigned files/items successfully
@@ -104,7 +107,7 @@ size limits).
   "completed_chunks": "integer — number of chunks with status 'complete' or 'partial'",
   "failed_chunks": ["string — chunk_ids that returned status 'failed'"],
   "chunk_results_dir": "string — path to {run_dir}/chunks/ directory",
-  "reduction_instructions": "string — how to synthesize: deduplicate, cross-validate, rank by severity, merge evidence",
+  "reduction_instructions": "string — how to synthesize: deduplicate, cross-validate, rank by classification (needs-fix first), merge evidence",
   "output_path": "string — where to write ReductionResult (e.g. 'hack/map-reduce/{run-id}/reduction-result.json')",
   "context": {
     "project": "string — project name",
@@ -134,17 +137,12 @@ summary to the Lead via SendMessage when complete.
   "total_findings": "integer — raw finding count across all chunks before deduplication",
   "deduplicated_findings": "integer — finding count after deduplication",
   "invalidated_findings": "integer — chunk-local findings disproven by cross-chunk validation",
-  "by_severity": {
-    "critical": 0,
-    "high": 0,
-    "medium": 0,
-    "low": 0,
-    "informational": 0
-  },
+  "needs_fix_count": 0,
+  "needs_input_count": 0,
   "findings": [
     {
       "id": "string — original MAP-{chunk_id}-NNN id or MERGED-NNN for merged findings",
-      "severity": "critical | high | medium | low | informational",
+      "classification": "needs-fix | needs-input",
       "confidence": "verified",
       "file": "string — file path",
       "line": "integer | null",

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -203,7 +203,7 @@ unique ID using the prefix for its reviewer:
 | Architect | `arch-` |
 | Security | `sec-` |
 
-Preserve: description, location reference (plan section or task number), severity, evidence,
+Preserve: description, location reference (plan section or task number), classification, evidence,
 source reviewer.
 
 ---
@@ -225,7 +225,7 @@ Build the findings JSON array:
     "reviewer": "Feasibility",
     "description": "...",
     "location": "Task 3, step 2",
-    "severity": "HIGH",
+    "classification": "needs-fix | needs-input",
     "evidence": "..."
   },
   ...
@@ -297,7 +297,7 @@ Findings: {verified_count} verified, {needs_context_count} needs context
   (from {total_raw} raw findings — {false_positive_count} false positives removed)
 
 RESEARCH GAPS
-  1. [{Reviewer}] {description} [{severity}]
+  1. [{Reviewer}] {description} [{classification}]
      {location}
      Evidence: {evidence}
 
@@ -320,7 +320,7 @@ SPECIFICATION
   ...
 
 ─── Needs Context ({needs_context_count}) ───
-  1. [{Reviewer}] {description} [{severity}]
+  1. [{Reviewer}] {description} [{classification}]
      {location}
      Investigation: {investigation_summary}
 
@@ -336,8 +336,8 @@ Total raw: {total_raw} | Verified: {verified_count} | False positives removed: {
 
 Category sections contain only `verified` findings. Group by category in order: RESEARCH GAPS
 (first — highest leverage to fix before implementation) → FEASIBILITY → SCOPE → DEPENDENCIES →
-ARCHITECTURE → SECURITY → SPECIFICATION. Within each category, sort by severity (CRITICAL →
-HIGH → MEDIUM → LOW). For the `[Reviewer]` tag, use the short reviewer name: Feasibility,
+ARCHITECTURE → SECURITY → SPECIFICATION. Within each category, sort by classification (needs-fix
+first, then needs-input). For the `[Reviewer]` tag, use the short reviewer name: Feasibility,
 Scope, Dependencies, Unknown Unknowns, Architect, Security.
 
 Omit category sections with zero verified findings.

--- a/code-quality/skills/plan-review/references/reviewer-prompts.md
+++ b/code-quality/skills/plan-review/references/reviewer-prompts.md
@@ -8,14 +8,14 @@ All plan reviewers receive `{plan_file_path}`, `{plan_content}`, `{plan_goal}`, 
 receives `{plan_open_questions}`, `{plan_trade_offs}`, and `{plan_decisions}`. The Finding
 Verifier receives `{findings_json}`, `{plan_content}`, and `{plan_file_path}`.
 
-## Severity Guidance (shared across all reviewers)
+## Classification Guidance (shared across all reviewers)
 
-| Severity | Meaning |
-|----------|---------|
-| CRITICAL | Would invalidate the plan's approach or block implementation entirely |
-| HIGH | Significant gap that likely requires plan revision before starting work |
-| MEDIUM | Issue that should be addressed but does not block implementation |
-| LOW | Minor improvement or style concern |
+See `code-quality/references/finding-classification.md` for the full classification taxonomy.
+
+- `needs-fix`: The reviewer has sufficient context to describe the problem AND the fix is within
+  the plan author's capability to resolve independently.
+- `needs-input`: The fix requires a decision the reviewer cannot make alone — architectural choice,
+  scope decision, or requires external validation before the plan can proceed.
 
 ---
 
@@ -67,7 +67,7 @@ CHECKLIST:
 For each finding, report:
 - Description: what the feasibility concern is
 - Location: task number or plan section (e.g., "Task 3, step 2" or "## Architecture section")
-- Severity: CRITICAL (step cannot be done as written) / HIGH (requires significant rework) / MEDIUM (risky, needs investigation) / LOW (minor overstatement)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific plan text that demonstrates the concern
 - Suggested clarification or fix (brief)
 
@@ -125,7 +125,7 @@ CHECKLIST:
 For each finding, report:
 - Description: what the scope or completeness concern is
 - Location: task number or plan section
-- Severity: CRITICAL (core requirement not addressed) / HIGH (significant gap in coverage) / MEDIUM (unclear or partial coverage) / LOW (nice-to-have missing)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific goal text and the gap in the plan
 - Suggested addition or removal (brief)
 
@@ -182,7 +182,7 @@ CHECKLIST:
 For each finding, report:
 - Description: what the dependency or ordering concern is
 - Location: specific task numbers involved (e.g., "Tasks 2 and 4")
-- Severity: CRITICAL (circular dependency or hard blocker) / HIGH (wrong order causes implementation failure) / MEDIUM (suboptimal ordering) / LOW (missed parallelization opportunity)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific task descriptions that show the ordering issue
 - Suggested reordering or restructure (brief)
 
@@ -254,16 +254,10 @@ CHECKLIST:
 6. External references: does the plan reference external APIs, services, or documentation?
    Are those references specific enough to act on, or are they vague hand-waves?
 
-SEVERITY GUIDANCE FOR RESEARCH GAPS:
-- CRITICAL: assumption is almost certainly wrong, or if wrong, invalidates the entire approach
-- HIGH: assumption is plausible but unverified; failure would require significant rework
-- MEDIUM: assumption is likely correct but should be spot-checked before implementation
-- LOW: assumption is probably fine; note for awareness
-
 For each finding, report:
 - Description: what is assumed but not verified, or what is missing from the plan
 - Location: the task or section where the assumption appears (or "implicit throughout" if pervasive)
-- Severity: see severity guidance above
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific plan text (or its absence) that demonstrates the gap
 - Suggested spike or verification step (brief — what question needs answering?)
 
@@ -324,7 +318,7 @@ CHECKLIST:
 For each finding, report:
 - Description: what the architectural concern is
 - Location: plan section, task number, or specific file/module reference
-- Severity: CRITICAL (design flaw that would require significant rework) / HIGH (significant architectural mismatch) / MEDIUM (suboptimal design that will cause maintenance burden) / LOW (minor inconsistency)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific plan text that demonstrates the concern
 - Suggested architectural adjustment (brief)
 
@@ -381,7 +375,7 @@ CHECKLIST:
 For each finding, report:
 - Description: what the security concern is
 - Location: task number or file path reference in the plan
-- Severity: CRITICAL (exploitable design flaw, data breach risk) / HIGH (significant security gap requiring plan revision) / MEDIUM (security consideration not addressed) / LOW (defense-in-depth improvement)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific plan text that demonstrates the concern or its absence
 - Suggested security requirement or design change (brief)
 
@@ -405,7 +399,7 @@ FINDINGS TO VERIFY:
 {findings_json}
 
 The findings are a JSON array. Each finding has an "id", "reviewer", "description",
-"location", "severity", and "evidence" field.
+"location", "classification", and "evidence" field.
 
 ## Verification Protocol
 
@@ -440,18 +434,21 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
     "finding_id": "feas-1",
     "verdict": "verified",
     "category": "Feasibility",
+    "classification": "needs-fix",
     "investigation_summary": "Confirmed: Task 3 step 2 says 'implement the streaming parser' with no further detail. The plan provides no specification of the format, error handling, or backpressure strategy."
   },
   {
     "finding_id": "scope-2",
     "verdict": "false_positive",
     "category": "Scope",
+    "classification": "needs-fix",
     "investigation_summary": "The plan addresses this in the 'Error Handling' section under Task 4, which the reviewer did not reference."
   },
   {
     "finding_id": "unk-1",
     "verdict": "needs_context",
     "category": "Research Gaps",
+    "classification": "needs-input",
     "investigation_summary": "The plan states it 'assumes API supports webhooks' but does not cite documentation. Whether this is a real gap depends on whether the team has already validated this externally."
   }
 ]

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -231,7 +231,7 @@ The Plan Adherence Reviewer receives: `{plan_content}`, `{plan_file_path}`, `{di
 
 After all agents complete, collect all findings into a consolidated list. Assign each finding a
 unique ID (e.g., `sec-1`, `qa-1`, `perf-1`, `cq-1`, `cor-1`, `pa-1`). Preserve: description, file:line,
-severity, evidence, source reviewer.
+classification, evidence, source reviewer.
 
 ---
 
@@ -253,7 +253,7 @@ Build the findings JSON array:
     "reviewer": "Security",
     "description": "...",
     "location": "file/path.py:42",
-    "severity": "HIGH",
+    "classification": "needs-fix | needs-input",
     "evidence": "...",
     "diff_context": "±10 lines of diff surrounding the finding location"
   },
@@ -279,7 +279,7 @@ The verifier receives: `{findings_json}` (the array above), `{claude_md_rules}`,
 The verifier **investigates each finding** — it reads the actual source files, traces call
 chains, and checks whether the finding is real. It returns a JSON array with a verdict for
 each finding:
-`[{finding_id, verdict, investigation_summary, category}, ...]`
+`[{finding_id, verdict, investigation_summary, category, classification}, ...]`
 
 Verdicts: `verified` (confirmed real), `false_positive` (investigated and disproven),
 `needs_context` (cannot confirm or deny — requires human judgment).
@@ -290,7 +290,7 @@ and a note: "Verification failed — showing all findings unverified."
 
 ### Categorize
 
-The verifier assigns each finding to a category based on its nature (not its severity):
+The verifier assigns each finding to a category based on its nature (not its classification):
 
 | Category | Examples |
 |----------|----------|
@@ -329,7 +329,7 @@ Findings: {verified_count} verified, {needs_context_count} needs context
   (from {total_raw} raw findings — {false_positive_count} false positives removed)
 
 TESTING GAPS
-  1. [{Reviewer}] {description} [{severity}]
+  1. [{Reviewer}] {description} [{classification}]
      {file}:{line}
      Evidence: {evidence}
 
@@ -352,7 +352,7 @@ STYLE & CONVENTIONS
   ...
 
 ─── Needs Context ({needs_context_count}) ───
-  1. [{Reviewer}] {description} [{severity}]
+  1. [{Reviewer}] {description} [{classification}]
      {file}:{line}
      Investigation: {investigation_summary}
 
@@ -363,7 +363,7 @@ Total raw: {total_raw} | Verified: {verified_count} | False positives removed: {
 
 Group findings by **category** (Testing Gaps → Correctness → Security → Architecture →
 Decisions Needed → Performance → Style & Conventions). Within each category,
-sort by severity (CRITICAL → HIGH → MEDIUM → LOW). For the `[Reviewer]` tag, use the short
+sort by classification (needs-fix first, then needs-input). For the `[Reviewer]` tag, use the short
 reviewer name: Security, QA, Performance, Code Quality, Correctness, Plan Adherence.
 
 Omit category sections with zero findings.

--- a/code-quality/skills/pr-review/references/reviewer-prompts.md
+++ b/code-quality/skills/pr-review/references/reviewer-prompts.md
@@ -49,7 +49,7 @@ CHECKLIST:
 For each finding, report:
 - Description: what the vulnerability is
 - Location: file:line
-- Severity: CRITICAL (exploitable remotely, data loss) / HIGH (exploitable with effort) / MEDIUM (limited impact) / LOW (defense in depth)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific code or configuration that demonstrates the issue
 - Suggested fix (brief)
 
@@ -97,7 +97,7 @@ CHECKLIST:
 For each finding, report:
 - Description: what scenario or path lacks coverage
 - Location: file:line (or "no test file" if coverage is missing entirely)
-- Severity: CRITICAL (core path untested) / HIGH (likely regression path) / MEDIUM (edge case) / LOW (nice to have)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific code path or condition that is not covered
 - Suggested test approach (brief)
 
@@ -145,7 +145,7 @@ CHECKLIST:
 For each finding, report:
 - Description: the performance problem
 - Location: file:line
-- Severity: CRITICAL (blocks scale, causes OOM/timeout) / HIGH (degrades at moderate load) / MEDIUM (noticeable at scale) / LOW (micro-optimization)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific code that demonstrates the issue, with expected impact (scale at which it matters, latency/throughput effect)
 - Suggested fix (brief)
 
@@ -199,7 +199,7 @@ CHECKLIST:
 For each finding, report:
 - Description: the quality concern
 - Location: file:line
-- Severity: CRITICAL (violates explicit CLAUDE.md rule with blocking impact) / HIGH (actively misleading, unmaintainable, or rule violation) / MEDIUM (degrades over time) / LOW (minor polish)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific code or doc text that demonstrates the issue
 - Suggested improvement (brief)
 
@@ -256,12 +256,12 @@ CHECKLIST:
    `Glob("skills/*/SKILL.md")` and count. If docs say "supports X" — search the codebase
    for X. If the PR adds a feature and updates docs, confirm the docs describe what was
    actually implemented, not an idealized version.
-   Documentation that matches the plan but not the implementation is a HIGH severity finding.
+   Documentation that matches the plan but not the implementation is a needs-fix finding.
 
 For each finding, report:
 - Description: what the correctness issue is
 - Location: file:line
-- Severity: CRITICAL (produces wrong results in normal use) / HIGH (wrong under specific conditions) / MEDIUM (subtle incorrectness, edge case) / LOW (technically wrong, low impact)
+- Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
 - Evidence: the specific code that demonstrates the issue, with the expected vs actual behavior
 - Suggested fix (brief)
 
@@ -315,11 +315,7 @@ INSTRUCTIONS:
 5. For each finding, report:
    - Description: what the deviation is
    - Location: file:line (or task reference from the plan)
-   - Severity:
-     CRITICAL = entire task is missing from the implementation
-     HIGH = task is only partially implemented
-     MEDIUM = task implemented differently from the specification
-     LOW = minor deviation with negligible impact
+   - Classification: needs-fix | needs-input (per code-quality/references/finding-classification.md)
    - Evidence: the specific plan text and the diff/code that shows the mismatch
    - Suggested action (brief)
 
@@ -348,7 +344,7 @@ FINDINGS TO VERIFY:
 {findings_json}
 
 The findings are a JSON array. Each finding has an "id" field and includes the finding
-description, location, severity, evidence, and a `diff_context` field with ±10 lines of
+description, location, classification, evidence, and a `diff_context` field with ±10 lines of
 surrounding diff.
 
 ## Investigation Protocol
@@ -384,18 +380,21 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
     "finding_id": "sec-1",
     "verdict": "verified",
     "category": "Security",
+    "classification": "needs-fix",
     "investigation_summary": "Confirmed: user input at line 42 reaches SQL query at line 58 without parameterization. Traced through handle_request -> process_query."
   },
   {
     "finding_id": "qa-2",
     "verdict": "false_positive",
     "category": "Testing Gaps",
+    "classification": "needs-fix",
     "investigation_summary": "Tests exist in tests/unit/test_auth.py:test_login_edge_cases covering this exact path."
   },
   {
     "finding_id": "perf-1",
     "verdict": "needs_context",
     "category": "Decisions Needed",
+    "classification": "needs-input",
     "investigation_summary": "N+1 query exists but dataset size is unclear. Could be 10 rows or 10,000 — performance impact depends on production data volume."
   }
 ]

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -81,7 +81,7 @@ comprehensive coverage from different angles.
 | 1 | **Correctness** | What inputs produce wrong results? What assumptions are untested? |
 | 2 | **Completeness** | What was requested but not delivered? Read the original request word-by-word. Includes documentation completeness (see below). |
 | 3 | **Robustness** | How does this fail? Bad input, missing deps, concurrent access, edge cases? |
-| 4 | **Simplicity (BLOCKING)** | What's over-engineered? What could be deleted? What's AI slop? Dead code, unnecessary abstractions, and unused imports are CRITICAL. |
+| 4 | **Simplicity (BLOCKING)** | What's over-engineered? What could be deleted? What's AI slop? Dead code, unnecessary abstractions, and unused imports are `needs-fix` — blocking. |
 | 5 | **Adversarial** | You are a hostile reviewer. The author claims this is done. Prove them wrong. |
 | 6 | **Structural** | What design flaws, race conditions, or failure modes exist in this system's architecture — not just in the current change, but in how it integrates? (Code/Mixed only) |
 
@@ -97,8 +97,8 @@ work-type-specific lens prompts.
 - **Round 4 (BLOCKING):** Calculate net lines delta (`git diff --stat`). Spawn
   `code-quality:code-simplifier` with the delta as context. Apply the full checklist from
   `code-quality/references/simplification-checklist.md`. Dead code, unnecessary abstractions,
-  and unused imports are CRITICAL findings — they BLOCK proceeding to Round 5. Fix all
-  CRITICAL simplification findings before continuing. These are objectively wasteful, not
+  and unused imports are `needs-fix` findings — they BLOCK proceeding to Round 5. Fix all
+  such simplification findings before continuing. These are objectively wasteful, not
   judgment calls.
 - **Round 5:** First-principles: "State the fundamental purpose in one sentence. Review against
   that purpose, not the structure you created."
@@ -285,17 +285,19 @@ Each reviewer receives:
 
 ### Synthesis Protocol
 
-After all 4 reviewers complete, synthesize findings by severity:
+After all 4 reviewers complete, synthesize findings by classification
+(see `code-quality/references/finding-classification.md`):
 
-1. **Collect** all findings across the 4 reviewers
-2. **Classify** each finding: CRITICAL / HIGH / MEDIUM / LOW
-3. **Fix all CRITICAL and HIGH findings** before proceeding to Layer 2.
-   These are blocking. Do not carry them forward.
-4. **Record MEDIUM and LOW findings** — include them in the output report, fix if
-   straightforward, document as follow-up if genuinely deferred.
+1. Collect all findings across the 4 reviewers
+2. Fix all `needs-fix` findings immediately. Do not carry them forward.
+3. For `needs-input` findings: present via AskUserQuestion with LoE table
+   (ID | Description | LoE | Suggested Action). User decides per-finding:
+   fix or defer. Fix approved items. Record deferred items with user's reason.
+4. Do NOT proceed to Layer 2 until all `needs-fix` items are fixed and all
+   `needs-input` items are resolved via user decision.
 
 **The synthesis step is not optional.** If you find yourself writing "domain review skipped"
-or "findings noted for later," stop. Fix the critical/high findings now.
+or "findings noted for later," stop. Fix the needs-fix findings now.
 
 ---
 
@@ -334,7 +336,7 @@ tasks, the quality gate waits for user responses. User can:
 
 **Failure handling:** If the agent crashes or times out, retry once. If the second attempt
 fails, mark as `[UNREVIEWED]` and proceed with note. If AskUserQuestion is unavailable, report
-unchecked tasks as CRITICAL findings.
+unchecked tasks as `needs-fix` findings.
 
 ---
 
@@ -587,16 +589,16 @@ Layer 1 — Self-Review:
   Issues fixed: [count]
   Identified-but-unactioned caught: [count]
   Project rules violations caught: [count]
-  Round 4 (Simplicity gate): [PASS — 0 CRITICAL | BLOCKED — N CRITICAL fixed]
+  Round 4 (Simplicity gate): [PASS — 0 needs-fix | BLOCKED — N needs-fix fixed]
   Net lines delta: +[added] / -[removed] (net: [+/-X])
 
 Layer 1.5 — Domain Expert Review: [N/A for non-code | COMPLETE]
-  Security reviewer: [count] findings ([critical/high/medium/low breakdown])
-  QA reviewer: [count] findings ([critical/high/medium/low breakdown])
-  Performance reviewer: [count] findings ([critical/high/medium/low breakdown])
-  Code-reviewer: [count] findings ([critical/high/medium/low breakdown])
-  Critical/High fixed before Layer 2: [count]
-  Medium/Low recorded: [count]
+  Security reviewer: [count] findings ([needs-fix/needs-input breakdown])
+  QA reviewer: [count] findings ([needs-fix/needs-input breakdown])
+  Performance reviewer: [count] findings ([needs-fix/needs-input breakdown])
+  Code-reviewer: [count] findings ([needs-fix/needs-input breakdown])
+  needs-fix fixed before Layer 2: [count]
+  needs-input resolved via user decision: [count]
 
 Layer 1.75 — Plan Adherence: [N/A (no plan) | COMPLETE]
   Plan file: [path or "not found"]

--- a/code-quality/skills/quality-gate/references/lens-rubrics.md
+++ b/code-quality/skills/quality-gate/references/lens-rubrics.md
@@ -49,7 +49,7 @@ structure. This file provides the specific questions and techniques for each len
 ### Round 4: Simplicity (BLOCKING)
 
 **This round is a blocking sub-gate.** Dead code, unnecessary abstractions, and unused imports
-are CRITICAL findings that must be fixed before proceeding to Round 5. These are objectively
+are `needs-fix` findings that must be fixed before proceeding to Round 5. These are objectively
 wasteful — not judgment calls.
 
 - Calculate net lines delta: `git diff --stat` on all changes. Pass the delta to the
@@ -63,8 +63,9 @@ wasteful — not judgment calls.
 - For each new dependency or custom implementation: does a well-maintained library solve this?
   (See `code-quality/references/dependency-evaluation.md`)
 - **Tool:** Spawn `code-quality:code-simplifier` for dead code, unused imports, over-abstraction.
-- **Gate:** Fix all CRITICAL simplification findings (dead code, unnecessary abstractions,
-  unused imports) before proceeding. MEDIUM/LOW findings (style, naming) can proceed.
+- **Gate:** Fix all `needs-fix` simplification findings (dead code, unnecessary abstractions,
+  unused imports) before proceeding. `needs-input` findings (architectural decisions) require
+  user confirmation before proceeding.
 
 ### Round 5: Adversarial
 

--- a/code-quality/skills/quality-gate/references/subagent-prompts.md
+++ b/code-quality/skills/quality-gate/references/subagent-prompts.md
@@ -37,7 +37,7 @@ CHECKLIST:
 For each finding, report:
 - Vulnerability type and location (file:line)
 - Attack vector (how an adversary exploits it)
-- Severity: CRITICAL (exploitable remotely, data loss) / HIGH (exploitable with effort) / MEDIUM (limited impact) / LOW (defense in depth)
+- Classification and LoE per `code-quality/references/finding-classification.md`
 - Suggested fix (brief)
 
 If no issues found, say "No security findings." Do not fabricate issues.
@@ -71,7 +71,7 @@ CHECKLIST:
 For each finding, report:
 - What scenario or path lacks coverage
 - Risk if it goes untested
-- Severity: CRITICAL (core path untested) / HIGH (likely regression path) / MEDIUM (edge case) / LOW (nice to have)
+- Classification and LoE per `code-quality/references/finding-classification.md`
 - Suggested test approach (brief)
 
 If coverage is adequate, say "No QA findings." Do not fabricate issues.
@@ -105,7 +105,7 @@ CHECKLIST:
 For each finding, report:
 - The performance problem and location (file:line)
 - Expected impact (scale at which it matters, latency/throughput effect)
-- Severity: CRITICAL (blocks scale, causes OOM/timeout) / HIGH (degrades at moderate load) / MEDIUM (noticeable at scale) / LOW (micro-optimization)
+- Classification and LoE per `code-quality/references/finding-classification.md`
 - Suggested fix (brief)
 
 If no performance issues found, say "No performance findings." Do not fabricate issues.
@@ -140,7 +140,7 @@ CHECKLIST:
 For each finding, report:
 - The quality concern and location (file:line)
 - Why it matters for long-term maintainability
-- Severity: HIGH (actively misleading or unmaintainable) / MEDIUM (degrades over time) / LOW (minor polish)
+- Classification and LoE per `code-quality/references/finding-classification.md`
 - Suggested improvement (brief)
 
 If code quality is good, say "No code quality findings." Do not fabricate issues.
@@ -229,12 +229,12 @@ PLAN FILE (if available):
    in the plan was implemented. For each plan task, check: are all steps completed?
    Were all files in the task's Files section modified? Does the implementation match
    the task's specification?
-   A plan task that is unchecked is a CRITICAL completeness gap — the plan is a contract.
+   A plan task that is unchecked is a `needs-fix` completeness gap — the plan is a contract.
 
 For each issue found, report:
 - What requirement or item is affected
 - What's missing or incomplete
-- Severity: CRITICAL (blocks the request) / HIGH (partial delivery) / MEDIUM (polish)
+- Classification and LoE per `code-quality/references/finding-classification.md`
 
 Be thorough. Assume at least 2 completeness gaps exist. Find them.
 ```
@@ -252,7 +252,7 @@ Review the fixes:
 3. What did YOU miss on your first pass? You had fresh eyes but still have blind spots.
 4. Look at the work holistically now — any remaining gaps?
 
-Report any remaining issues with the same severity format.
+Report any remaining issues with the same classification format.
 ```
 
 ---
@@ -303,7 +303,7 @@ FOCUS AREA FOR ALL WORK TYPES:
 For each issue found, report:
 - The specific problem
 - Why it matters (impact)
-- Severity: CRITICAL / HIGH / MEDIUM
+- Classification and LoE per `code-quality/references/finding-classification.md`
 - Suggested fix (brief)
 
 This work has at least 3 real issues. Find them.

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -117,7 +117,7 @@ After receiving the plan, the Lead MUST:
 2. If `questions` is non-empty, present EVERY question to the user via `AskUserQuestion`
 3. Verify scope: compare the plan's components against the original task — if any requested
    work is missing from the plan, add it back or ask the user via `AskUserQuestion`
-4. Raise any high-severity risks to the user before proceeding
+4. Raise any high-impact risks to the user before proceeding
 5. Note the `cynefin_domain` — use it to inform Phase 2.5 skip decision and pipeline mode
 
 Do NOT proceed to Phase 3 until all architect questions are resolved and scope is verified.
@@ -143,12 +143,11 @@ Output: SecurityDesignReview JSON written to `{run_dir}/security-design-review.j
 (see schema in `references/communication-schema.md`).
 
 **Routing:**
-- Critical/High findings → Route back to Architect (Phase 2) with security feedback for
+- needs-input requiring architectural redesign → Route back to Architect (Phase 2) with security feedback for
   redesign. Architect revises plan, re-run Phase 2.5. Maximum 2 Architect↔Security iterations.
-- Medium/Low/None → Append security constraints to architect-plan.json as
+- no needs-input requiring redesign → Append security constraints to architect-plan.json as
   `security_constraints` array and proceed to Phase 3.
-- If 2 iterations exhausted with unresolved Critical findings → Escalate to human via
-  AskUserQuestion.
+- If 2 iterations exhausted with unresolved findings → Escalate to human via AskUserQuestion.
 
 ### Phase 2.7: Speculative Fork (conditional)
 
@@ -286,7 +285,7 @@ auto-detected optional reviewers (UI, API, DB). Also spawn the Plan Adherence re
 incremental plan file is found (see below). All reviewers operate in read-only mode on the
 completed implementation. Each writes structured JSON findings to `{run_dir}/reviews/`
 (see schema in `references/communication-schema.md`). The Lead collects ALL findings and
-synthesizes into a consolidated view. Every finding — regardless of severity — is routed to
+synthesizes into a consolidated view. Every finding — regardless of classification — is routed to
 Phase 5 for action. No finding is silently dropped or left unactioned in the audit trail.
 
 **Plan Adherence reviewer:** Before spawning Phase 4 agents, search `{memory_dir}/plans/` for an
@@ -342,7 +341,7 @@ and are written to `{run_dir}/reviews/structural-concurrency.json` and
 `{run_dir}/reviews/structural-integration.json`.
 
 **Routing:**
-- Critical/High STRUCT findings follow the Phase 4 escalation routing rules
+- STRUCT findings requiring architectural redesign follow the Phase 4 escalation routing rules
 - STRUCT escalations count toward the cumulative `design_escalation_count` cap (max 2 total
   re-implementations before human escalation)
 - STRUCT escalation events are logged to `{run_dir}/escalations.json`
@@ -353,17 +352,16 @@ Phase 5 receives findings from both Phase 4 AND Phase 4.5 in its consolidated fi
 
 ### Phase 5: Fix, Test Coverage & Simplify
 
-Skip this phase only if ALL reviews (Phases 4 and 4.5) report zero findings of any severity.
+Skip this phase only if ALL reviews (Phases 4 and 4.5) report zero findings.
 Otherwise, spawn agents in this order:
 
-**Step 5.1 — Fixer:** Spawn the Fixer with ALL consolidated findings (every severity level)
-and full context of the implementation. The Fixer addresses each finding with targeted, minimal
-changes — critical/high first, then medium, then low. After the Fixer completes, check its
-output for `deferred` items — findings it couldn't resolve. For each deferred item:
+**Step 5.1 — Fixer:** Spawn the Fixer with ALL consolidated findings (all classifications)
+and full context of the implementation. The Fixer processes all findings — process in file order
+per `code-quality/references/finding-classification.md` Fixer Protocol. After the Fixer
+completes, the Lead handles user triage for `needs_input_items` and structural verification
+per Step 5.2.1. For each `user_deferred` item:
 1. Create a `TaskCreate` entry marked as blocked with the reason (visible in task list throughout)
 2. Add to the "Scope Accountability" section of `swarm-report.md` (permanent record)
-3. If any deferred item is critical or high severity, use `AskUserQuestion` to notify the user
-   before proceeding — do NOT silently continue past critical unresolved findings
 
 **Step 5.2 — Test Coverage Agent:** If ANY Phase 4 or 4.5 reviewer identified test coverage
 gaps, missing tests, or untested code paths, spawn the Test Coverage Agent (sonnet,
@@ -472,9 +470,9 @@ The Docs Reviewer checks:
    Docs must always describe what the code does, never what the plan said it would do.
 
 Findings are written to `{run_dir}/reviews/docs-review.json` using the standard ReviewFindings
-schema with `DOC-R` prefix. Critical/High findings are routed back to the Docs agent for fixes
-(max 1 iteration — the Docs Reviewer re-reviews after fixes). Low/Medium findings are recorded
-in the audit trail.
+schema with `DOC-R` prefix. `needs-fix` findings are routed back to the Docs agent for fixes
+(max 1 iteration — the Docs Reviewer re-reviews after fixes). `needs-input` findings are
+presented to the user via AskUserQuestion. All findings are recorded in the audit trail.
 
 After the Docs Reviewer completes (or confirms clean), spawn a separate **Lessons Extractor** agent (sonnet model). This
 agent scans the swarm run's audit trail and extracts principle-level lessons to
@@ -534,9 +532,9 @@ Phase 2: Architect (opus)
 Phase 2.5: Security Design Review (conditional, opus)
   +-- Reviews architect-plan.json for threat surface
   +-- STRIDE analysis of proposed architecture
-  +-- Critical/High findings --> back to Architect (max 2 iterations)
-  +-- Medium/Low/None --> append security_constraints, proceed
-  +-- Unresolved Critical after 2 iterations --> AskUserQuestion
+  +-- needs-input requiring redesign --> back to Architect (max 2 iterations)
+  +-- no needs-input requiring redesign --> append security_constraints, proceed
+  +-- Unresolved findings after 2 iterations --> AskUserQuestion
      |
      v
 Phase 2.7: Speculative Fork (conditional)
@@ -579,7 +577,7 @@ Phase 4.5: Structural Design Review (always runs)
      |
      v
 Phase 5: Fix, Test Coverage & Simplify (if any findings exist)
-  +-- Fixer: ALL findings (critical → high → medium → low)
+  +-- Fixer: ALL findings (process in file order — needs-fix first, then needs-input to Lead)
   +-- Test Coverage Agent: coverage gaps from Phase 4/4.5
   +-- Code-Simplifier: post-fix pass
      |
@@ -698,7 +696,7 @@ After escalation, wait for user input before proceeding.
 | Phase 2.8: Reduction Review | Config-only, docs-only, or test-only changes. Tasks where architect plan modifies fewer than 3 files total. |
 | Test-Writer | `--skip-tests` flag provided, or changes are purely config/docs with no logic |
 | Domain Reviewers (UI/API/DB) | Not auto-detected from codebase analysis |
-| Phase 5: Fix | ALL Phase 4 AND Phase 4.5 review agents report zero findings of any severity |
+| Phase 5: Fix | ALL Phase 4 AND Phase 4.5 review agents report zero findings |
 | Test Coverage Agent | No Phase 4 or 4.5 reviewer identified any test coverage gaps |
 | Code-Simplifier | Neither Fixer nor Test Coverage Agent made any changes in Phase 5 |
 | Phase 5.5: Plan Reconciliation | No incremental plan file found in `{memory_dir}/plans/` matching the feature branch. |

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -360,11 +360,9 @@ Flag any component that crosses a trust boundary without appropriate validation.
 Write your findings to `{run_dir}/security-design-review.json` using the SecurityDesignReview
 schema from `references/communication-schema.md`. Include all required fields.
 
-**Severity guidance:**
-- `critical` — Design flaw that would create an exploitable vulnerability if implemented as-is
-- `high` — Design decision that significantly increases attack surface or violates security principles
-- `medium` — Design choice that creates unnecessary security risk but has mitigations
-- `low` — Security improvement that would be good practice but is not urgent
+## Finding Classification
+
+Use the classification taxonomy and LoE scale from `references/finding-classification.md` (Finding Classification and Level of Effort sections).
 
 **Verdict guidance:**
 - `proceed` — No critical or high findings. Append any constraints and let implementation begin.
@@ -380,7 +378,7 @@ SendMessage(type="message", recipient="team-lead",
   content="Security design review complete (iteration {N}).\n\n"
           "Results: {run_dir}/security-design-review.json\n\n"
           "Verdict: {proceed | revise | escalate}\n\n"
-          "STRIDE findings: {N total — N critical, N high, N medium, N low}\n"
+          "STRIDE findings: {N total — N needs-fix, N needs-input}\n"
           "Security constraints for implementer: {N}\n\n"
           "[Brief summary of most significant findings, if any]",
   summary="Security design: {verdict} — N findings")
@@ -639,7 +637,8 @@ SendMessage(type="message", recipient="team-lead",
     "verdict": "rejected",
     "issues": [
       {
-        "severity": "critical",
+        "classification": "needs-fix",
+        "loe": "trivial",
         "file": "src/auth/oauth.py",
         "line": 42,
         "description": "Token expiry not handled — if the access token is expired, refresh() silently returns None",
@@ -648,7 +647,7 @@ SendMessage(type="message", recipient="team-lead",
     ],
     "turn_count": 10
   }',
-  summary="Reviewer: component-1 rejected — 1 critical")
+  summary="Reviewer: component-1 rejected — 1 needs-fix")
 ```
 
 ## Approach
@@ -960,24 +959,28 @@ Write to `{run_dir}/reviews/security.json`:
 
 ```json
 {
+  "schema": "ReviewFindings",
   "reviewer": "security-reviewer",
   "timestamp": "2026-02-27T12:00:00Z",
   "summary": {
     "total_findings": 3,
-    "by_severity": {"critical": 0, "high": 1, "medium": 1, "low": 1}
+    "needs_fix_count": 2,
+    "needs_input_count": 1,
+    "verdict": "findings"
   },
   "findings": [
     {
       "id": "SEC-001",
-      "severity": "high",
+      "classification": "needs-fix",
+      "loe": "trivial",
       "category": "injection",
-      "title": "SQL injection via unsanitized user input",
       "file": "src/auth/oauth.py",
-      "line_start": 42,
-      "line_end": 44,
+      "line": 42,
       "description": "User-supplied `client_id` is interpolated directly into a raw SQL query.",
       "evidence": "Line 43: query = f'SELECT * FROM clients WHERE id = {client_id}'",
-      "fix": "Use parameterized queries: cursor.execute('SELECT * FROM clients WHERE id = ?', (client_id,))"
+      "suggested_fix": "Use parameterized queries: cursor.execute('SELECT * FROM clients WHERE id = ?', (client_id,))",
+      "risk": "SQL injection — attacker can read or modify any row in the database",
+      "input_needed": null
     }
   ]
 }
@@ -988,10 +991,10 @@ Then send a summary:
 ```
 SendMessage(type="message", recipient="team-lead",
   content="Security review complete. Results: {run_dir}/reviews/security.json\n\n"
-          "Findings: 3 (0 critical, 1 high, 1 medium, 1 low)\n"
-          "High: SQL injection in src/auth/oauth.py:43\n"
+          "Findings: 3 (2 needs-fix, 1 needs-input)\n"
+          "needs-fix: SQL injection in src/auth/oauth.py:43\n"
           "No hardcoded secrets. Auth flow looks correct.",
-  summary="Security: 3 findings (1 high)")
+  summary="Security: 3 findings (2 needs-fix, 1 needs-input)")
 ```
 ```
 
@@ -1060,13 +1063,9 @@ You do NOT modify any code.
 - Wrapper functions that add no value
 - Defensive error handling for things that cannot fail
 
-## Severity Scale
+## Finding Classification
 
-Use the shared severity scale from `references/communication-schema.md` (ReviewFindings):
-- **critical:** Bug or correctness issue that will cause incorrect behavior in production
-- **high:** Serious convention violation or error handling gap
-- **medium:** Clear improvement that should be addressed
-- **low:** Stylistic or minor — still report these, the Fixer addresses all severity levels
+Use the classification taxonomy and LoE scale from `references/finding-classification.md` (Finding Classification and Level of Effort sections).
 
 ## Output Format
 
@@ -1078,19 +1077,22 @@ Write to `{run_dir}/reviews/qa.json`:
   "timestamp": "2026-02-27T12:00:00Z",
   "summary": {
     "total_findings": 5,
-    "by_severity": {"critical": 0, "high": 0, "medium": 3, "low": 2, "informational": 0}
+    "needs_fix_count": 5,
+    "needs_input_count": 0,
+    "verdict": "findings"
   },
   "findings": [
     {
       "id": "QA-001",
-      "severity": "medium",
+      "classification": "needs-fix",
+      "loe": "moderate",
       "category": "complexity",
-      "title": "Function exceeds single responsibility",
       "file": "src/auth/oauth.py",
-      "line_start": 80,
-      "line_end": 130,
+      "line": 80,
       "description": "handle_callback() does token exchange AND session creation AND audit logging.",
-      "fix": "Extract session creation and audit logging into separate functions."
+      "evidence": "Lines 80-130: single function handles three distinct responsibilities",
+      "suggested_fix": "Extract session creation and audit logging into separate functions.",
+      "risk": "Function will grow further and become impossible to test in isolation"
     }
   ]
 }
@@ -1333,12 +1335,13 @@ from `references/communication-schema.md`. Use `PLAN` prefix for all finding IDs
 Category values: `missing-task`, `partial-implementation`, `plan-spec-divergence`,
 `architect-acknowledged-descope`.
 
-**Severity guidance:**
-- `critical` — A task the user explicitly requested is entirely absent from the implementation
-- `high` — A task is substantially incomplete (core functionality missing)
-- `medium` — A task is partially addressed but missing edge cases or secondary requirements
-- `low` — Minor deviation from plan spec that does not affect functionality
-- `informational` — Architect-acknowledged descopes; record for audit trail, do not escalate
+## Finding Classification
+
+Use the classification taxonomy and LoE scale from `references/finding-classification.md` (Finding Classification and Level of Effort sections).
+
+**Plan adherence classification guidance:**
+- `needs-fix` — A task the user explicitly requested is absent or substantially incomplete
+- `needs-input` — Architect-acknowledged descopes where user must decide whether to include the task
 
 ## Communication
 
@@ -1353,7 +1356,7 @@ SendMessage(type="message", recipient="team-lead",
           "Partially addressed: N\n"
           "Not addressed: N\n"
           "Architect-acknowledged descopes: N\n\n"
-          "Findings: N (N critical, N high, N medium, N low, N informational)\n"
+          "Findings: N (N needs-fix, N needs-input)\n"
           "[Brief summary of most significant gaps, if any]",
   summary="Plan Adherence: N findings — N tasks unaddressed")
 ```
@@ -1444,7 +1447,7 @@ Then send a summary to the lead:
 SendMessage(type="message", recipient="team-lead",
   content="Structural review (Concurrency & State) complete. "
           "Results: {run_dir}/reviews/structural-concurrency.json\n\n"
-          "Findings: N (N critical, N high, N medium, N low)\n"
+          "Findings: N (N needs-fix, N needs-input)\n"
           "[Brief summary of most significant structural issue found, if any]",
   summary="Structural-Concurrency: N STRUCT findings")
 ```
@@ -1536,7 +1539,7 @@ Then send a summary to the lead:
 SendMessage(type="message", recipient="team-lead",
   content="Structural review (Integration & Contract) complete. "
           "Results: {run_dir}/reviews/structural-integration.json\n\n"
-          "Findings: N (N critical, N high, N medium, N low)\n"
+          "Findings: N (N needs-fix, N needs-input)\n"
           "[Brief summary of most significant structural issue found, if any]",
   summary="Structural-Integration: N STRUCT findings")
 ```
@@ -1574,18 +1577,15 @@ You have access to: Read, Write, Edit, Glob, Grep, Bash.
 
 ## Fix Protocol
 
-### Priority Order
-1. Critical security findings
-2. High security findings
-3. Critical/high QA and correctness findings
-4. Medium findings (all categories)
-5. Performance findings
-6. Low findings
-7. Informational items — document as concrete follow-up with file:line references
+You have access to: Read, Write, Edit, Glob, Grep, Bash.
+You do NOT have AskUserQuestion — needs-input findings go to the Lead for user triage.
 
-Fix ALL findings in this list. Every severity level is your responsibility.
+### Processing Order
 
-### For Each Finding
+1. Process all `needs-fix` findings in file order (minimizes context switching)
+2. Collect all `needs-input` findings into `needs_input_items` — do NOT attempt to resolve them
+
+### For Each `needs-fix` Finding
 
 1. Read the affected file to understand current state
 2. Apply the minimal fix that resolves the issue
@@ -1596,7 +1596,7 @@ Do NOT:
 - Refactor code beyond what the finding requires
 - Change variable names, formatting, or style unless the finding specifically requires it
 - Add abstraction layers to "improve" the design
-- Skip or defer findings because of their severity level — every finding gets addressed
+- Classify any finding as `needs-input` to avoid doing work — `needs-input` means you genuinely cannot determine the fix, not that the fix is hard
 
 ### Test After Fixes
 
@@ -1610,25 +1610,37 @@ If tests fail after your fix, diagnose carefully:
 - Did your fix introduce a regression?
 - Was the test already fragile?
 
-Do not ship a fix that breaks tests. Revert and note it as a deferred item if you can't resolve.
+Do not ship a fix that breaks tests. Revert and note it as a technical blocker in `needs_input_items` if you genuinely cannot resolve.
 
 ## Output
 
-Send a FixSummary to the lead when done:
+Send a FixSummary to the lead when done (use the FixSummary schema from
+`references/communication-schema.md`):
 
 ```
 SendMessage(type="message", recipient="team-lead",
   content='{
-    "type": "FixSummary",
-    "fixed": [
-      {"id": "SEC-001", "description": "Parameterized the SQL query in oauth.py:43"},
-      {"id": "QA-001", "description": "Extracted session creation into create_session()"}
+    "schema": "FixSummary",
+    "findings_fixed": ["SEC-001", "QA-001"],
+    "needs_input_items": [
+      {
+        "id": "SEC-003",
+        "loe": "significant",
+        "description": "Auth bypass in admin endpoint requires redesigning the permission model",
+        "input_needed": "Should the permission model be redesigned now or deferred to a separate task?",
+        "suggested_action": "Redesign now — the current model creates a privilege escalation path"
+      }
     ],
-    "deferred": [
-      {"id": "SEC-003", "reason": "Fix would require API change — needs architect review"}
-    ]
+    "user_deferred": [],
+    "fixes": [
+      {"finding_id": "SEC-001", "description": "Parameterized the SQL query in oauth.py:43",
+       "file": "src/auth/oauth.py", "line_range": "43"},
+      {"finding_id": "QA-001", "description": "Extracted session creation into create_session()",
+       "file": "src/auth/oauth.py", "line_range": "80-130"}
+    ],
+    "files_modified": ["src/auth/oauth.py"]
   }',
-  summary="Fixer: 5 fixed, 1 deferred")
+  summary="Fixer: 2 fixed, 1 needs-input")
 ```
 ```
 
@@ -2021,8 +2033,9 @@ taxonomy § Component Discovery (don't trust the Docs agent's counts):
 Write findings to `{run_dir}/reviews/docs-review.json` using the ReviewFindings schema:
 - Prefix: `DOC-R`
 - Categories: `impact-coverage`, `accuracy`, `consistency`, `completeness`
-- Severity: CRITICAL (never used), HIGH (missed surface, wrong count, factual error),
-  MEDIUM (description inaccuracy, style mismatch), LOW (minor wording)
+- Classification: `needs-fix` (missed surface, wrong count, factual error, description inaccuracy,
+  style mismatch, minor wording — all are fixable by the Docs agent without user input);
+  `needs-input` only if user must decide scope (e.g., whether to document an internal API)
 
 Send summary to lead when done.
 ````
@@ -2115,7 +2128,7 @@ For each source, ask: **"What principle-level pattern does this reveal?"**
 | `architect-plan.json` → `questions` | Were there open questions that caused friction? What question type keeps appearing? |
 | `reviews/*.json` → finding categories | What categories of issues did the reviewers keep finding? (auth gaps, complexity, naming — pattern across sessions) |
 | `escalations.json` → `type` | Did design-level escalations occur? What class of design decision needed rework? |
-| `fix-summary.json` → `findings_deferred` | What types of issues were deferred? Why? |
+| `fix-summary.json` → `needs_input_items` + `user_deferred` | What types of issues needed input or were declined? Why? |
 | `.swarm-run` → Phase 2.5 decision | Was the security design review skipped? Was that correct in retrospect? |
 
 ### Principle-Level Filter

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -1567,7 +1567,7 @@ SendMessage(type="message", recipient="team-lead",
 
 You are the Fixer. You address ALL review findings from the parallel review phase. You make
 targeted, precise fixes — you do NOT refactor, reorganize, or improve beyond what the findings
-require. You fix every finding assigned to you, regardless of severity.
+require. You fix every finding assigned to you, regardless of classification.
 
 You have access to: Read, Write, Edit, Glob, Grep, Bash.
 
@@ -1698,7 +1698,7 @@ when no appropriate existing file exists. Match the project's naming conventions
 - Do NOT rewrite or modify existing tests (Phase 3 Test-Writer owns those)
 - Do NOT modify implementation code (Fixer owns that)
 - Do NOT write trivial tests just for coverage numbers
-- Do NOT skip findings because they seem "low severity" — if a reviewer flagged a coverage
+- Do NOT skip findings because they seem low-importance — if a reviewer flagged a coverage
   gap, write the test
 
 ## Output

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -362,7 +362,7 @@ schema from `references/communication-schema.md`. Include all required fields.
 
 ## Finding Classification
 
-Use the classification taxonomy and LoE scale from `references/finding-classification.md` (Finding Classification and Level of Effort sections).
+Use the classification taxonomy and LoE scale from `code-quality/references/finding-classification.md` (Finding Classification and Level of Effort sections).
 
 **Verdict guidance:**
 - `proceed` — No critical or high findings. Append any constraints and let implementation begin.
@@ -1065,7 +1065,7 @@ You do NOT modify any code.
 
 ## Finding Classification
 
-Use the classification taxonomy and LoE scale from `references/finding-classification.md` (Finding Classification and Level of Effort sections).
+Use the classification taxonomy and LoE scale from `code-quality/references/finding-classification.md` (Finding Classification and Level of Effort sections).
 
 ## Output Format
 
@@ -1337,7 +1337,7 @@ Category values: `missing-task`, `partial-implementation`, `plan-spec-divergence
 
 ## Finding Classification
 
-Use the classification taxonomy and LoE scale from `references/finding-classification.md` (Finding Classification and Level of Effort sections).
+Use the classification taxonomy and LoE scale from `code-quality/references/finding-classification.md` (Finding Classification and Level of Effort sections).
 
 **Plan adherence classification guidance:**
 - `needs-fix` — A task the user explicitly requested is absent or substantially incomplete

--- a/code-quality/skills/swarm/references/communication-schema.md
+++ b/code-quality/skills/swarm/references/communication-schema.md
@@ -121,7 +121,9 @@ Written by the Phase 2.5 security-design agent to `{run_dir}/security-design-rev
   "stride_findings": [
     {
       "category": "Spoofing | Tampering | Repudiation | InformationDisclosure | DenialOfService | ElevationOfPrivilege",
-      "severity": "critical | high | medium | low",
+      "classification": "needs-fix | needs-input",
+      "loe": "trivial | moderate | significant",
+      "input_needed": "string | null — what decision the user must make (required when classification is needs-input)",
       "component_id": "string — affected component ID from architect plan",
       "description": "string — threat description",
       "mitigation": "string — recommended mitigation"
@@ -140,9 +142,11 @@ Written by the Phase 2.5 security-design agent to `{run_dir}/security-design-rev
 ```
 
 **Verdict semantics:**
-- `proceed` — No Critical or High findings. Security constraints (if any) are appended to architect-plan.json and the pipeline continues.
-- `revise` — Critical or High findings require architect plan revision before implementation. Lead routes findings back to Architect.
-- `escalate` — Unresolvable Critical findings after 2 Architect↔Security iterations. Lead escalates to human via AskUserQuestion.
+- `proceed` — No `needs-fix` findings blocking implementation. Security constraints (if any) are appended to architect-plan.json and the pipeline continues.
+- `revise` — `needs-fix` findings require architect plan revision before implementation. Lead routes findings back to Architect.
+- `escalate` — Unresolvable findings after 2 Architect↔Security iterations. Lead escalates to human via AskUserQuestion.
+
+See `code-quality/references/finding-classification.md` for classification guidance and the anti-deferral principle.
 
 ---
 
@@ -225,7 +229,8 @@ Sent when the Reviewer completes assessment of a component.
   "verdict": "approved | rejected",
   "issues": [
     {
-      "severity": "critical | high | medium | low",
+      "classification": "needs-fix | needs-input",
+      "loe": "trivial | moderate | significant",
       "file": "string — file path",
       "line": "integer | null — line number if known",
       "description": "string — what is wrong",
@@ -328,29 +333,29 @@ and sends a summary to the Lead.
   "timestamp": "string — ISO 8601 datetime",
   "summary": {
     "total_findings": "integer",
-    "by_severity": {
-      "critical": "integer",
-      "high": "integer",
-      "medium": "integer",
-      "low": "integer",
-      "informational": "integer"
-    },
+    "needs_fix_count": "integer",
+    "needs_input_count": "integer",
     "verdict": "clean | findings"
   },
   "findings": [
     {
       "id": "string — unique ID with prefix (see table below)",
-      "severity": "critical | high | medium | low | informational",
+      "classification": "needs-fix | needs-input",
+      "loe": "trivial | moderate | significant — required for Fixer-pipeline, optional for advisory",
       "category": "string — issue category (e.g. injection, auth, complexity, naming)",
       "file": "string — file path",
       "line": "integer | null — line number if applicable",
       "description": "string — clear description of the issue",
       "evidence": "string — quoted code snippet or specific observation",
       "suggested_fix": "string — specific, actionable recommendation",
-      "risk": "string — what could go wrong if this is not addressed"
+      "risk": "string — what could go wrong if this is not addressed",
+      "input_needed": "string | null — what decision the user must make (required when classification is needs-input)"
     }
   ]
 }
+```
+
+See `code-quality/references/finding-classification.md` for classification guidance and the anti-deferral principle.
 ```
 
 ### Finding ID Prefix Convention
@@ -380,13 +385,21 @@ The Fixer sends this to the Lead after completing Phase 5 work. Written to
 {
   "schema": "FixSummary",
   "findings_fixed": ["string — finding IDs that were fully resolved"],
-  "findings_deferred": [
+  "needs_input_items": [
     {
-      "id": "string — finding ID",
-      "reason": "string — why it was deferred (e.g. requires architectural change, out of scope)"
+      "id": "string",
+      "loe": "trivial | moderate | significant",
+      "description": "string",
+      "input_needed": "string — what decision the user must make",
+      "suggested_action": "string — what the Fixer recommends"
     }
   ],
-  "files_modified": ["string — paths of files changed during fixing"],
+  "user_deferred": [
+    {
+      "id": "string",
+      "reason": "string — user's stated reason for deferral"
+    }
+  ],
   "fixes": [
     {
       "finding_id": "string",
@@ -395,12 +408,7 @@ The Fixer sends this to the Lead after completing Phase 5 work. Written to
       "line_range": "string | null — e.g. '42-48' for changed range"
     }
   ],
-  "deferred_items": [
-    {
-      "finding_id": "string",
-      "recommended_action": "string — what the team should do with this later"
-    }
-  ]
+  "files_modified": ["string — paths of files changed during fixing"]
 }
 ```
 

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -377,7 +377,7 @@ After Step 1.3 approval, commit to full autonomy. The ONLY allowed interruptions
 
 1. **Architect raises blockers** — unclear/risky design decisions (Phase 2)
 2. **Error escalation after max retries** — a component is permanently blocked (Phase 3/5/7)
-3. **Critical/high Fixer deferrals** — findings the Fixer could NOT resolve (Phase 5)
+3. **Needs-input Fixer items** — findings requiring user decision that the Fixer could not resolve (Phase 5)
 4. **Final completion report** — announcing the swarm is done (Phase 7)
 
 Do NOT interrupt the user for:
@@ -516,17 +516,17 @@ proposed architecture, and writes its findings to `{run_dir}/security-design-rev
 After the security-design agent reports completion, read `{run_dir}/security-design-review.json`.
 Check the `verdict` field:
 
-**`proceed`** (no Critical/High findings):
+**`proceed`** (no `needs-input` findings requiring architectural redesign):
 - Append the `security_constraints` array from the review to `architect-plan.json` as a
   top-level `security_constraints` field
 - Notify the Architect of the constraints so they are available for Phase 3 clarification questions
 - Proceed to Phase 3
 
-**`revise`** (Critical or High findings present):
+**`revise`** (`needs-input` findings requiring plan revision present):
 - Send findings to the Architect:
   ```
   SendMessage(type="message", recipient="architect",
-    content="Security design review found Critical/High issues requiring plan revision.\n\n"
+    content="Security design review found findings requiring plan revision.\n\n"
             "Findings: {run_dir}/security-design-review.json\n\n"
             "Please revise {run_dir}/architect-plan.json to address these findings and "
             "send an updated summary when done.",
@@ -1234,19 +1234,28 @@ If the file exists, read it. If it is missing, note the gap and proceed.
 
 ### Step 4.4: Lead Synthesis
 
-Read all review JSON files. Categorize findings:
+Read all review JSON files. Collect all findings regardless of classification:
 
 | Category | Criteria | Action |
 |----------|----------|--------|
-| critical/high | Critical/high security findings; critical/high QA findings | Send to Fixer (priority) |
-| medium | Medium security; medium QA; high performance | Send to Fixer |
-| low/informational | Low/informational security; low QA; informational | Send to Fixer |
+| needs-fix | All `needs-fix` findings from all reviewers | Send to Fixer |
+| needs-input | All `needs-input` findings from all reviewers | Send to Fixer (Fixer batches them into FixSummary for Lead-mediated user triage) |
 | test coverage | Missing tests, untested paths, coverage gaps | Send to Test Coverage Agent |
 
-Build a consolidated findings list for the Fixer (all severities) and a test coverage
+Build a consolidated findings list for the Fixer (all findings) and a test coverage
 findings list for the Test Coverage Agent. Group by file when possible.
 
-If ALL reviews report zero findings of any severity, set a flag: `skip_phase5 = true`.
+After building the consolidated list, write `total_findings_in` to
+`{run_dir}/synthesis-counts.json` for use in Step 5.2.1 verification:
+
+```json
+{
+  "total_findings_in": <integer — total finding count across all reviewers>,
+  "timestamp": "<ISO 8601>"
+}
+```
+
+If ALL reviews report zero findings, set a flag: `skip_phase5 = true`.
 
 ### Step 4.5: Escalation Routing
 
@@ -1427,7 +1436,7 @@ Add all actionable STRUCT findings to the consolidated findings list that Phase 
 Phase 5 treats STRUCT findings identically to Phase 4 findings — same priority order, same fix
 protocol.
 
-If ALL structural findings are clean (zero findings of any severity), note this in the audit
+If ALL structural findings are clean (zero findings), note this in the audit
 trail and skip_phase5 remains unchanged from Phase 4's determination.
 
 ### Step 4.5.5: Shutdown Structural Analysts
@@ -1443,9 +1452,9 @@ SendMessage(type="shutdown_request", recipient="structural-integration", content
 
 ### Step 5.1: Skip Check
 
-If `skip_phase5 = true` (all Phase 4 AND Phase 4.5 reviews report zero findings of any
-severity): skip Phase 5 entirely. Mark Phase 5 task as completed with note "No findings —
-skipped." Proceed to Phase 6.
+If `skip_phase5 = true` (all Phase 4 AND Phase 4.5 reviews report zero findings):
+skip Phase 5 entirely. Mark Phase 5 task as completed with note "No findings — skipped."
+Proceed to Phase 6.
 
 ### Step 5.2: Spawn Fixer
 
@@ -1456,20 +1465,34 @@ Agent(name="fixer", subagent_type="general-purpose", model="sonnet",
             "CONSOLIDATED FINDINGS:\n<JSON findings from synthesis>")
 ```
 
-Fixer addresses all findings: critical first, then high, then medium, then low. It sends a
-`FixSummary` message to the lead when done.
+Fixer addresses all findings — process in file order per `code-quality/references/finding-classification.md`
+Fixer Protocol. It sends a `FixSummary` message to the lead when done.
 
-### Step 5.2.1: Handle Fixer Deferrals
+### Step 5.2.1: Handle Fixer Output Verification
 
-After the Fixer completes, check its FixSummary for deferred items (`deferred`, `findings_deferred`,
-or `deferred_items` fields — check all three due to naming inconsistency). For each deferred item:
+After the Fixer completes and sends its FixSummary, the Lead handles user triage and
+structural verification:
 
-1. `TaskCreate` with the finding ID, reason, and recommended action (visible in task list)
+**User triage for needs-input items:**
+1. Read `needs_input_items` from the FixSummary
+2. If non-empty, present to the user via multiSelect `AskUserQuestion`:
+   - One option per finding: label = Finding ID, description = "LoE: [X]. [Description]. Suggested: [action]"
+   - User checks items to fix, leaves unchecked items to skip
+3. Checked items: send back to Fixer for resolution (or fix inline if trivial), add to `findings_fixed`
+4. Unchecked items: recorded in `user_deferred` with reason "User declined via triage"
+5. Update the final FixSummary with `user_deferred` entries
+
+**Structural verification:**
+1. Read `total_findings_in` from `{run_dir}/synthesis-counts.json`
+2. Count `findings_fixed + user_deferred` from the final FixSummary
+3. If delta > 0 (findings silently dropped): escalate via `AskUserQuestion`
+4. If delta == 0 (all findings accounted for): proceed
+
+See `code-quality/references/finding-classification.md` Verification Protocol.
+
+For each `user_deferred` item:
+1. `TaskCreate` with the finding ID, reason, and the Fixer's suggested action (visible in task list)
 2. Add to the "Scope Accountability" section of swarm-report.md
-3. If the deferred item is critical or high severity: `AskUserQuestion` to notify the user.
-   Do NOT silently continue past critical unresolved findings.
-
-If no deferred items exist, skip this step.
 
 ### Step 5.2.5: Spawn Test Coverage Agent (conditional)
 
@@ -1672,12 +1695,13 @@ Agent(name="docs-reviewer", subagent_type="general-purpose", model="sonnet",
 ```
 
 The Docs Reviewer writes findings to `{run_dir}/reviews/docs-review.json`. If it reports
-Critical/High findings:
+`needs-fix` findings:
 1. Route findings back to the Docs agent (still alive)
 2. Docs agent fixes, re-commits
 3. Docs Reviewer re-reviews (max 1 iteration)
 
-If clean or only Low/Medium findings, proceed.
+If `needs-input` findings: present to user via AskUserQuestion before proceeding.
+If no `needs-fix` findings, proceed.
 
 ### Step 6.6: Shutdown Docs Agent
 
@@ -1791,7 +1815,7 @@ Run directory: {run_dir}
 - Files modified: N
 - Lines added: +N / Lines removed: -N
 - Tests added: N
-- Review findings fixed: N (M deferred)
+- Review findings fixed: N (M user-deferred)
 - Blocked items: N
 
 ## Pipeline Execution
@@ -1804,12 +1828,12 @@ Run directory: {run_dir}
 
 ## Review Findings
 
-| Reviewer | Findings | Critical | High | Medium | Low |
-|----------|----------|----------|------|--------|-----|
-| security | 3 | 1 | 1 | 1 | 0 |
-| qa | 5 | 0 | 2 | 2 | 1 |
-| code-reviewer | 2 | 0 | 0 | 1 | 1 |
-| performance | 1 | 0 | 0 | 0 | 1 |
+| Reviewer | Findings | Needs-Fix | Needs-Input |
+|----------|----------|-----------|-------------|
+| security | 3 | 2 | 1 |
+| qa | 5 | 5 | 0 |
+| code-reviewer | 2 | 2 | 0 |
+| performance | 1 | 1 | 0 |
 
 ## Blocked Items
 
@@ -1839,7 +1863,7 @@ Original request: <verbatim user request>
 | session-cleanup | BLOCKED | Rejected 3x, stashed |
 
 Items NOT in plan that were requested: [none / list any gaps]
-Fixer deferred items: [none / list with reasons]
+User-deferred items: [none / list with reasons]
 
 ## Remaining Tech Debt
 

--- a/code-quality/skills/swarm/references/pipeline-model.md
+++ b/code-quality/skills/swarm/references/pipeline-model.md
@@ -339,7 +339,7 @@ the Lead synthesizes them and shuts down all reviewers before proceeding to Phas
 
 ### Phase 5: Fix Team Spawn (conditional)
 
-If any reviewer reported findings of any severity, spawn Phase 5 agents:
+If any reviewer reported findings, spawn Phase 5 agents:
 
 ```
 Lead spawns sequentially:
@@ -361,7 +361,7 @@ Lead spawns sequentially:
 ```
 
 Three agents, run sequentially. Docs agent completes first, then Docs Reviewer verifies the
-documentation changes (critical/high findings route back to Docs for fixes, max 1 iteration).
+documentation changes (needs-fix findings route back to Docs for fixes, max 1 iteration).
 After Docs Reviewer confirms clean, Lessons Extractor reads the audit trail and writes to
 `{memory_dir}/LESSONS.md`. Shut down each after it reports completion.
 

--- a/code-quality/skills/unfuck/SKILL.md
+++ b/code-quality/skills/unfuck/SKILL.md
@@ -112,9 +112,9 @@ The orchestrator assigns categories in priority order (security → dead code �
 5. Generate `{run_dir}/cleanup-report.md` with:
    - Summary stats (files modified, lines added/removed, net delta, issues fixed by category)
    - Per-category breakdown with specific changes and commit SHAs
-   - Blocked items (test failures, needs-review) with stash names and manual fix guidance
+   - Blocked items (test failures, needs-input) with stash names and manual fix guidance
    - External tools used vs agent-only analysis
-   - Remaining tech debt intentionally deferred
+   - Remaining `needs-input` findings presented to user via AskUserQuestion with LoE (see `code-quality/references/finding-classification.md`)
 5. Clean up intermediate discovery files
 6. Report completion to user with summary and report location
 
@@ -132,7 +132,7 @@ The orchestrator assigns categories in priority order (security → dead code �
 - Security fixes NEVER auto-applied if they could change business logic
 - AskUserQuestion for all ambiguous or high-risk decisions
 - `--dry-run` flag for discovery + planning without implementation
-- Agents use `needs-review` escape hatch for uncertain changes
+- Agents use `needs-input` escape hatch for uncertain changes — see `code-quality/references/finding-classification.md` Fixer Protocol
 
 ## Output Files
 
@@ -148,7 +148,7 @@ The orchestrator assigns categories in priority order (security → dead code �
 | File | Content |
 |------|---------|
 | `references/orchestration-playbook.md` | Complete phase-by-phase coordination guide with JSON schemas, dedup algorithm, rollback procedures, TeamCreate config, and error handling |
-| `references/discovery-agents.md` | Full prompts for all 7 discovery agents — role, methodology, external tool commands, LSP patterns, severity/risk guides, output format |
+| `references/discovery-agents.md` | Full prompts for all 7 discovery agents — role, methodology, external tool commands, LSP patterns, classification/LoE/risk guides, output format |
 | `references/implementation-agents.md` | Full prompts for all 7 implementation agents — fix strategies, paired skills, safety rules, test cadence, commit formats |
 | `references/ai-slop-checklist.md` | 32 anti-patterns across 7 categories (structural, error handling, naming, comments, testing, imports, types) with before/after examples and false-positive guidance |
 | `references/external-tools.md` | Tool matrix by language, detection commands, JSON output schemas, parsing instructions, Phase 0 detection script, fallback strategies |

--- a/code-quality/skills/unfuck/references/ai-slop-checklist.md
+++ b/code-quality/skills/unfuck/references/ai-slop-checklist.md
@@ -11,16 +11,18 @@ during `/unfuck` Phase 1 discovery.
 4. Generate before/after code for the top 20 worst findings
 5. Rate each finding against the false-positive guidance before including it
 
-## Severity Ratings
+## Finding Classification
 
-- **critical**: Pattern that actively harms readability AND maintainability (e.g., abstraction layer that makes debugging impossible)
-- **high**: Pattern that significantly increases code complexity without benefit
-- **medium**: Pattern that adds unnecessary code but doesn't actively harm
-- **low**: Style preference that experienced developers would typically simplify
+All slop findings use `classification: needs-fix` — slop patterns are always fixable by the agent without user input. Only use `needs-input` if removing the pattern would change the public API in a way the user must approve. See `code-quality/references/finding-classification.md` for the full classification taxonomy and LoE scale.
+
+Assign `loe` per finding:
+- **trivial**: Delete a comment; remove a type suffix from a variable name; inline a one-liner
+- **moderate**: Remove a wrapper function with multiple call sites; eliminate a catch-rethrow chain
+- **significant**: Remove an entire abstraction layer (interface + implementation class); split a god class
 
 ---
 
-## Category 1: Structural Slop (default severity: high)
+## Category 1: Structural Slop (classification: needs-fix)
 
 ### SS-01: Unnecessary Wrapper Function
 
@@ -384,7 +386,7 @@ function validate(input: string, rules: Rule[]): boolean {
 
 ---
 
-## Category 2: Error Handling Slop (default severity: high)
+## Category 2: Error Handling Slop (classification: needs-fix)
 
 ### EH-01: Catch and Rethrow Without Modification
 
@@ -699,7 +701,7 @@ class UserService:
 
 ---
 
-## Category 3: Naming Slop (default severity: medium)
+## Category 3: Naming Slop (classification: needs-fix)
 
 ### NS-01: Overly Verbose Names
 
@@ -882,7 +884,7 @@ class FileManager {
 
 ---
 
-## Category 4: Comment Slop (default severity: medium)
+## Category 4: Comment Slop (classification: needs-fix)
 
 ### CS-01: Comments Restating the Code
 
@@ -1115,7 +1117,7 @@ function handleLogin(credentials: Credentials) {
 
 ---
 
-## Category 5: Testing Slop (default severity: medium)
+## Category 5: Testing Slop (classification: needs-fix)
 
 ### TS-01: Tests That Test the Mock
 
@@ -1401,7 +1403,7 @@ test("createUser returns user with generated ID", async () => {
 
 ---
 
-## Category 6: Import/Dependency Slop (default severity: low)
+## Category 6: Import/Dependency Slop (classification: needs-fix)
 
 ### ID-01: Unused Imports
 
@@ -1587,7 +1589,7 @@ from utils.validation import validate_email
 
 ---
 
-## Category 7: Type/Annotation Slop (default severity: low)
+## Category 7: Type/Annotation Slop (classification: needs-fix)
 
 ### TA-01: `any` Type Everywhere
 
@@ -1840,63 +1842,51 @@ def get_user_from_cache(key: str) -> User:
 
 ### Priority for Fixing
 
-1. **Critical + high severity** findings in core modules (most-imported, most-modified files)
-2. **High severity** findings anywhere
-3. **Medium severity** in frequently-modified files (check `git log --format='' --name-only | sort | uniq -c | sort -rn | head -20`)
-4. **Everything else** -- batch into a cleanup PR
+Process all `needs-fix` findings. Order by file (core modules first — most-imported, most-modified files), then by source order within each file. Do not skip findings based on perceived importance.
 
-### Weighted Severity Scores
-
-When calculating a file's slop score, weight each finding:
-
-| Severity | Weight |
-|----------|--------|
-| Critical | 4 |
-| High | 2 |
-| Medium | 1 |
-| Low | 0.5 |
-
-A file with 1 critical + 2 medium findings has a weighted score of 4 + 1 + 1 = 6 (Heavy).
+Core modules first: `git log --format='' --name-only | sort | uniq -c | sort -rn | head -20`
 
 ---
 
 ## Quick Reference: Pattern ID Index
 
-| ID | Name | Default Severity |
-|----|------|-----------------|
-| SS-01 | Unnecessary Wrapper Function | high |
-| SS-02 | Over-Abstraction (Single Implementation Interface) | high |
-| SS-03 | Premature Generalization (Single-Variant Pattern) | high |
-| SS-04 | Single-Use Helper Function | high |
-| SS-05 | Configuration Over Hardcoding | high |
-| SS-06 | Unnecessary Indirection Layer | high |
-| SS-07 | God Object | critical |
-| SS-08 | Premature Class | high |
-| EH-01 | Catch and Rethrow Without Modification | high |
-| EH-02 | Logging at Every Level | high |
-| EH-03 | Defensive Coding Against Impossible States | high |
-| EH-04 | Fallback Values Masking Bugs | high |
-| EH-05 | Error Handling Deeper Than Boundaries | high |
-| EH-06 | Excessive Validation of Trusted Data | high |
-| NS-01 | Overly Verbose Names | medium |
-| NS-02 | Redundant Type-in-Name | medium |
-| NS-03 | Generic Meaningless Names | medium |
-| NS-04 | Redundant Namespace in Name | medium |
-| CS-01 | Comments Restating the Code | medium |
-| CS-02 | Excessive Docstrings on Internal Functions | medium |
-| CS-03 | AI-Generated TODO Comments | medium |
-| CS-04 | Section Divider Comments | medium |
-| CS-05 | Commented-Out Code | medium |
-| TS-01 | Tests That Test the Mock | medium |
-| TS-02 | Excessive Mocking | medium |
-| TS-03 | Tests Mirroring Implementation | medium |
-| TS-04 | Snapshot Tests for Everything | medium |
-| TS-05 | Tests Without Meaningful Assertions | medium |
-| ID-01 | Unused Imports | low |
-| ID-02 | Whole-Library Imports for One Function | low |
-| ID-03 | Circular Import Workarounds | low |
-| ID-04 | Re-Export-Everything Index Files | low |
-| TA-01 | `any` Type Everywhere | low |
-| TA-02 | Overly Complex Generic Types | low |
-| TA-03 | Redundant Type Annotations | low |
-| TA-04 | Type Assertion Abuse | low |
+All patterns: `classification: needs-fix`. See Finding Classification section for LoE assignment guidance.
+
+| ID | Name | Typical LoE |
+|----|------|------------|
+| SS-01 | Unnecessary Wrapper Function | trivial–moderate |
+| SS-02 | Over-Abstraction (Single Implementation Interface) | significant |
+| SS-03 | Premature Generalization (Single-Variant Pattern) | significant |
+| SS-04 | Single-Use Helper Function | trivial |
+| SS-05 | Configuration Over Hardcoding | trivial–moderate |
+| SS-06 | Unnecessary Indirection Layer | moderate–significant |
+| SS-07 | God Object | significant |
+| SS-08 | Premature Class | moderate |
+| EH-01 | Catch and Rethrow Without Modification | trivial |
+| EH-02 | Logging at Every Level | trivial–moderate |
+| EH-03 | Defensive Coding Against Impossible States | trivial |
+| EH-04 | Fallback Values Masking Bugs | trivial–moderate |
+| EH-05 | Error Handling Deeper Than Boundaries | moderate |
+| EH-06 | Excessive Validation of Trusted Data | trivial–moderate |
+| NS-01 | Overly Verbose Names | trivial |
+| NS-02 | Redundant Type-in-Name | trivial |
+| NS-03 | Generic Meaningless Names | moderate |
+| NS-04 | Redundant Namespace in Name | trivial |
+| CS-01 | Comments Restating the Code | trivial |
+| CS-02 | Excessive Docstrings on Internal Functions | trivial |
+| CS-03 | AI-Generated TODO Comments | trivial |
+| CS-04 | Section Divider Comments | trivial |
+| CS-05 | Commented-Out Code | trivial |
+| TS-01 | Tests That Test the Mock | moderate |
+| TS-02 | Excessive Mocking | moderate |
+| TS-03 | Tests Mirroring Implementation | moderate |
+| TS-04 | Snapshot Tests for Everything | moderate |
+| TS-05 | Tests Without Meaningful Assertions | trivial–moderate |
+| ID-01 | Unused Imports | trivial |
+| ID-02 | Whole-Library Imports for One Function | trivial |
+| ID-03 | Circular Import Workarounds | significant |
+| ID-04 | Re-Export-Everything Index Files | moderate |
+| TA-01 | `any` Type Everywhere | moderate |
+| TA-02 | Overly Complex Generic Types | moderate–significant |
+| TA-03 | Redundant Type Annotations | trivial |
+| TA-04 | Type Assertion Abuse | moderate |

--- a/code-quality/skills/unfuck/references/ai-slop-checklist.md
+++ b/code-quality/skills/unfuck/references/ai-slop-checklist.md
@@ -7,7 +7,7 @@ during `/unfuck` Phase 1 discovery.
 
 1. Read source files in batches of 10-20 files
 2. For each file, scan against ALL categories below
-3. For each match, record: file, line range, pattern ID, severity, suggested fix
+3. For each match, record: file, line range, pattern ID, classification, loe, suggested fix
 4. Generate before/after code for the top 20 worst findings
 5. Rate each finding against the false-positive guidance before including it
 
@@ -298,7 +298,7 @@ class UserController {
 
 ### SS-07: God Object Created by "Organizing" Code
 
-**Severity: critical**
+**Classification: needs-fix**
 
 **Detection:** A class or module that accumulates unrelated methods because AI tried to "organize" functions into a class. Look for classes with >10 public methods that touch different domains, or a `utils` class with methods spanning formatting, validation, networking, and file I/O.
 

--- a/code-quality/skills/unfuck/references/discovery-agents.md
+++ b/code-quality/skills/unfuck/references/discovery-agents.md
@@ -166,11 +166,17 @@ Use the shared output schema with:
 - `category`: `"dead-code"`
 - `subcategory`: one of `"unused-export"`, `"orphan-file"`, `"unused-dependency"`, `"dead-feature"`, `"commented-code"`, `"dead-test"`
 
-### Severity Guide
-- **critical**: Not used for dead code (reserve for security/correctness)
-- **high**: Entire unused files, unused public API exports, unused dependencies adding bundle size
-- **medium**: Unused private functions, unused variables in non-trivial scope
-- **low**: Commented-out code, unused test utilities, minor dead branches
+### Classification Guide
+
+See `code-quality/references/finding-classification.md` for the full taxonomy and LoE scale.
+
+- **needs-fix**: Agent has sufficient context to remove the dead code independently. Default for all dead code findings.
+- **needs-input**: Fix requires a user decision (e.g., removing a public API export that may have external consumers, or dead code that could be intentional scaffolding for upcoming work).
+
+Assign `loe` per finding:
+- **trivial**: Single line/import removal, no callers
+- **moderate**: Multi-file cleanup (remove file + references in imports)
+- **significant**: Removing an entire unused module with multiple dependents to update
 
 ### Risk Guide
 - **low**: Zero references anywhere, not an entry point, safe to remove
@@ -311,11 +317,17 @@ Use the shared output schema with:
 - `category`: `"duplicate"`
 - `subcategory`: one of `"exact-duplicate"`, `"near-duplicate"`, `"redundant-wrapper"`, `"overlapping-module"`
 
-### Severity Guide
-- **critical**: Not used for duplicates
-- **high**: Exact duplicates of >20 lines, entire modules with overlapping responsibility
-- **medium**: Near-duplicates that should be consolidated, redundant wrappers with few callers
-- **low**: Minor copy-paste in tests, small redundant utilities
+### Classification Guide
+
+See `code-quality/references/finding-classification.md` for the full taxonomy and LoE scale.
+
+- **needs-fix**: Agent can determine the canonical version and consolidate independently. Default for exact duplicates and clear near-duplicates.
+- **needs-input**: Subtle behavioral differences that may be intentional, or consolidation that would cross architectural boundaries the agent cannot safely evaluate.
+
+Assign `loe` per finding:
+- **trivial**: Inline a single-use wrapper; remove one obvious copy
+- **moderate**: Consolidate 2-3 copies into a shared utility, update call sites
+- **significant**: Merge overlapping modules with many dependents; requires coordinated refactor
 
 ### Risk Guide
 - **low**: Clear duplicates with straightforward consolidation path
@@ -540,11 +552,17 @@ Use the shared output schema with:
 - `category`: `"security"`
 - `subcategory`: one of `"injection"`, `"broken-auth"`, `"data-exposure"`, `"xxe"`, `"broken-access-control"`, `"misconfiguration"`, `"xss"`, `"insecure-deserialization"`, `"vulnerable-dependency"`, `"insufficient-logging"`
 
-### Severity Guide
-- **critical**: Active vulnerabilities — exposed secrets in code, SQL injection with user input, RCE via command injection, authentication bypass
-- **high**: Authentication/authorization gaps, hardcoded credentials (even if not production), missing input validation at system boundaries
-- **medium**: Security misconfiguration, missing security headers, overly permissive CORS, components with known medium-severity CVEs
-- **low**: Best practice violations, informational findings, missing logging, minor configuration issues
+### Classification Guide
+
+See `code-quality/references/finding-classification.md` for the full taxonomy and LoE scale.
+
+- **needs-fix**: The vulnerability is clear and the fix is mechanical (replace string concat with parameterized query, remove hardcoded secret, add `Loader=yaml.SafeLoader`). Default for most security findings.
+- **needs-input**: Fix requires an architectural decision (e.g., "should we use env vars or a secrets manager?", "should this endpoint require auth?", updating a major dependency with breaking changes). Security policy decisions are always `needs-input`.
+
+Assign `loe` per finding:
+- **trivial**: One-line fix (add a header, fix a config flag, use safe loader)
+- **moderate**: Replace string-interpolated query with parameterized version; move secret to env var
+- **significant**: Add auth middleware layer; redesign auth flow; change dependency version with breaking changes
 
 ### Risk Guide
 - **low**: Clear vulnerability with straightforward fix (add parameterized query, remove hardcoded secret)
@@ -737,11 +755,17 @@ Use the shared output schema with:
 - `category`: `"architecture"`
 - `subcategory`: one of `"circular-dependency"`, `"divergent-pattern"`, `"god-object"`, `"layer-violation"`, `"naming-inconsistency"`, `"api-inconsistency"`
 
-### Severity Guide
-- **critical**: Not typically used for architecture (unless a circular dependency causes runtime errors)
-- **high**: Circular dependencies crossing layers, god modules imported by >20 files, layer violations in core paths
-- **medium**: Divergent patterns creating maintenance burden, naming inconsistencies, minor circular deps
-- **low**: Style inconsistencies, minor organizational issues, suggestions for improvement
+### Classification Guide
+
+See `code-quality/references/finding-classification.md` for the full taxonomy and LoE scale.
+
+- **needs-fix**: Clear structural problem with a deterministic fix (break circular dep by extracting shared types, rename files to match convention, fix obvious layer violation).
+- **needs-input**: Consolidating a divergent pattern requires choosing which approach is canonical — user should decide. Splitting a god module where the right boundaries are unclear.
+
+Assign `loe` per finding:
+- **trivial**: Rename a file; fix an obvious layer violation with a single import change
+- **moderate**: Break circular dependency by extracting a shared types module; unify naming in one area
+- **significant**: Split a god module; break cycles across architectural layers; pattern used in 20+ files
 
 ### Risk Guide
 - **low**: Pattern can be unified with find-and-replace or simple refactor
@@ -989,11 +1013,17 @@ Use the shared output schema with:
 - `category`: `"ai-slop"`
 - `subcategory`: one of `"structural"`, `"error-handling"`, `"naming"`, `"comment"`, `"testing"`, `"import"`, `"type-annotation"`
 
-### Severity Guide
-- **critical**: Not used for slop (reserve for security/correctness)
-- **high**: Entire unnecessary abstraction layers, factory/strategy patterns with one variant, god-class wrappers
-- **medium**: Unnecessary wrappers, catch-rethrow chains, excessive comments, testing mocks not behavior
-- **low**: Minor naming issues, redundant type annotations, style-level slop
+### Classification Guide
+
+See `code-quality/references/finding-classification.md` for the full taxonomy and LoE scale.
+
+- **needs-fix**: All slop findings are `needs-fix` — the agent can determine the correct simplification. If the agent cannot determine the correct simplification, it should not flag the pattern at all.
+- **needs-input**: Only if simplifying would change the public API in a way the user must approve (e.g., removing an exported interface that external code might depend on).
+
+Assign `loe` per finding:
+- **trivial**: Delete a restating comment; remove a type-in-name suffix; inline a single-use one-liner
+- **moderate**: Remove an unnecessary wrapper with multiple call sites to update; remove a catch-rethrow chain
+- **significant**: Remove an entire abstraction layer (interface + implementation → concrete class direct usage); split a god class
 
 ### Risk Guide
 - **low**: Can be simplified by removing/inlining without affecting callers
@@ -1186,11 +1216,17 @@ Use the shared output schema with:
 - `category`: `"complexity"`
 - `subcategory`: one of `"long-function"`, `"deep-nesting"`, `"many-parameters"`, `"magic-values"`, `"long-file"`, `"high-cyclomatic"`, `"callback-hell"`, `"multiple-responsibilities"`
 
-### Severity Guide
-- **critical**: Not used for complexity
-- **high**: Functions >150 lines, nesting >5 levels, cyclomatic complexity >20, files >1000 lines, 9+ parameters
-- **medium**: Functions 50-150 lines, nesting 4-5 levels, cyclomatic complexity 11-20, files 500-1000 lines, 6-8 parameters
-- **low**: Borderline cases, magic values, minor parameter count issues, promise chains
+### Classification Guide
+
+See `code-quality/references/finding-classification.md` for the full taxonomy and LoE scale.
+
+- **needs-fix**: The refactoring path is clear (extract helpers, add guard clauses, replace magic value with constant, group parameters). Default for all complexity findings.
+- **needs-input**: The function has unclear responsibilities and the correct split requires domain knowledge the agent doesn't have; or the refactoring is in performance-critical code where extraction may harm performance.
+
+Assign `loe` per finding:
+- **trivial**: Extract one magic constant; add a guard clause to eliminate one nesting level
+- **moderate**: Extract 2-4 helper functions from a long function; group parameters into a struct/dataclass
+- **significant**: Split a 1000+ line file into focused modules; refactor a function with deep cyclomatic complexity and many callers
 
 ### Risk Guide
 - **low**: Can be refactored by extracting helper functions, adding early returns, introducing constants
@@ -1454,11 +1490,17 @@ Use the shared output schema with:
 - `category`: `"documentation"`
 - `subcategory`: one of `"readme-drift"`, `"broken-link"`, `"missing-docs"`, `"stale-todo"`, `"config-drift"`, `"api-doc-drift"`, `"changelog-drift"`, `"undocumented-component"`, `"registry-mismatch"`
 
-### Severity Guide
-- **critical**: Not used for documentation
-- **high**: README installation commands that don't work, documented API endpoints that don't exist, broken links in user-facing docs, components on disk with zero documentation across all surfaces (undocumented-component), registry mismatches where plugin.json and marketplace.json disagree
-- **medium**: Stale TODOs, missing documentation on public API, configuration drift, outdated examples, component count mismatches in README tables
-- **low**: Minor wording inaccuracies, orphaned doc files, missing docstrings on internal functions
+### Classification Guide
+
+See `code-quality/references/finding-classification.md` for the full taxonomy and LoE scale.
+
+- **needs-fix**: The correct update is clear (fix a broken link, remove a stale TODO referencing deleted code, update a command that no longer works). Default for documentation findings.
+- **needs-input**: Docs and code disagree and it's unclear which is correct (the feature may be half-implemented, or the doc may intentionally describe future intent).
+
+Assign `loe` per finding:
+- **trivial**: Fix a broken link; remove a stale TODO; correct a config key name
+- **moderate**: Update a README section to match current code; fix multiple broken API doc signatures
+- **significant**: Docs claim a feature exists that doesn't — may require code investigation before updating
 
 ### Risk Guide
 - **low**: Documentation-only fix, no code changes needed
@@ -1479,11 +1521,9 @@ All seven agents write JSON files conforming to this schema. The orchestrator me
   "timestamp": "<ISO-8601 timestamp>",
   "summary": {
     "total_findings": 0,
-    "by_severity": {
-      "critical": 0,
-      "high": 0,
-      "medium": 0,
-      "low": 0
+    "by_classification": {
+      "needs_fix": 0,
+      "needs_input": 0
     },
     "external_tools_used": ["<tool-name>"],
     "agent_analysis_used": true
@@ -1491,7 +1531,8 @@ All seven agents write JSON files conforming to this schema. The orchestrator me
   "findings": [
     {
       "id": "<AGENT_PREFIX>-001",
-      "severity": "critical|high|medium|low",
+      "classification": "needs-fix|needs-input",
+      "loe": "trivial|moderate|significant",
       "category": "<agent-category>",
       "subcategory": "<specific-subcategory>",
       "title": "Short human-readable description",
@@ -1503,6 +1544,7 @@ All seven agents write JSON files conforming to this schema. The orchestrator me
       "source": "agent-analysis|<tool-name>|agent-analysis+<tool-name>",
       "suggested_fix": "Actionable fix description, optionally with before/after code blocks",
       "risk": "low|medium|high",
+      "input_needed": "What decision the user must make — required when classification is needs-input, null otherwise",
       "dependencies": ["symbols or files affected by fixing this"],
       "related_findings": ["IDs of related findings from this agent"]
     }

--- a/code-quality/skills/unfuck/references/discovery-agents.md
+++ b/code-quality/skills/unfuck/references/discovery-agents.md
@@ -1002,7 +1002,7 @@ Do NOT flag these as slop — they are legitimate patterns:
 
 ## Before/After Snippets
 
-For the **top 20 worst offenders** (highest severity, most egregious), generate before/after code snippets showing the simplified version. Include these in the finding's `suggested_fix` field as fenced code blocks.
+For the **top 20 worst offenders** (highest LoE, most impactful), generate before/after code snippets showing the simplified version. Include these in the finding's `suggested_fix` field as fenced code blocks.
 
 ## Output
 
@@ -1083,8 +1083,8 @@ If tools are unavailable, proceed to manual analysis.
 3. **Calculate function length** from symbol start/end lines.
 
 4. **Flag thresholds:**
-   | Length | Severity | Notes |
-   |--------|----------|-------|
+   | Length | Level | Notes |
+   |--------|-------|-------|
    | 50-80 lines | medium | Worth reviewing |
    | 80-150 lines | high | Should definitely be split |
    | 150+ lines | high | Urgent — almost certainly doing too many things |
@@ -1102,8 +1102,8 @@ If tools are unavailable, proceed to manual analysis.
 2. **Read the surrounding function** to confirm nesting depth.
 
 3. **Flag thresholds:**
-   | Depth | Severity | Notes |
-   |-------|----------|-------|
+   | Depth | Level | Notes |
+   |-------|-------|-------|
    | 4 levels | low | Mildly complex |
    | 5 levels | medium | Should use early returns or extract |
    | 6+ levels | high | Requires refactoring |
@@ -1119,8 +1119,8 @@ If tools are unavailable, proceed to manual analysis.
 1. For functions found in Step 2, use LSP `hover` to get the full signature.
 
 2. **Flag thresholds:**
-   | Count | Severity | Notes |
-   |-------|----------|-------|
+   | Count | Level | Notes |
+   |-------|-------|-------|
    | 5-6 params | low | Consider options object |
    | 7-8 params | medium | Should use options object/dataclass |
    | 9+ params | high | Definitely needs restructuring |
@@ -1158,8 +1158,8 @@ wc -l $(find {project_path} -name '*.py' -o -name '*.ts' -o -name '*.tsx' -o -na
 ```
 
 **Flag thresholds:**
-| Length | Severity | Notes |
-|--------|----------|-------|
+| Length | Level | Notes |
+|--------|-------|-------|
 | 300-500 lines | low | Getting long, review organization |
 | 500-1000 lines | medium | Should likely be split |
 | 1000+ lines | high | Definitely needs splitting |
@@ -1175,8 +1175,8 @@ For languages without radon/eslint, manually assess complexity:
 3. **Cyclomatic complexity = 1 + branch_count**
 
 **Flag thresholds:**
-| Complexity | Grade | Severity |
-|------------|-------|----------|
+| Complexity | Grade | Level |
+|------------|-------|-------|
 | 11-15 | C | medium |
 | 16-20 | D | high |
 | 21+ | E/F | high |

--- a/code-quality/skills/unfuck/references/external-tools.md
+++ b/code-quality/skills/unfuck/references/external-tools.md
@@ -215,7 +215,7 @@ src/models.py:15: unused import 'typing.Optional' (90% confidence)
   ]
 }
 ```
-- **Extraction:** Each result -> one security finding. Map Bandit severity to our severity scale.
+- **Extraction:** Each result -> one security finding. The `"severity"` field in Bandit output is Bandit's own severity label (LOW/MEDIUM/HIGH) — use it as a signal for LoE estimation when classifying findings per `code-quality/references/finding-classification.md`. All security findings default to `classification: needs-fix` unless they require an architectural decision.
 - **Fallback:** Agent OWASP walkthrough.
 
 #### ruff — Code Quality & Imports

--- a/code-quality/skills/unfuck/references/implementation-agents.md
+++ b/code-quality/skills/unfuck/references/implementation-agents.md
@@ -20,10 +20,10 @@ All implementation agents MUST follow these rules:
 
 4. **Don't fight other agents.** Other implementation agents run concurrently and may modify the same files. Always re-read current state before editing. If a file has unexpected changes, skip the finding and note the conflict.
 
-5. **Needs-review escape hatch.** If a finding is ambiguous, risky, or requires human judgment:
+5. **Needs-input escape hatch.** If a finding is ambiguous, risky, or requires human judgment:
    - Do NOT attempt the fix
-   - Log it as `needs-review` in your output with a clear explanation
-   - The orchestrator includes these in the cleanup report for the user
+   - Log it as `needs-input` in your FixSummary `needs_input_items` with `loe` and `input_needed` description
+   - Follow the Fixer Protocol in `code-quality/references/finding-classification.md` — emit FixSummary to Lead, Lead triages with user via AskUserQuestion
 
 6. **Conventional commit messages.** Use present indicative tense ("removes" not "remove", "fixes" not "fix", "consolidates" not "consolidate").
 
@@ -129,18 +129,15 @@ Run the full test suite one final time before committing.
 After completing all removals, produce this summary:
 
 ```
-Dead Code Removal Summary
+Dead Code Removal Summary (FixSummary format — see code-quality/references/finding-classification.md)
 =========================
-Removed: N items (X functions, Y classes, Z imports, W files, V variables)
-Skipped: M items
-  - <symbol> in <file>: <reason for skipping>
-  - ...
+Fixed: N items removed (X functions, Y classes, Z imports, W files, V variables)
 Cascade removals: K items (discovered and removed during cascade checks)
+Needs-input: R items (collected in FixSummary needs_input_items, sent to Lead for user triage)
+  - <finding ID>: LoE=<loe>. <description>. Input needed: <what decision>
+  - ...
 Test failures encountered: F
   - <file>:<line> <change attempted>: <error message>
-  - ...
-Needs-review: R items
-  - <symbol> in <file>: <why human judgment needed>
   - ...
 ```
 
@@ -245,28 +242,24 @@ After all consolidations, run the project's formatter.
 - NEVER change function signatures in ways that break existing callers — add optional parameters instead
 - NEVER consolidate across architectural boundaries (e.g., do not merge a frontend validator with a backend validator even if they look identical)
 - Use LSP `findReferences` for EVERY function before removing any copy
-- If duplicates have subtle behavioral differences you cannot reconcile safely, flag as `needs-review`
+- If duplicates have subtle behavioral differences you cannot reconcile safely, flag as `needs-input`
 - Test after EACH consolidation group, not just at the end
 
 ## Output
 
 ```
-Duplicate Consolidation Summary
+Duplicate Consolidation Summary (FixSummary format — see code-quality/references/finding-classification.md)
 ================================
-Consolidated: N duplicate groups (X exact, Y near-exact, Z structural)
+Fixed: N duplicate groups consolidated (X exact, Y near-exact, Z structural)
 Total lines removed: L
 New shared functions created: C
   - <shared_module>:<function_name> (replaces N copies)
-  - ...
 Call sites updated: S
-Skipped: M groups
-  - <group description>: <reason for skipping>
+Needs-input: R groups (collected in FixSummary needs_input_items, sent to Lead for user triage)
+  - <finding ID>: LoE=<loe>. <description>. Input needed: <e.g., subtle behavioral differences — which copy is canonical?>
   - ...
 Test failures encountered: F
   - <group>: <error message>
-  - ...
-Needs-review: R groups
-  - <group>: <why human judgment needed — e.g., subtle behavioral differences>
   - ...
 ```
 
@@ -303,13 +296,9 @@ You follow `code-quality:security` patterns: fix with precision, test after ever
 
 ## Strategy
 
-### Step 1: Triage by Severity
+### Step 1: Process in File Order per Fixer Protocol
 
-Process findings in strict severity order:
-1. **CRITICAL** — Active vulnerabilities, exposed secrets, authentication bypasses. Fix immediately.
-2. **HIGH** — Injection vectors, authorization gaps, session management flaws. Fix next.
-3. **MEDIUM** — Missing security headers, overly broad permissions, weak configurations. Fix after high.
-4. **LOW** — Informational leakage, minor hardening opportunities. Fix last.
+Process all `needs-fix` findings in file order (per `code-quality/references/finding-classification.md` Fixer Protocol). Within a file, order by LoE descending (significant > moderate > trivial), then by risk of fix ascending (low > medium > high). Collect all `needs-input` findings into `needs_input_items` in the FixSummary — do NOT attempt to fix them unilaterally.
 
 ### Step 2: Fix by Vulnerability Type
 
@@ -359,7 +348,7 @@ For each finding, apply the appropriate fix pattern:
 1. Check the CVE details to understand the vulnerability
 2. Update to the latest patched version
 3. Check for breaking changes in the changelog between current and target version
-4. If breaking changes exist, flag as `needs-review`
+4. If breaking changes exist, flag as `needs-input`
 
 **Missing security headers:**
 1. Add middleware or configuration for security headers:
@@ -390,35 +379,31 @@ After all fixes, run the formatter, then run the full test suite.
 
 ## Safety Rules
 
-- NEVER auto-fix if the fix could change business logic — create a `needs-review` entry instead
+- NEVER auto-fix if the fix could change business logic — create a `needs-input` entry instead
 - NEVER remove existing security middleware, checks, or guards even if they seem redundant (defense in depth)
 - NEVER log or print secret values, even in error messages or debug output
 - NEVER weaken existing security controls (e.g., do not relax a strict CSP to fix a convenience issue)
 - NEVER commit actual secret values — only references to environment variables
 - Test after EVERY security fix, not in batches
-- If a security fix requires architectural changes (e.g., redesigning the auth flow), flag as `needs-review`
-- If you are unsure whether a fix is correct, do not apply it — flag as `needs-review`
+- If a security fix requires architectural changes (e.g., redesigning the auth flow), flag as `needs-input`
+- If you are unsure whether a fix is correct, do not apply it — flag as `needs-input`
 
 ## Output
 
 ```
-Security Fix Summary
+Security Fix Summary (FixSummary format — see code-quality/references/finding-classification.md)
 ====================
-Fixed: N vulnerabilities (X critical, Y high, Z medium, W low)
-  - [CRITICAL] <description> in <file>:<line> — <fix applied>
-  - [HIGH] <description> in <file>:<line> — <fix applied>
+Fixed: N vulnerabilities
+  - <finding ID> in <file>:<line> — <fix applied>
   - ...
-Skipped: M findings
-  - <finding>: <reason>
-  - ...
-Test failures encountered: F
-  - <file>:<line> <fix attempted>: <error message>
-  - ...
-Needs-review: R findings
-  - <finding>: <why human judgment needed>
+Needs-input: R findings (collected in FixSummary needs_input_items, sent to Lead for user triage)
+  - <finding ID>: LoE=<loe>. <description>. Input needed: <what decision>
   - ...
 Secrets found and rotated: S
   - <secret type> in <file> — replaced with env var <VAR_NAME>
+  - ...
+Test failures encountered: F
+  - <file>:<line> <fix attempted>: <error message>
   - ...
 ```
 
@@ -460,12 +445,9 @@ This is nuanced work requiring strong pattern recognition. You must understand W
 
 ## Strategy
 
-### Step 1: Prioritize by Severity
+### Step 1: Process in File Order per Fixer Protocol
 
-Process findings from highest to lowest severity:
-1. **High severity** — Unnecessary abstractions that actively harm readability (factory patterns with 1 variant, interfaces with 1 implementor)
-2. **Medium severity** — Verbose patterns that add noise (restating comments, type-in-name, catch-and-rethrow)
-3. **Low severity** — Minor verbosity (overly long variable names, unnecessary intermediate variables)
+Process all `needs-fix` findings in file order (per `code-quality/references/finding-classification.md` Fixer Protocol). Within a file, order by LoE descending (significant > moderate > trivial), then by risk of fix ascending (low > medium > high). Collect all `needs-input` findings into `needs_input_items` in the FixSummary.
 
 ### Step 2: Understand Before Simplifying
 
@@ -561,7 +543,7 @@ counter += 1
 
 **Testing mocks that mock the thing being tested:**
 - Rewrite the test to test real behavior
-- Flag as `needs-review` if the test is complex and you are unsure of the intended behavior
+- Flag as `needs-input` if the test is complex and you are unsure of the intended behavior
 
 **Unnecessary intermediate variables:**
 - If a variable is assigned once and used once on the very next line, inline it
@@ -590,27 +572,24 @@ After all simplifications, run the project's formatter, then the full test suite
 - NEVER simplify code that handles concurrent access (locks, semaphores, atomic operations)
 - NEVER simplify code in hot paths without understanding performance implications
 - NEVER change the public API of a module (exported function names, parameter types, return types)
-- If a simplification would change how errors propagate to callers, flag as `needs-review`
-- If you are unsure whether a pattern is slop or intentional design, flag as `needs-review`
+- If a simplification would change how errors propagate to callers, flag as `needs-input`
+- If you are unsure whether a pattern is slop or intentional design, flag as `needs-input`
 - Test after every 5 simplifications
 
 ## Output
 
 ```
-AI Slop Simplification Summary
+AI Slop Simplification Summary (FixSummary format — see code-quality/references/finding-classification.md)
 ================================
-Simplified: N findings
-  - <file>:<line> — <pattern type>: <brief description of change>
+Simplified: N needs-fix findings
+  - <finding ID> in <file>:<line> — <pattern type>: <brief description of change>
   - ...
 Total lines removed: L (net reduction)
-Skipped: M findings
-  - <finding>: <reason>
+Needs-input: R findings (collected in FixSummary needs_input_items, sent to Lead for user triage)
+  - <finding ID>: LoE=<loe>. <description>. Input needed: <what decision>
   - ...
 Test failures encountered: F
   - <file>:<line> <simplification attempted>: <error message>
-  - ...
-Needs-review: R findings
-  - <finding>: <why human judgment needed>
   - ...
 ```
 
@@ -721,36 +700,30 @@ After all unification changes, run the formatter, then the full test suite.
 - If fixing a circular dependency requires adding a new module, ensure it is properly integrated (added to `__init__.py`, build configs, etc.)
 - NEVER change the external behavior of any function while unifying its implementation pattern
 - NEVER unify patterns across intentional boundaries (e.g., different microservices may intentionally use different patterns)
-- If unifying a pattern would require changing >20 files, flag as `needs-review` first
+- If unifying a pattern would require changing >20 files, flag as `needs-input` first
 - If a naming convention is language-idiomatic in its context (e.g., `camelCase` in JavaScript, `snake_case` in Python), do not cross-language standardize
-- When in doubt about which pattern should be dominant, flag as `needs-review`
+- When in doubt about which pattern should be dominant, flag as `needs-input`
 
 ## Output
 
 ```
-Architecture Unification Summary
+Architecture Unification Summary (FixSummary format — see code-quality/references/finding-classification.md)
 ==================================
-Circular dependencies broken: N
-  - <cycle description> — <strategy used>
-  - ...
-Patterns standardized: P
-  - <pattern type>: migrated M instances to match dominant pattern
-  - ...
-Layer violations fixed: L
-  - <code> moved from <source> to <destination>
-  - ...
-God objects split: G
-  - <object> split into N focused modules
-  - ...
-Naming conventions unified: C renames
-Skipped: S findings
-  - <finding>: <reason>
+Fixed: N findings resolved
+  Circular dependencies broken: N
+    - <cycle description> — <strategy used>
+  Patterns standardized: P
+    - <pattern type>: migrated M instances to match dominant pattern
+  Layer violations fixed: L
+    - <code> moved from <source> to <destination>
+  God objects split: G
+    - <object> split into N focused modules
+  Naming conventions unified: C renames
+Needs-input: R findings (collected in FixSummary needs_input_items, sent to Lead for user triage)
+  - <finding ID>: LoE=<loe>. <description>. Input needed: <what decision>
   - ...
 Test failures encountered: F
   - <change>: <error message>
-  - ...
-Needs-review: R findings
-  - <finding>: <why human judgment needed>
   - ...
 ```
 
@@ -855,7 +828,7 @@ For each TODO/FIXME:
 2. **References a fixed issue:** Remove the FIXME (verify the issue is actually fixed)
 3. **References legitimate future work:** Keep it
 4. **References an external issue tracker:** Check if the issue is still open. If closed, remove the TODO
-5. **Is vague or context-free** (e.g., `# TODO: fix this`): Flag as `needs-review`
+5. **Is vague or context-free** (e.g., `# TODO: fix this`): Flag as `needs-input`
 
 ### Step 6: Update CHANGELOG (if it exists)
 
@@ -879,31 +852,26 @@ After all documentation updates, verify markdown formatting is correct:
 - Do NOT add documentation for internal helper functions
 - Do NOT change the tone or voice of existing documentation
 - Do NOT add badges, shields, or decorative elements unless the project already uses them
-- Do NOT create new documentation files — only update existing ones (unless the project has zero docs, in which case flag as `needs-review`)
+- Do NOT create new documentation files — only update existing ones (unless the project has zero docs, in which case flag as `needs-input`)
 - Verify every command you document by checking the actual build/config files
 - When in doubt about whether to document something, do not document it
 
 ## Output
 
 ```
-Documentation Update Summary
+Documentation Update Summary (FixSummary format — see code-quality/references/finding-classification.md)
 ==============================
-Files updated: N
-  - <file>: <changes made>
-  - ...
-Broken links fixed: L
-Stale TODOs removed: T
-  - <file>:<line> — <reason for removal>
-  - ...
-Public APIs documented: A
-  - <module>:<function> — added <style> docstring
-  - ...
-CHANGELOG updated: yes/no
-Skipped: S findings
-  - <finding>: <reason>
-  - ...
-Needs-review: R findings
-  - <finding>: <why human judgment needed>
+Fixed: N documentation findings resolved
+  Files updated: N
+    - <file>: <changes made>
+  Broken links fixed: L
+  Stale TODOs removed: T
+    - <file>:<line> — <reason for removal>
+  Public APIs documented: A
+    - <module>:<function> — added <style> docstring
+  CHANGELOG updated: yes/no
+Needs-input: R findings (collected in FixSummary needs_input_items, sent to Lead for user triage)
+  - <finding ID>: LoE=<loe>. <description>. Input needed: <what decision>
   - ...
 ```
 
@@ -940,15 +908,9 @@ You follow `code-quality:code-simplifier` patterns: extract clearly, name descri
 
 ## Strategy
 
-### Step 1: Prioritize by Impact
+### Step 1: Process in File Order per Fixer Protocol
 
-Process findings that provide the most readability improvement first:
-1. **Long functions (>50 lines)** — highest impact, often contain multiple extractable sections
-2. **Deep nesting (>4 levels)** — second highest, significantly reduces cognitive load
-3. **Magic numbers/strings** — medium impact, improves maintainability
-4. **Long parameter lists (>5 params)** — medium impact, improves call-site readability
-5. **Nested ternaries** — medium impact, improves debuggability
-6. **Long files (>500 lines)** — lowest priority, most risk (many cross-file changes)
+Process all `needs-fix` findings in file order (per `code-quality/references/finding-classification.md` Fixer Protocol). Within a file, order by LoE descending (significant > moderate > trivial), then by risk of fix ascending (low > medium > high). Collect all `needs-input` findings into `needs_input_items` in the FixSummary.
 
 ### Step 2: Refactor Long Functions
 
@@ -1120,7 +1082,7 @@ For each file >500 lines:
    - Which groups become separate files?
    - What should each new file be named?
    - Will the split create circular imports?
-3. If the split would create circular dependencies, flag as `needs-review`
+3. If the split would create circular dependencies, flag as `needs-input`
 4. Extract each group into its own file
 5. Update the original file to re-export from the new files (maintain backward compatibility)
 6. Update ALL imports across the codebase (use LSP `findReferences` + Grep)
@@ -1144,41 +1106,34 @@ After all refactorings, run the formatter, then the full test suite.
 - NEVER change the observable behavior of any function while reducing its complexity
 - NEVER change the public API (function names, parameters, return types) without updating all callers
 - NEVER extract a function if the extracted code relies on local variables that would require passing >5 parameters (that trades one complexity for another)
-- NEVER split a file if the result would create circular dependencies — flag as `needs-review`
+- NEVER split a file if the result would create circular dependencies — flag as `needs-input`
 - When extracting guard clauses, ensure the error types and messages are preserved exactly
 - When replacing magic values, verify the constant is not already defined elsewhere in the codebase (avoid duplicating constants)
-- If a complexity finding is in performance-critical code (tight loops, hot paths), flag as `needs-review` — extraction can impact performance
+- If a complexity finding is in performance-critical code (tight loops, hot paths), flag as `needs-input` — extraction can impact performance
 
 ## Output
 
 ```
-Complexity Reduction Summary
+Complexity Reduction Summary (FixSummary format — see code-quality/references/finding-classification.md)
 ==============================
-Long functions refactored: N (extracted M helper functions)
-  - <file>:<function> — split into N functions: <names>
-  - ...
-Deep nesting flattened: D
-  - <file>:<function> — reduced from N levels to M levels
-  - ...
-Magic values extracted: V (created C named constants)
-  - <file>:<line> — <value> becomes <CONSTANT_NAME>
-  - ...
-Long parameter lists simplified: P
-  - <file>:<function> — N params grouped into <TypeName>
-  - ...
-Nested ternaries converted: T
-Long files split: S
-  - <file> — split into N files: <names>
-  - ...
+Fixed: N needs-fix findings
+  Long functions refactored: N (extracted M helper functions)
+    - <file>:<function> — split into N functions: <names>
+  Deep nesting flattened: D
+    - <file>:<function> — reduced from N levels to M levels
+  Magic values extracted: V (created C named constants)
+    - <file>:<line> — <value> becomes <CONSTANT_NAME>
+  Long parameter lists simplified: P
+    - <file>:<function> — N params grouped into <TypeName>
+  Nested ternaries converted: T
+  Long files split: S
+    - <file> — split into N files: <names>
 Total lines added/removed: +A/-R (net change: +/-N)
-Skipped: K findings
-  - <finding>: <reason>
+Needs-input: Q findings (collected in FixSummary needs_input_items, sent to Lead for user triage)
+  - <finding ID>: LoE=<loe>. <description>. Input needed: <what decision>
   - ...
 Test failures encountered: F
   - <refactoring>: <error message>
-  - ...
-Needs-review: Q findings
-  - <finding>: <why human judgment needed>
   - ...
 ```
 

--- a/code-quality/skills/unfuck/references/orchestration-playbook.md
+++ b/code-quality/skills/unfuck/references/orchestration-playbook.md
@@ -227,7 +227,7 @@ Each teammate, after writing its JSON output file, sends a summary to the team l
 ```
 SendMessage(type="message", recipient="team-lead",
   content="[Agent name] complete. Results: {run_dir}/discovery/[file].json\n\n
-    Summary: N findings (X critical, Y high, Z medium, W low)\n
+    Summary: N findings (X needs-fix, Y needs-input)\n
     Key findings: [1-3 sentence highlights]\n
     External tools used: [list]\n
     Gaps: [any analysis areas that couldn't be covered]",
@@ -276,7 +276,7 @@ Agent(name="synthesis-planner", subagent_type="general-purpose", model="opus",
      prompt="[context bundle]\n\n[Full synthesis instructions below]\n\nRun directory: {run_dir}")
 ```
 
-The synthesis teammate performs Steps 2.1-2.6 independently and writes the cleanup plan to disk. When done, it sends a brief summary to the team lead via SendMessage (total findings, by-severity breakdown, categories with findings, any items needing user review).
+The synthesis teammate performs Steps 2.1-2.6 independently and writes the cleanup plan to disk. When done, it sends a brief summary to the team lead via SendMessage (total findings, by-classification breakdown, categories with findings, any items needing user review).
 
 The orchestrator then handles Step 2.7 (user checkpoint) based on the summary.
 
@@ -335,7 +335,7 @@ Assign findings to implementation categories in this priority order:
 | 6 | **Architecture** | Structural changes last, most risk, benefits from prior cleanup |
 | 7 | **Documentation** | Always last -- reflects all prior changes accurately |
 
-Within each category, order findings by severity (critical > high > medium > low), then by risk of fix (low > medium > high).
+Within each category, order findings by LoE descending (significant > moderate > trivial), then by risk of fix ascending (low > medium > high). See `code-quality/references/finding-classification.md` for the LoE scale and Fixer Protocol.
 
 ### Step 2.5: Generate cleanup plan
 
@@ -351,21 +351,23 @@ Tools used: <list of available tools that were actually used by agents>
 
 ## Summary
 - Total findings: N
-- By severity: N critical, N high, N medium, N low
+- By classification: N needs-fix, N needs-input
 - By category: N dead-code, N duplicates, N security, N ai-slop, N complexity, N architecture, N documentation
 - Estimated risk: low/medium/high per category
 
 ## Category 1: Security (N findings)
 
 ### Finding S-001: <title>
-- **Severity:** critical|high|medium|low
+- **Classification:** needs-fix | needs-input
+- **LoE:** trivial | moderate | significant
 - **File:** path/to/file.py:42-58
 - **Description:** <what's wrong>
 - **Evidence:** <how it was detected>
 - **Source:** <agent name> + <tool name if applicable>
 - **Suggested fix:** <from implementation-agents.md strategy>
-- **Risk:** low|medium|high (risk of the fix breaking something)
+- **Risk:** low|medium|high (risk of the fix breaking something — probability of regression, not finding severity)
 - **Tags:** systemic-security (if cross-referenced)
+- **Input needed:** <what decision the user must make — only when classification is needs-input>
 
 ### Finding S-002: ...
 
@@ -387,9 +389,9 @@ Tools used: <list of available tools that were actually used by agents>
 ## Category 7: Documentation (N findings)
 ...
 
-## Deferred Items
-Items intentionally excluded (too risky for automated cleanup):
-- <item>: <reason>
+## Needs-Input Items
+Findings that require a user decision before the Fixer can act. See `code-quality/references/finding-classification.md` Fixer Protocol for triage procedure.
+- <finding ID>: <description> (LoE: <trivial|moderate|significant>) — <what decision is needed>
 ```
 
 ### Step 2.6: Create task list
@@ -430,7 +432,7 @@ AskUserQuestion(
     "header": "Cleanup Scope",
     "options": [
       {"label": "Full cleanup", "description": "Apply all N findings across M categories"},
-      {"label": "Skip [risky category]", "description": "Apply all except [category] (N findings deferred)"},
+      {"label": "Skip [risky category]", "description": "Apply all except [category] (N findings recorded as user_deferred in final FixSummary)"},
       {"label": "Security + dead code only", "description": "Conservative cleanup — only the safest categories"},
       {"label": "Review plan first", "description": "I'll review {run_dir}/cleanup-plan.md before proceeding"}
     ],
@@ -607,8 +609,9 @@ Branch: cleanup/comprehensive-{run-id}
 - **Lines removed:** N
 - **Lines added:** N
 - **Net delta:** -N lines (or +N if documentation additions outweigh removals)
-- **Issues fixed:** N (across M categories)
-- **Issues blocked:** N (need manual review)
+- **Issues fixed:** N needs-fix findings (across M categories)
+- **Issues user_deferred:** N needs-input findings the user declined
+- **Issues blocked:** N (test failures — need manual review)
 
 ## Changes by Category
 
@@ -671,10 +674,9 @@ Commit: `stu5678` -- `docs: syncs documentation with code changes`
 | def5678 | refactor: removes dead code -- 15 unused items |
 | ... | ... |
 
-## Remaining Tech Debt
-Items intentionally deferred (low severity, high risk, or requires human decision):
-- [ ] <item>: <reason for deferral>
-- [ ] <item>: <reason for deferral>
+## Needs-Input Items (user_deferred)
+Items the user explicitly declined via triage:
+- [ ] <finding ID>: <description> — <user's reason for deferral>
 ```
 
 Get the line stats with:
@@ -703,7 +705,7 @@ Skill(skill="code-quality:reflect")
 ```
 
 This performs a final cross-check against the original cleanup plan, verifying:
-- All planned categories were addressed (or documented as blocked/deferred)
+- All planned categories were addressed (or documented as blocked or user_deferred)
 - No regression was introduced
 - The cleanup report accurately reflects what was done
 - Version bumps were applied where needed
@@ -742,11 +744,9 @@ All 7 discovery agents MUST write their output using this schema. The orchestrat
   "timestamp": "2026-02-18T12:00:00Z",
   "summary": {
     "total_findings": 15,
-    "by_severity": {
-      "critical": 0,
-      "high": 3,
-      "medium": 8,
-      "low": 4
+    "by_classification": {
+      "needs_fix": 13,
+      "needs_input": 2
     },
     "external_tools_used": ["knip"],
     "agent_analysis_used": true
@@ -754,7 +754,8 @@ All 7 discovery agents MUST write their output using this schema. The orchestrat
   "findings": [
     {
       "id": "DC-001",
-      "severity": "high",
+      "classification": "needs-fix",
+      "loe": "trivial",
       "category": "dead-code",
       "title": "Unused exported function",
       "file": "src/utils/helpers.ts",
@@ -773,17 +774,20 @@ All 7 discovery agents MUST write their output using this schema. The orchestrat
 
 ### Field Definitions
 
+See `code-quality/references/finding-classification.md` for the canonical classification taxonomy and LoE scale.
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `$schema` | string | Always `"discovery-output"` |
 | `agent` | string | Agent name matching the roster (e.g., `"dead-code-hunter"`) |
 | `timestamp` | string | ISO 8601 timestamp of when the agent completed |
 | `summary.total_findings` | number | Total number of findings in this output |
-| `summary.by_severity` | object | Breakdown by severity level |
+| `summary.by_classification` | object | Breakdown by `needs_fix` and `needs_input` counts |
 | `summary.external_tools_used` | array | List of external tools that produced findings |
 | `summary.agent_analysis_used` | boolean | Whether the agent performed manual code analysis |
 | `findings[].id` | string | Unique within this agent's output. Format: category prefix + sequential number |
-| `findings[].severity` | string | `critical` = security vulnerability or data loss risk; `high` = definite issue, safe fix available; `medium` = probable issue, review recommended; `low` = style/preference, optional fix |
+| `findings[].classification` | string | `needs-fix` = agent can resolve independently; `needs-input` = requires user decision before acting |
+| `findings[].loe` | string | `trivial` = one-liner or mechanical; `moderate` = multi-file or some judgment; `significant` = architectural impact |
 | `findings[].category` | string | Primary category: `dead-code`, `duplicates`, `security`, `architecture`, `ai-slop`, `complexity`, `documentation` |
 | `findings[].title` | string | Short descriptive title |
 | `findings[].file` | string | Relative path from project root |
@@ -793,7 +797,7 @@ All 7 discovery agents MUST write their output using this schema. The orchestrat
 | `findings[].evidence` | string | How it was detected -- tool output, analysis reasoning, etc. |
 | `findings[].source` | string | `"agent-analysis"`, `"<tool-name>"`, or `"agent-analysis+<tool-name>"` for confirmed by both |
 | `findings[].suggested_fix` | string | Recommended fix strategy |
-| `findings[].risk` | string | Risk of the suggested fix breaking something: `low` (safe), `medium` (needs testing), `high` (needs review) |
+| `findings[].risk` | string | Risk of the fix breaking something (probability of regression): `low` (safe), `medium` (needs testing), `high` (needs review). Distinct from finding classification. |
 | `findings[].related_findings` | array | IDs of related findings in OTHER agents' output (populated during Phase 2 synthesis) |
 
 ### ID Prefix Conventions


### PR DESCRIPTION
## Summary
- Replaces 7-tier severity classification (critical/high/medium/low/informational) with 2-tier finding classification (needs-fix/needs-input) across all 8 skills, 8 agents, and shared schemas (37 files, 826 insertions, 654 deletions)
- Creates canonical shared reference `code-quality/references/finding-classification.md` with anti-deferral principle, classification taxonomy, LoE scale, ReviewFindings/FixSummary schemas, Fixer protocol, and verification protocol
- Adds structural enforcement via orchestration verification step (counts findings-in vs findings-addressed, escalates on delta)