### PR TITLE
fix(code-quality): replaces ghost severity labels

### DIFF
--- a/code-quality/skills/quality-gate/references/subagent-prompts.md
+++ b/code-quality/skills/quality-gate/references/subagent-prompts.md
@@ -298,7 +298,7 @@ FOCUS AREA FOR ALL WORK TYPES:
   and verify each documented claim, count, description, and behavior against on-disk
   reality. If docs say "5 agents" — count them. If docs say "supports X" — find the
   code that does it. If docs describe behavior — read the implementation and confirm.
-  Documentation that matches the plan but not the code is a CRITICAL finding.
+  Documentation that matches the plan but not the code is a `needs-fix` finding.
 
 For each issue found, report:
 - The specific problem

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -2001,7 +2001,7 @@ You have access to: Read, Glob, Grep.
 Read `documentation_impact` above. For each entry:
 1. Check if the documentation surface was actually modified (Grep for recent changes or
    read the file and verify the expected update exists)
-2. If an entry was NOT addressed, report as HIGH finding with the specific surface and
+2. If an entry was NOT addressed, report as `needs-fix` finding with the specific surface and
    expected action
 
 ### Step 2: Accuracy Verification
@@ -2026,7 +2026,7 @@ Perform your own component discovery using ecosystem-specific patterns from
 taxonomy § Component Discovery (don't trust the Docs agent's counts):
 - Detect project type from files present, apply matching discovery patterns
 - Compare YOUR counts against what's documented
-- If you find components the Docs agent missed, report as HIGH finding
+- If you find components the Docs agent missed, report as `needs-fix` finding
 
 ## Output
 

--- a/code-quality/skills/unfuck/references/discovery-agents.md
+++ b/code-quality/skills/unfuck/references/discovery-agents.md
@@ -367,7 +367,7 @@ Run each tool and parse its output. If a tool is unavailable, skip silently.
 ```bash
 unset HTTPS_PROXY HTTP_PROXY https_proxy http_proxy ALL_PROXY all_proxy; uvx semgrep --config auto --json --quiet . 2>/dev/null
 ```
-Parse the JSON output. Semgrep rules are high-quality — trust its findings but verify severity.
+Parse the JSON output. Semgrep rules are high-quality — trust its findings. The `"severity"` field in Semgrep output is Semgrep's own severity label (WARNING/ERROR) — use it as a signal for LoE estimation when classifying findings per `code-quality/references/finding-classification.md`.
 **Note:** The `unset` prefix clears ALL proxy variables (including `ALL_PROXY`/`all_proxy`) that cause semgrep to crash when set to empty strings — common in Claude Code environments.
 
 **Gitleaks (secrets detection):**
@@ -1342,7 +1342,7 @@ rules from the taxonomy. Key checks:
 - Component counts on disk must match counts in documentation
 - Package manifest descriptions must mention all major component types
 - Registry entries must match manifest entries
-- If a significant component exists on disk but isn't in ANY documentation surface → HIGH finding
+- If a significant component exists on disk but isn't in ANY documentation surface → `needs-fix` finding
 
 **What counts as "significant"** is defined by the trigger categories in the taxonomy — anything
 that would fire a documentation trigger if added in a PR must be documented.

--- a/code-quality/skills/unfuck/references/external-tools.md
+++ b/code-quality/skills/unfuck/references/external-tools.md
@@ -267,6 +267,7 @@ src/models.py:15: unused import 'typing.Optional' (90% confidence)
   ]
 }
 ```
+- **Extraction:** The `"severity"` field in Semgrep output is Semgrep's own severity label (WARNING/ERROR) — use it as a signal for LoE estimation when classifying findings per `code-quality/references/finding-classification.md`. All security findings default to `classification: needs-fix`.
 - **Auto-fix support:** `unset HTTPS_PROXY HTTP_PROXY https_proxy http_proxy ALL_PROXY all_proxy; uvx semgrep --config auto --autofix` (used in Phase 3, not Phase 1)
 - **Extraction:** Each result -> one security finding.
 - **Fallback:** Agent OWASP walkthrough with pattern matching via Grep.
@@ -290,7 +291,7 @@ src/models.py:15: unused import 'typing.Optional' (90% confidence)
   }
 ]
 ```
-- **Extraction:** Each leak -> one CRITICAL security finding.
+- **Extraction:** Each leak -> one `needs-fix` security finding.
 - **Fallback:** Agent regex scanning for common secret patterns:
   ```
   (?i)(api[_-]?key|secret|password|token|credential)\s*[:=]\s*['"][^'"]{8,}


### PR DESCRIPTION
## Summary
- Replaces 5 ghost severity labels (HIGH finding, CRITICAL finding) with `needs-fix` classification across 4 files
- Adds Semgrep severity disambiguation notes matching the existing Bandit pattern in external-tools.md
- Found by quality-gate Layer 2 adversarial reviewer after PR #93 merge