### PR TITLE
fix(code-quality): fixes ghost severity labels and deferral patterns

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, and index-repo",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/agents/performance.md
+++ b/code-quality/agents/performance.md
@@ -162,7 +162,7 @@ Use the classification and anti-deferral principle from `code-quality/references
    - Expected improvement: [Metrics]
 
 ### Other Optimizations
-1. [Optimization] — LoE: [estimate]
+1. [Optimization] - LoE: [estimate]
 
 ## Trade-offs
 

--- a/code-quality/agents/performance.md
+++ b/code-quality/agents/performance.md
@@ -161,8 +161,8 @@ Use the classification and anti-deferral principle from `code-quality/references
    - Solution: [Approach]
    - Expected improvement: [Metrics]
 
-### Needs-Input
-1. [Optimization requiring architectural decision] — LoE: [estimate]. Decision needed: [what decision]
+### Other Optimizations
+1. [Optimization] — LoE: [estimate]
 
 ## Trade-offs
 

--- a/code-quality/agents/performance.md
+++ b/code-quality/agents/performance.md
@@ -161,8 +161,8 @@ Use the classification and anti-deferral principle from `code-quality/references
    - Solution: [Approach]
    - Expected improvement: [Metrics]
 
-### Other Optimizations
-1. [Micro-optimization that may not be worth it]
+### Needs-Input
+1. [Optimization requiring architectural decision] — LoE: [estimate]. Decision needed: [what decision]
 
 ## Trade-offs
 
@@ -174,7 +174,7 @@ Use the classification and anti-deferral principle from `code-quality/references
 ## Implementation Priority
 1. [First optimization] - Highest impact, low risk
 2. [Second optimization] - Good impact, medium effort
-3. [Third optimization] - Consider if still needed
+3. [Third optimization] - LoE: [estimate]
 
 ## Benchmarking Plan
 - Baseline: [How to measure current state]

--- a/code-quality/agents/plan-adherence.md
+++ b/code-quality/agents/plan-adherence.md
@@ -129,4 +129,4 @@ Tasks completed but checkbox not checked: [list] — orchestrator should update 
 - **Completed but checkbox not checked**: If you find strong evidence an item is implemented but the plan still shows `- [ ]`, report it in the "Agent Note" section for the orchestrator to update. Do NOT write to the plan file yourself.
 - **Partial completion**: Report exactly which sub-steps are done and which are missing.
 - **Unparseable plan**: No task sections or no checkboxes found → needs-fix finding, not a silent pass.
-- **Missing plan file**: If the plan file path does not exist or is unreadable, report as CRITICAL: "Plan file not found at [path]" and halt verification.
+- **Missing plan file**: If the plan file path does not exist or is unreadable, report as a needs-fix finding: "Plan file not found at [path]" and halt verification.

--- a/code-quality/references/finding-classification.md
+++ b/code-quality/references/finding-classification.md
@@ -30,6 +30,11 @@ Two-tier taxonomy:
 - "This requires an architectural decision" IS `needs-input`.
 - "This is stylistic" is `needs-fix` — apply the project's conventions.
 
+**Post-triage states** (assigned after user interaction via AskUserQuestion, not by reviewers):
+
+- `user-acknowledged`: User has seen the finding and accepts responsibility. Counted as resolved.
+- `user-deferred`: User explicitly chose not to act on the finding now. Counted as resolved.
+
 ## Level of Effort (LoE) Scale
 
 Required for Fixer-pipeline skills (swarm, quality-gate, unfuck). Optional for advisory skills.
@@ -129,7 +134,8 @@ How the Fixer processes findings:
 
 Structural enforcement after Fixer completes and user triage is done:
 
-- Count findings-in vs (findings_fixed + user_deferred). Note: user-approved needs-input items
-  appear in `findings_fixed` after the Fixer processes them, so this formula covers all outcomes.
+- Count findings-in vs (findings_fixed + user_deferred + user_acknowledged). Note: user-approved
+  needs-input items appear in `findings_fixed` after the Fixer processes them, so this formula
+  covers all outcomes.
 - Delta > 0 → findings were silently dropped → escalate via AskUserQuestion
 - Delta == 0 → all findings accounted for → proceed

--- a/code-quality/references/finding-classification.md
+++ b/code-quality/references/finding-classification.md
@@ -134,8 +134,7 @@ How the Fixer processes findings:
 
 Structural enforcement after Fixer completes and user triage is done:
 
-- Count findings-in vs (findings_fixed + user_deferred + user_acknowledged). Note: user-approved
-  needs-input items appear in `findings_fixed` after the Fixer processes them, so this formula
-  covers all outcomes.
+- Count findings-in vs (findings_fixed + user_deferred). Note: user-approved needs-input items
+  appear in `findings_fixed` after the Fixer processes them, so this formula covers all outcomes.
 - Delta > 0 → findings were silently dropped → escalate via AskUserQuestion
 - Delta == 0 → all findings accounted for → proceed

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -343,8 +343,8 @@ For each `needs-input` TODO:
 - **Selected:** Update classification to `user-acknowledged` in inventory.json.
 - **Not selected:** Update classification to `user-deferred` in inventory.json.
 
