### PR TITLE
fix(code-quality): adds verification protocol to unfuck and quality-gate

### DIFF
--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -296,6 +296,11 @@ After all 4 reviewers complete, synthesize findings by classification
 4. Do NOT proceed to Layer 2 until all `needs-fix` items are fixed and all
    `needs-input` items are resolved via user decision.
 
+**Finding completion verification:** After fixing all `needs-fix` items and resolving all
+`needs-input` items, verify completeness per `code-quality/references/finding-classification.md`
+Verification Protocol: count total findings from all 4 reviewers vs (findings fixed +
+user-deferred items). Delta > 0 → findings were silently dropped → fix them before Layer 2.
+
 **The synthesis step is not optional.** If you find yourself writing "domain review skipped"
 or "findings noted for later," stop. Fix the needs-fix findings now.
 

--- a/code-quality/skills/unfuck/references/orchestration-playbook.md
+++ b/code-quality/skills/unfuck/references/orchestration-playbook.md
@@ -584,6 +584,16 @@ Agent(name="quality-review", subagent_type="general-purpose",
      prompt="Review these files for code quality issues introduced during cleanup:\n<file list>\n\nCheck for:\n- Broken imports after dead code removal\n- Inconsistent naming after duplicate consolidation\n- Missing error handling after simplification\n- Incomplete refactoring (half-done changes)")
 ```
 
+### Step 4.2b: Finding completion verification
+
+Verify all discovery findings were addressed. See `code-quality/references/finding-classification.md`
+Verification Protocol.
+
+Count `total_findings` from `{run_dir}/cleanup-plan.md` (the discovery synthesis output).
+Count `findings_fixed + user_deferred` from implementation agent FixSummary outputs.
+Delta > 0 → findings were silently dropped → escalate via AskUserQuestion before proceeding.
+Delta == 0 → all findings accounted for → proceed.
+
 ### Step 4.3: Verification patterns
 
 Apply `code-quality:quality-gate` verification patterns:


### PR DESCRIPTION
## Summary
- Adds finding-count verification step to unfuck orchestration Phase 4 (Step 4.2b)
- Adds finding completion verification to quality-gate Layer 1.5 synthesis protocol
- Found by quality-gate Layer 2 adversarial reviewer: verification protocol was only referenced in swarm (1/3 Fixer pipelines)