-If zero `needs-input` TODOs exist, skip this step. If AskUserQuestion is unavailable, leave
-`needs-input` items as-is in the inventory (they are already surfaced in the output).
+If zero `needs-input` TODOs exist, skip this step. If AskUserQuestion is unavailable, treat
+`needs-input` items as `needs_context` in the inventory (surface them, don't hide them).
 
 ---
 

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -8,7 +8,7 @@ description: |
   - "Validate library usage"
   - "Review the entire project"
   Analyzes files in parallel with LSP and Context7, detecting issues, duplicates, and documentation drift.
-allowed-tools: [LSP, Read, Grep, Glob, Write, Bash, Agent, Skill, mcp__context7__resolve-library-id, mcp__context7__query-docs]
+allowed-tools: [LSP, Read, Grep, Glob, Write, Bash, Agent, Skill, AskUserQuestion, mcp__context7__resolve-library-id, mcp__context7__query-docs]
 ---
 
 # file-audit
@@ -320,6 +320,31 @@ IMPORTANT:
 | **error** | Broken code, security vulnerability | Requires immediate action (needs-fix) |
 | **warning** | Deprecated API, unused code, duplicates | Requires action (needs-fix) |
 | **info** | Style issue, minor optimization | Review and decide (needs-input if architectural, needs-fix if stylistic) |
+
+### Step 4.5: Needs-Input Resolution
+
+After writing inventory.json, check the generated TODO list for items classified as `needs-input`.
+If any exist, present them to the user before exiting. Do NOT exit with unresolved `needs-input`
+items.
+
+```
+AskUserQuestion(questions=[{
+  "question": "These audit findings need your decision. Select items to address — unselected items will be marked as deferred.",
+  "header": "File Audit",
+  "options": [
+    {"label": "{file}:{issue_type}", "description": "{action} (diagnostic: {diagnostic_level})"},
+    ...
+  ],
+  "multiSelect": true
+}])
+```
+
+For each `needs-input` TODO:
+- **Selected:** Update classification to `user-acknowledged` in inventory.json.
+- **Not selected:** Update classification to `user-deferred` in inventory.json.
+
+If zero `needs-input` TODOs exist, skip this step. If AskUserQuestion is unavailable, leave
+`needs-input` items as-is in the inventory (they are already surfaced in the output).
 
 ---
 

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -329,7 +329,7 @@ items.
 
 ```
 AskUserQuestion(questions=[{
-  "question": "These audit findings need your decision. Select items to address — unselected items will be marked as deferred.",
+  "question": "These audit findings need your decision. Select items to address - unselected items will be marked as deferred.",
   "header": "File Audit",
   "options": [
     {"label": "{file}:{issue_type}", "description": "{action} (diagnostic: {diagnostic_level})"},

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -321,6 +321,14 @@ IMPORTANT:
 | **warning** | Deprecated API, unused code, duplicates | Requires action (needs-fix) |
 | **info** | Style issue, minor optimization | Review and decide (needs-input if architectural, needs-fix if stylistic) |
 
+### Step 4.25: Finding Fidelity Check
+
+After writing inventory.json, verify no findings were lost during consolidation. Count the total
+issues discovered across all analyzed files (from per-file analysis results) and compare against
+the total todos in the inventory's `todos` array. If the todo count is less than the discovered
+issue count, findings were dropped during consolidation - investigate and restore them before
+proceeding. This is the same principle as the Reconcile step in pr-review and plan-review.
+
 ### Step 4.5: Needs-Input Resolution
 
 After writing inventory.json, check the generated TODO list for items classified as `needs-input`.

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -152,8 +152,14 @@ LEAD (you)
 2. **For analysis workloads:** present the synthesized summary and findings to the user.
    Offer to write a detailed report or create actionable TODO items.
 
-3. **For implementation workloads:** apply changes in priority order (needs-fix first, then
-   needs-input), run tests after each batch, verify nothing regressed. Roll back on test failure.
+3. **For implementation workloads:**
+   - Apply all `needs-fix` changes first, run tests, verify nothing regressed. Roll back on
+     test failure.
+   - For `needs-input` findings: present via multiSelect AskUserQuestion before applying.
+     Each option: label = finding ID, description = "[category] description (file:line)".
+     User selects which to apply. Selected items are applied, then tests re-run. Unselected
+     items are recorded as `user-deferred` in the final report. Do NOT apply `needs-input`
+     changes without user approval.
 
 4. **Write final report** to `{run_dir}/map-reduce-report.md` with:
    - Summary statistics (files analyzed, total findings, deduplicated, invalidated)

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -149,7 +149,11 @@ LEAD (you)
    > invalidated by cross-chunk validation. Consider re-running with different splits or a
    > single-agent analysis."
 
-2. **For analysis workloads:** present the synthesized summary and findings to the user.
+2. **For analysis workloads:** present the synthesized summary and `needs-fix` findings to the
+   user. For `needs-input` findings: present via multiSelect AskUserQuestion before finalizing
+   the report. Each option: label = finding ID, description = "[category] description
+   (file:line)". User selects items to acknowledge; unselected items are recorded as
+   `user-deferred` in the final report. Do NOT exit with unresolved `needs-input` findings.
    Offer to write a detailed report or create actionable TODO items.
 
 3. **For implementation workloads:**

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -152,10 +152,10 @@ LEAD (you)
 2. **For analysis workloads:** present the synthesized summary and `needs-fix` findings to the
    user. For `needs-input` findings: present via multiSelect AskUserQuestion before finalizing
    the report. Each option: label = finding ID, description = "[category] description
-   (file:line)". User selects items to acknowledge; unselected items are recorded as
-   `user-deferred` in the final report. Do NOT exit with unresolved `needs-input` findings.
-   If AskUserQuestion is unavailable, record all `needs-input` findings as `user-deferred` with
-   reason "AskUserQuestion unavailable - surfaced in report" in the final report.
+   (file:line)". Selected items are recorded as `user-acknowledged`; unselected items are
+   recorded as `user-deferred` in the final report. Do NOT exit with unresolved `needs-input`
+   findings. If AskUserQuestion is unavailable, treat all `needs-input` findings as
+   `needs_context` in the final report (surface them, don't hide them).
    Offer to write a detailed report or create actionable TODO items.
 
 3. **For implementation workloads:**
@@ -165,8 +165,8 @@ LEAD (you)
      Each option: label = finding ID, description = "[category] description (file:line)".
      User selects which to apply. Selected items are applied, then tests re-run. Unselected
      items are recorded as `user-deferred` in the final report. Do NOT apply `needs-input`
-     changes without user approval. If AskUserQuestion is unavailable, record all `needs-input`
-     findings as `user-deferred` with reason "AskUserQuestion unavailable - surfaced in report".
+     changes without user approval. If AskUserQuestion is unavailable, treat all `needs-input`
+     findings as `needs_context` in the final report (surface them, don't hide them).
 
 4. **Write final report** to `{run_dir}/map-reduce-report.md` with:
    - Summary statistics (files analyzed, total findings, deduplicated, invalidated)

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -154,6 +154,8 @@ LEAD (you)
    the report. Each option: label = finding ID, description = "[category] description
    (file:line)". User selects items to acknowledge; unselected items are recorded as
    `user-deferred` in the final report. Do NOT exit with unresolved `needs-input` findings.
+   If AskUserQuestion is unavailable, record all `needs-input` findings as `user-deferred` with
+   reason "AskUserQuestion unavailable - surfaced in report" in the final report.
    Offer to write a detailed report or create actionable TODO items.
 
 3. **For implementation workloads:**
@@ -163,7 +165,8 @@ LEAD (you)
      Each option: label = finding ID, description = "[category] description (file:line)".
      User selects which to apply. Selected items are applied, then tests re-run. Unselected
      items are recorded as `user-deferred` in the final report. Do NOT apply `needs-input`
-     changes without user approval.
+     changes without user approval. If AskUserQuestion is unavailable, record all `needs-input`
+     findings as `user-deferred` with reason "AskUserQuestion unavailable - surfaced in report".
 
 4. **Write final report** to `{run_dir}/map-reduce-report.md` with:
    - Summary statistics (files analyzed, total findings, deduplicated, invalidated)

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -245,7 +245,7 @@ The verifier receives: `{findings_json}` (the array above), `{plan_content}`,
 
 The verifier **re-reads the plan** to check each finding against plan content. It returns a
 JSON array with a verdict for each finding:
-`[{finding_id, verdict, investigation_summary, category}, ...]`
+`[{finding_id, verdict, investigation_summary, category, classification}, ...]`
 
 Verdicts: `verified` (finding accurately references plan content), `false_positive` (finding
 misread or misrepresents the plan), `needs_context` (cannot confirm or deny — requires human

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -256,6 +256,15 @@ Parse the verifier's response as JSON. If parsing fails, extract JSON from betwe
 and set `{verification_note}` to `"⚠ Verification failed — all findings shown unverified"`.
 If verification succeeded, set `{verification_note}` to empty string.
 
+### Reconcile
+
+**Finding fidelity check:** Before categorizing, verify the verifier returned a verdict for
+every submitted finding. For each finding ID in the original `{findings_json}`, check if a
+matching `finding_id` exists in the verifier's response. Any finding without a returned verdict
+is assigned verdict `unverified` with `investigation_summary`: "Verifier did not return a
+verdict for this finding." This prevents silent finding loss during verification — the same
+principle as the Fixer verification protocol in `code-quality/references/finding-classification.md`.
+
 ### Categorize
 
 The verifier assigns each finding to a category based on its nature:

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -262,7 +262,7 @@ If verification succeeded, set `{verification_note}` to empty string.
 every submitted finding. For each finding ID in the original `{findings_json}`, check if a
 matching `finding_id` exists in the verifier's response. Any finding without a returned verdict
 is assigned verdict `unverified` with `investigation_summary`: "Verifier did not return a
-verdict for this finding." This prevents silent finding loss during verification — the same
+verdict for this finding." This prevents silent finding loss during verification - the same
 principle as the Fixer verification protocol in `code-quality/references/finding-classification.md`.
 
 ### Categorize
@@ -301,7 +301,7 @@ Build a multiSelect AskUserQuestion with one option per `needs-input` finding:
 
 ```
 AskUserQuestion(questions=[{
-  "question": "These plan findings need your decision. Select items to acknowledge — unselected items will be marked as deferred.",
+  "question": "These plan findings need your decision. Select items to acknowledge - unselected items will be marked as deferred.",
   "header": "Plan Review",
   "options": [
     {"label": "{id}", "description": "[{Reviewer}] {description} ({location})"},
@@ -314,10 +314,10 @@ AskUserQuestion(questions=[{
 ### Record Decisions
 
 For each `needs-input` finding:
-- **Selected:** Update the finding's classification to `[user-acknowledged]` in the output.
-- **Not selected:** Update the finding's classification to `[user-deferred]` in the output.
+- **Selected:** Update the finding's classification to `user-acknowledged` in the output.
+- **Not selected:** Update the finding's classification to `user-deferred` in the output.
 
-Both outcomes are valid — the point is that every `needs-input` item gets a recorded user
+Both outcomes are valid - the point is that every `needs-input` item gets a recorded user
 decision, not silent deferral.
 
 ---

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -278,6 +278,41 @@ sections. Keep `needs_context` and `unverified` findings for the Needs Context s
 
 ---
 
+## Phase 3.5 — Needs-Input Resolution
+
+If any surviving findings (after filtering false positives) have classification `needs-input`,
+present them to the user before producing the report. Do NOT skip this step — the skill must
+not exit with unresolved `needs-input` items.
+
+If zero `needs-input` findings remain after Phase 3, skip to Phase 4.
+
+### Present to User
+
+Build a multiSelect AskUserQuestion with one option per `needs-input` finding:
+
+```
+AskUserQuestion(questions=[{
+  "question": "These plan findings need your decision. Select items to acknowledge — unselected items will be marked as deferred.",
+  "header": "Plan Review",
+  "options": [
+    {"label": "{id}", "description": "[{Reviewer}] {description} ({location})"},
+    ...
+  ],
+  "multiSelect": true
+}])
+```
+
+### Record Decisions
+
+For each `needs-input` finding:
+- **Selected:** Update the finding's classification to `[user-acknowledged]` in the output.
+- **Not selected:** Update the finding's classification to `[user-deferred]` in the output.
+
+Both outcomes are valid — the point is that every `needs-input` item gets a recorded user
+decision, not silent deferral.
+
+---
+
 ## Phase 4 — Terminal Output
 
 Print the structured report. Use `━` (U+2501) for the divider lines.
@@ -324,10 +359,14 @@ SPECIFICATION
      {location}
      Investigation: {investigation_summary}
 
+─── User Decisions ({user_decision_count}) ───
+  1. [{Reviewer}] {description} [{user-acknowledged | user-deferred}]
+     {location}
+
 {verification_note}
 {skipped_note}
 Reviewed by: {reviewer_list}
-Total raw: {total_raw} | Verified: {verified_count} | False positives removed: {false_positive_count} | Needs context: {needs_context_count}
+Total raw: {total_raw} | Verified: {verified_count} | False positives removed: {false_positive_count} | Needs context: {needs_context_count} | User decisions: {user_decision_count}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -346,10 +385,14 @@ Omit category sections with zero verified findings.
 at the bottom — they do NOT appear in category sections above. These are items the verifier
 could not confirm or deny and require human judgment.
 
+User decisions from Phase 3.5 appear in their own section. Both `user-acknowledged` and
+`user-deferred` items are shown — this is the audit trail proving every `needs-input` finding
+received an explicit user decision.
+
 ### No Findings After Verification
 
-Use this path only when `verified_count == 0` AND `needs_context_count == 0`. If
-`needs_context_count > 0`, use the "Findings Exist" path.
+Use this path only when `verified_count == 0` AND `needs_context_count == 0` AND
+`user_decision_count == 0`. If any count is > 0, use the "Findings Exist" path.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -365,7 +408,7 @@ Checked for: {checked_areas}
 
 {skipped_note}
 Reviewed by: {reviewer_list}
-Total raw: {total_raw} | Verified: 0 | False positives removed: {false_positive_count} | Needs context: 0
+Total raw: {total_raw} | Verified: 0 | False positives removed: {false_positive_count} | Needs context: 0 | User decisions: 0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -383,6 +426,8 @@ Total raw: {total_raw} | Verified: 0 | False positives removed: {false_positive_
 | Security reviewer skipped | Include in `{skipped_note}`: "Security (no auth/security paths detected)" |
 | All findings false positive | Output "no findings" report format (not an error) |
 | Verification JSON parse fails | All findings get `unverified` verdict, routed to Needs Context section; `{verification_note}` warns in output |
+| Zero `needs-input` findings | Skip Phase 3.5, proceed directly to Phase 4 |
+| AskUserQuestion unavailable | Treat all `needs-input` findings as `needs_context` in Phase 4 output (surface them, don't hide them) |
 
 ---
 

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -290,7 +290,7 @@ sections. Keep `needs_context` and `unverified` findings for the Needs Context s
 ## Phase 3.5 — Needs-Input Resolution
 
 If any surviving findings (after filtering false positives) have classification `needs-input`,
-present them to the user before producing the report. Do NOT skip this step — the skill must
+present them to the user before producing the report. Do NOT skip this step - the skill must
 not exit with unresolved `needs-input` items.
 
 If zero `needs-input` findings remain after Phase 3, skip to Phase 4.
@@ -395,7 +395,7 @@ at the bottom — they do NOT appear in category sections above. These are items
 could not confirm or deny and require human judgment.
 
 User decisions from Phase 3.5 appear in their own section. Both `user-acknowledged` and
-`user-deferred` items are shown — this is the audit trail proving every `needs-input` finding
+`user-deferred` items are shown - this is the audit trail proving every `needs-input` finding
 received an explicit user decision.
 
 ### No Findings After Verification

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -322,7 +322,7 @@ they appear in the Needs Context section with the verification failure note.
 ## Phase 3.5 — Needs-Input Resolution
 
 If any surviving findings (after filtering false positives) have classification `needs-input`,
-present them to the user before producing the report. Do NOT skip this step — the skill must
+present them to the user before producing the report. Do NOT skip this step - the skill must
 not exit with unresolved `needs-input` items.
 
 If zero `needs-input` findings remain after Phase 3, skip to Phase 4.
@@ -423,7 +423,7 @@ are items the verifier could not confirm or deny and require human judgment. The
 hidden or filtered — they are surfaced transparently.
 
 User decisions from Phase 3.5 appear in their own section. Both `user-acknowledged` and
-`user-deferred` items are shown — this is the audit trail proving every `needs-input` finding
+`user-deferred` items are shown - this is the audit trail proving every `needs-input` finding
 received an explicit user decision.
 
 ### No Findings After Verification

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -294,7 +294,7 @@ and a note: "Verification failed — showing all findings unverified."
 every submitted finding. For each finding ID in the original `{findings_json}`, check if a
 matching `finding_id` exists in the verifier's response. Any finding without a returned verdict
 is assigned verdict `unverified` with `investigation_summary`: "Verifier did not return a
-verdict for this finding." This prevents silent finding loss during verification — the same
+verdict for this finding." This prevents silent finding loss during verification - the same
 principle as the Fixer verification protocol in `code-quality/references/finding-classification.md`.
 
 ### Categorize
@@ -333,7 +333,7 @@ Build a multiSelect AskUserQuestion with one option per `needs-input` finding:
 
 ```
 AskUserQuestion(questions=[{
-  "question": "These findings need your decision. Select items to acknowledge — unselected items will be marked as deferred.",
+  "question": "These findings need your decision. Select items to acknowledge - unselected items will be marked as deferred.",
   "header": "PR Review",
   "options": [
     {"label": "{id}", "description": "[{Reviewer}] {description} ({file}:{line})"},
@@ -346,12 +346,12 @@ AskUserQuestion(questions=[{
 ### Record Decisions
 
 For each `needs-input` finding:
-- **Selected:** Update the finding's classification to `[user-acknowledged]` in the output.
+- **Selected:** Update the finding's classification to `user-acknowledged` in the output.
   The user has seen it and accepts responsibility.
-- **Not selected:** Update the finding's classification to `[user-deferred]` in the output.
+- **Not selected:** Update the finding's classification to `user-deferred` in the output.
   The user explicitly chose not to act on it now.
 
-Both outcomes are valid — the point is that every `needs-input` item gets a recorded user
+Both outcomes are valid - the point is that every `needs-input` item gets a recorded user
 decision, not silent deferral.
 
 ---

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -288,6 +288,15 @@ Parse the verifier's response as JSON. If parsing fails, extract JSON from betwe
 `[` and last `]` markers. If that also fails, include all findings with verdict `unverified`
 and a note: "Verification failed — showing all findings unverified."
 
+### Reconcile
+
+**Finding fidelity check:** Before categorizing, verify the verifier returned a verdict for
+every submitted finding. For each finding ID in the original `{findings_json}`, check if a
+matching `finding_id` exists in the verifier's response. Any finding without a returned verdict
+is assigned verdict `unverified` with `investigation_summary`: "Verifier did not return a
+verdict for this finding." This prevents silent finding loss during verification — the same
+principle as the Fixer verification protocol in `code-quality/references/finding-classification.md`.
+
 ### Categorize
 
 The verifier assigns each finding to a category based on its nature (not its classification):

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -6,7 +6,7 @@ description: |
   reviewers (security, QA, performance, code quality, correctness, plan adherence),
   verifies findings by investigating source code, categorizes by type, and prints a
   structured report to the terminal. Never comments on GitHub PRs.
-allowed-tools: [Read, Glob, Grep, Bash, Agent]
+allowed-tools: [Read, Glob, Grep, Bash, Agent, AskUserQuestion]
 ---
 
 # PR Review Skill

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -310,6 +310,43 @@ they appear in the Needs Context section with the verification failure note.
 
 ---
 
+## Phase 3.5 — Needs-Input Resolution
+
+If any surviving findings (after filtering false positives) have classification `needs-input`,
+present them to the user before producing the report. Do NOT skip this step — the skill must
+not exit with unresolved `needs-input` items.
+
+If zero `needs-input` findings remain after Phase 3, skip to Phase 4.
+
+### Present to User
+
+Build a multiSelect AskUserQuestion with one option per `needs-input` finding:
+
+```
+AskUserQuestion(questions=[{
+  "question": "These findings need your decision. Select items to acknowledge — unselected items will be marked as deferred.",
+  "header": "PR Review",
+  "options": [
+    {"label": "{id}", "description": "[{Reviewer}] {description} ({file}:{line})"},
+    ...
+  ],
+  "multiSelect": true
+}])
+```
+
+### Record Decisions
+
+For each `needs-input` finding:
+- **Selected:** Update the finding's classification to `[user-acknowledged]` in the output.
+  The user has seen it and accepts responsibility.
+- **Not selected:** Update the finding's classification to `[user-deferred]` in the output.
+  The user explicitly chose not to act on it now.
+
+Both outcomes are valid — the point is that every `needs-input` item gets a recorded user
+decision, not silent deferral.
+
+---
+
 ## Phase 4 — Terminal Output
 
 Print the structured report. Use `━` (U+2501) for the divider lines.
@@ -356,8 +393,12 @@ STYLE & CONVENTIONS
      {file}:{line}
      Investigation: {investigation_summary}
 
+─── User Decisions ({user_decision_count}) ───
+  1. [{Reviewer}] {description} [{user-acknowledged | user-deferred}]
+     {file}:{line}
+
 Reviewed by: {reviewer_list}
-Total raw: {total_raw} | Verified: {verified_count} | False positives removed: {false_positive_count} | Needs context: {needs_context_count}
+Total raw: {total_raw} | Verified: {verified_count} | False positives removed: {false_positive_count} | Needs context: {needs_context_count} | User decisions: {user_decision_count}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -372,11 +413,15 @@ Findings with verdict `needs_context` appear in a dedicated section at the botto
 are items the verifier could not confirm or deny and require human judgment. They are NOT
 hidden or filtered — they are surfaced transparently.
 
+User decisions from Phase 3.5 appear in their own section. Both `user-acknowledged` and
+`user-deferred` items are shown — this is the audit trail proving every `needs-input` finding
+received an explicit user decision.
+
 ### No Findings After Verification
 
-Use this path only when `verified_count == 0` AND `needs_context_count == 0` (all findings
-were false positives, or no findings were reported). If `needs_context_count > 0`, use the
-"Findings Exist" path — it has the Needs Context section for those items.
+Use this path only when `verified_count == 0` AND `needs_context_count == 0` AND
+`user_decision_count == 0` (all findings were false positives, or no findings were reported).
+If any count is > 0, use the "Findings Exist" path.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -391,7 +436,7 @@ No verified issues found.
 Checked for: security, test coverage, performance, code quality, correctness, plan adherence.
 
 Reviewed by: {reviewer_list}
-Total raw: {total_raw} | Verified: 0 | False positives removed: {false_positive_count} | Needs context: 0
+Total raw: {total_raw} | Verified: 0 | False positives removed: {false_positive_count} | Needs context: 0 | User decisions: 0
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
@@ -414,6 +459,8 @@ After output, return to the original branch or worktree recorded in Phase 0.
 | Cannot checkout branch | Auto-stash and retry. If stash fails, stop: "Cannot checkout PR branch and stash failed." |
 | All findings false positive | Output "no findings" report format (not an error) |
 | Verification JSON parse fails | All findings get `unverified` verdict, treated as `needs_context` in output |
+| Zero `needs-input` findings | Skip Phase 3.5, proceed directly to Phase 4 |
+| AskUserQuestion unavailable | Treat all `needs-input` findings as `needs_context` in Phase 4 output (surface them, don't hide them) |
 
 ---
 

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -4,7 +4,7 @@ description: |
   Use when about to claim ANY work is complete — code, research, planning,
   config, or general answers. Also after /swarm, /spawn, subagent-driven
   development, or any significant deliverable.
-allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, SendMessage, Skill]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, SendMessage, Skill]
 ---
 
 # Quality Gate
@@ -300,6 +300,10 @@ After all 4 reviewers complete, synthesize findings by classification
 `needs-input` items, verify completeness per `code-quality/references/finding-classification.md`
 Verification Protocol: count total findings from all 4 reviewers vs (findings fixed +
 user-deferred items). Delta > 0 → findings were silently dropped → fix them before Layer 2.
+
+If AskUserQuestion is unavailable during synthesis, treat all `needs-input` findings as
+`needs_context` - surface them in the quality gate output report (don't hide them, don't
+block on them). Do NOT silently drop needs-input findings because the tool is unavailable.
 
 **The synthesis step is not optional.** If you find yourself writing "domain review skipped"
 or "findings noted for later," stop. Fix the needs-fix findings now.

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -143,9 +143,9 @@ Output: SecurityDesignReview JSON written to `{run_dir}/security-design-review.j
 (see schema in `references/communication-schema.md`).
 
 **Routing:**
-- needs-input requiring architectural redesign → Route back to Architect (Phase 2) with security feedback for
+- needs-fix findings requiring architect plan revision → Route back to Architect (Phase 2) with security feedback for
   redesign. Architect revises plan, re-run Phase 2.5. Maximum 2 Architect↔Security iterations.
-- no needs-input requiring redesign → Append security constraints to architect-plan.json as
+- no needs-fix findings blocking implementation → Append security constraints to architect-plan.json as
   `security_constraints` array and proceed to Phase 3.
 - If 2 iterations exhausted with unresolved findings → Escalate to human via AskUserQuestion.
 
@@ -532,8 +532,8 @@ Phase 2: Architect (opus)
 Phase 2.5: Security Design Review (conditional, opus)
   +-- Reviews architect-plan.json for threat surface
   +-- STRIDE analysis of proposed architecture
-  +-- needs-input requiring redesign --> back to Architect (max 2 iterations)
-  +-- no needs-input requiring redesign --> append security_constraints, proceed
+  +-- needs-fix findings requiring revision --> back to Architect (max 2 iterations)
+  +-- no needs-fix findings blocking implementation --> append security_constraints, proceed
   +-- Unresolved findings after 2 iterations --> AskUserQuestion
      |
      v

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -365,9 +365,9 @@ schema from `references/communication-schema.md`. Include all required fields.
 Use the classification taxonomy and LoE scale from `code-quality/references/finding-classification.md` (Finding Classification and Level of Effort sections).
 
 **Verdict guidance:**
-- `proceed` — No needs-fix findings blocking implementation. Append any constraints and let implementation begin.
-- `revise` — needs-fix findings present. Architect must revise the plan before implementation.
-- `escalate` — This is the second review iteration and needs-fix findings remain unresolved.
+- `proceed` — No `needs-fix` findings blocking implementation. Append any constraints and let implementation begin.
+- `revise` — `needs-fix` findings require architect plan revision before implementation.
+- `escalate` — This is the second review iteration and `needs-fix` findings remain unresolved.
 
 ## Communication
 

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -365,9 +365,9 @@ schema from `references/communication-schema.md`. Include all required fields.
 Use the classification taxonomy and LoE scale from `code-quality/references/finding-classification.md` (Finding Classification and Level of Effort sections).
 
 **Verdict guidance:**
-- `proceed` — No critical or high findings. Append any constraints and let implementation begin.
-- `revise` — Critical or high findings present. Architect must revise the plan before implementation.
-- `escalate` — This is the second review iteration and critical findings remain unresolved.
+- `proceed` — No needs-fix findings blocking implementation. Append any constraints and let implementation begin.
+- `revise` — needs-fix findings present. Architect must revise the plan before implementation.
+- `escalate` — This is the second review iteration and needs-fix findings remain unresolved.
 
 ## Communication
 

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -365,9 +365,9 @@ schema from `references/communication-schema.md`. Include all required fields.
 Use the classification taxonomy and LoE scale from `code-quality/references/finding-classification.md` (Finding Classification and Level of Effort sections).
 
 **Verdict guidance:**
-- `proceed` — No `needs-fix` findings blocking implementation. Append any constraints and let implementation begin.
-- `revise` — `needs-fix` findings require architect plan revision before implementation.
-- `escalate` — This is the second review iteration and `needs-fix` findings remain unresolved.
+- `proceed` - No `needs-fix` findings blocking implementation. Append any constraints and let implementation begin.
+- `revise` - `needs-fix` findings require architect plan revision before implementation.
+- `escalate` - This is the second review iteration and `needs-fix` findings remain unresolved.
 
 ## Communication
 

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -539,7 +539,7 @@ Check the `verdict` field:
 - Present to user via AskUserQuestion before proceeding:
   ```
   AskUserQuestion(questions=[{
-    "question": "Security design review found needs-fix issues that could not be resolved "
+    "question": "Security design review found issues requiring fixes that could not be resolved "
                 "after 2 architect revisions. Details: {run_dir}/security-design-review.json\n\n"
                 "How should we proceed?",
     "header": "Security Design: Unresolved Findings",

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -535,14 +535,14 @@ Check the `verdict` field:
 - After Architect revises the plan, increment iteration counter and re-run Phase 2.5.1
 - **Maximum 2 Architect↔Security iterations total**
 
-**`escalate`** (unresolvable Critical findings after 2 iterations):
+**`escalate`** (unresolvable needs-fix findings after 2 iterations):
 - Present to user via AskUserQuestion before proceeding:
   ```
   AskUserQuestion(questions=[{
-    "question": "Security design review found Critical issues that could not be resolved "
+    "question": "Security design review found needs-fix issues that could not be resolved "
                 "after 2 architect revisions. Details: {run_dir}/security-design-review.json\n\n"
                 "How should we proceed?",
-    "header": "Security Design: Unresolved Critical Findings",
+    "header": "Security Design: Unresolved Findings",
     "options": [
       {"label": "Proceed anyway", "description": "Accept the risk and continue to implementation"},
       {"label": "Abort", "description": "Stop — I will redesign the approach"}
@@ -1868,7 +1868,7 @@ User-deferred items: [none / list with reasons]
 ## Remaining Tech Debt
 
 - [ ] session-cleanup blocked — needs manual implementation
-- [ ] ui-reviewer flagged 2 low a11y improvements (deferred — requires design input)
+- [ ] ui-reviewer flagged 2 a11y improvements (user-deferred — requires design input)
 ```
 
 Get line stats:

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -516,13 +516,13 @@ proposed architecture, and writes its findings to `{run_dir}/security-design-rev
 After the security-design agent reports completion, read `{run_dir}/security-design-review.json`.
 Check the `verdict` field:
 
-**`proceed`** (no `needs-input` findings requiring architectural redesign):
+**`proceed`** (no `needs-fix` findings blocking implementation):
 - Append the `security_constraints` array from the review to `architect-plan.json` as a
   top-level `security_constraints` field
 - Notify the Architect of the constraints so they are available for Phase 3 clarification questions
 - Proceed to Phase 3
 
-**`revise`** (`needs-input` findings requiring plan revision present):
+**`revise`** (`needs-fix` findings require architect plan revision):
 - Send findings to the Architect:
   ```
   SendMessage(type="message", recipient="architect",

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1868,7 +1868,7 @@ User-deferred items: [none / list with reasons]
 ## Remaining Tech Debt
 
 - [ ] session-cleanup blocked — needs manual implementation
-- [ ] ui-reviewer flagged 2 a11y improvements (user-deferred — requires design input)
+- [ ] ui-reviewer flagged 2 a11y improvements (user-deferred - requires design input)
 ```
 
 Get line stats:

--- a/code-quality/skills/unfuck/references/external-tools.md
+++ b/code-quality/skills/unfuck/references/external-tools.md
@@ -269,7 +269,6 @@ src/models.py:15: unused import 'typing.Optional' (90% confidence)
 ```
 - **Extraction:** The `"severity"` field in Semgrep output is Semgrep's own severity label (WARNING/ERROR) — use it as a signal for LoE estimation when classifying findings per `code-quality/references/finding-classification.md`. All security findings default to `classification: needs-fix`.
 - **Auto-fix support:** `unset HTTPS_PROXY HTTP_PROXY https_proxy http_proxy ALL_PROXY all_proxy; uvx semgrep --config auto --autofix` (used in Phase 3, not Phase 1)
-- **Extraction:** Each result -> one security finding.
 - **Fallback:** Agent OWASP walkthrough with pattern matching via Grep.
 
 #### gitleaks — Secret Detection


### PR DESCRIPTION
## Summary
- Fixes 6 verified findings from PR review of #93, #94, #95: ghost severity labels (CRITICAL, critical/high, low) in plan-adherence agent, swarm agent-prompts, and orchestration-playbook
- Removes duplicate Extraction bullet in unfuck external-tools and replaces deferral-pattern placeholders in performance agent output template
- Bumps code-quality 3.10.0 → 3.10.1