### PR TITLE
feat(dev-guard): adds SubagentStop hook for FixSummary validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,9 +66,9 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.52.0",
+      "version": "1.53.0",
       "source": "./dev-guard",
-      "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
+      "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification",
       "category": "quality",
       "tags": ["hooks", "git", "validation", "policies"],
       "author": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Python 3.13+. Ruff line-length 100, select `E,W,F,I,UP,B,SIM`. Tests in `dev-gua
 Personal Claude Code plugin marketplace with 9 plugins. Master registry: `.claude-plugin/marketplace.json`.
 
 - **LSP plugins (5):** `pyright-uvx`, `vtsls-npx`, `gopls-go`, `vscode-html-css-npx`, `rust-analyzer-rustup`
-- **dev-guard/** — Tool selection guard, commit validation, pre-push review (only plugin with tests)
+- **dev-guard/** — Tool selection guard, commit validation, pre-push review, subagent completion verification (only plugin with tests)
 - **code-quality/** — Agents (architect, security, QA, performance, test-runner, code-reviewer, code-simplifier), skills (20), commands (4), and orchestration
 - **git-tools/** — Git history, hooks, commit review, contributing guide; SessionStart git instructions
 - **github-mcp/** — GitHub MCP server (HTTP, api.githubcopilot.com); full toolsets for PRs, issues, actions, code security

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Requires `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable. Enables `mcp__gith
 
 | Plugin | Description | Components | Docs |
 |--------|-------------|------------|------|
-| dev-guard | Tool selection policies, commit validation, and pre-push review | 3 hooks | [README](dev-guard/README.md) |
+| dev-guard | Tool selection policies, commit validation, pre-push review, and subagent completion verification | 5 hooks | [README](dev-guard/README.md) |
 
 > **⚠️ Important:** Dev-guard's `"ask"` action uses Claude Code's JSON `hookSpecificOutput` protocol. This correctly overrides `permissions.allow` auto-approve rules in the CLI but is [not supported in VS Code](https://github.com/anthropics/claude-code/issues/13339). See the [dev-guard README](dev-guard/README.md#action-field) for details.
 
@@ -93,6 +93,8 @@ Requires `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable. Enables `mcp__gith
 - **PreToolUse: Tool Selection Guard** - Enforces native tool usage, Python/Rust tooling, git safety, URL fetch guard
 - **PreToolUse: Pre-push Review** - Commit summary and suggestions when pushing 3+ commits
 - **PostToolUse: Commit Validation** - Conventional Commits format enforcement
+- **Stop:** Quality stop gate - Deterministic triage + LLM evaluation for completion claims and write activity
+- **SubagentStop:** FixSummary validation - Structural completeness check for Fixer subagent outputs
 
 ## Installation
 

--- a/code-quality/skills/fix/SKILL.md
+++ b/code-quality/skills/fix/SKILL.md
@@ -315,10 +315,11 @@ with reason "non-interactive — AskUserQuestion unavailable". For `spike_invali
 also preserve the spike verdict and plan impact details in the reason field so they surface in
 the Phase 5 DEFERRED section.
 
-**LoE escalation:** If an investigator estimates a finding's LoE as `significant`, move that
-finding to "needs refinement" and present to the user via `AskUserQuestion` before queuing for
-implementation. Significant LoE means the finding may have architectural impact — user should
-confirm before the lead proceeds.
+**LoE escalation:** If an investigator estimates a finding's LoE as `significant` AND returned
+verdict `refinement_needed`, include the LoE context in the AskUserQuestion presentation. If the
+investigator returned `resolution` despite `significant` LoE, proceed with the resolution — the
+investigator already determined a clear fix. Flag all `significant` LoE findings in the Phase 5
+report regardless of verdict.
 
 **Handling unverifiable findings:** If an investigator receives a finding with `verifier_verdict: "needs_context"` and cannot verify it (insufficient evidence to confirm or deny), it returns verdict `invalid` with reason "could not verify — insufficient evidence". The lead routes this to the `unverified_unresolved` bucket (not `findings_invalid`).
 

--- a/code-quality/skills/fix/references/investigator-prompt.md
+++ b/code-quality/skills/fix/references/investigator-prompt.md
@@ -43,6 +43,20 @@ _Repeat the `<finding-data>` block for each batched finding, incrementing the `i
 
 ---
 
+VERDICT GUIDANCE:
+Default to `resolution`. If you can determine a fix — even if it is not the only possible
+fix — use `resolution` and implement your best recommendation. Only use `refinement_needed`
+when two or more approaches exist with genuinely different tradeoffs that you cannot resolve
+without knowing the user's priorities. If you lean toward one option, use `resolution` with
+that option and explain your rationale in the Rationale field.
+
+`refinement_needed` is NOT:
+- A way to defer work you could do yourself
+- An escape hatch for uncertain fixes (use your best judgment and pick `resolution`)
+- A safety net for complex changes (complex does not mean ambiguous)
+
+---
+
 INVESTIGATION INSTRUCTIONS:
 
 For each finding wrapped in `<finding-data>` tags above:

--- a/code-quality/skills/incremental-planning/SKILL.md
+++ b/code-quality/skills/incremental-planning/SKILL.md
@@ -101,7 +101,7 @@ specific questions — not generic ones.
 
 ### Actions
 
-- Launch an **Explore agent** (`Agent` with `subagent_type: "Explore"`) for relevant codebase areas
+- Launch an **Explore agent** (`Agent` with `subagent_type: "general-purpose"`) for relevant codebase areas
 - Read `PROJECT.md` from the memory directory (detect using `code-quality/references/project-memory-reference.md` Directory Detection section) for past architectural decisions
 - Read `LESSONS.md` (if exists) from the memory directory for relevant past lessons. Silently incorporate applicable
   lessons — especially Architecture and Planning categories — into your approach without

--- a/code-quality/skills/plan-review/references/reviewer-prompts.md
+++ b/code-quality/skills/plan-review/references/reviewer-prompts.md
@@ -450,6 +450,21 @@ Assign each finding to the category that best describes its nature:
 | Security | Missing security considerations, auth gaps, sensitive data handling |
 | Specification | Ambiguous steps, missing detail, unclear success criteria |
 
+## Classification Guidance
+
+Default classification to `needs-fix`. The reviewer already applied "default to needs-fix" —
+preserve the reviewer's classification unless your investigation reveals a NEW decision point
+the reviewer missed (e.g., you discovered two mutually exclusive approaches with different
+tradeoffs that the plan must choose between).
+
+Do NOT reclassify a finding to `needs-input` because:
+- You are uncertain whether the finding is valid — use verdict `needs_context` instead
+- The finding seems hard to address — that is an LoE concern, not a classification concern
+- The category is "Research Gaps" — unvalidated assumptions are actionable (validate them)
+
+Only set `needs-input` when your investigation surfaced a specific, articulable decision the
+user must make that was not apparent from the reviewer's original report.
+
 ## Output
 
 Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
@@ -472,8 +487,8 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
     "finding_id": "unk-1",
     "verdict": "needs_context",
     "category": "Research Gaps",
-    "classification": "needs-input",
-    "investigation_summary": "The plan states it 'assumes API supports webhooks' but does not cite documentation. Whether this is a real gap depends on whether the team has already validated this externally."
+    "classification": "needs-fix",
+    "investigation_summary": "The plan states it 'assumes API supports webhooks' but does not cite documentation. Whether this is a real gap depends on whether the team has already validated this externally. The fix (adding a validation step to the plan) is clear regardless."
   }
 ]
 

--- a/code-quality/skills/plan-review/references/reviewer-prompts.md
+++ b/code-quality/skills/plan-review/references/reviewer-prompts.md
@@ -463,7 +463,9 @@ Do NOT reclassify a finding to `needs-input` because:
 - The category is "Research Gaps" — unvalidated assumptions are actionable (validate them)
 
 Only set `needs-input` when your investigation surfaced a specific, articulable decision the
-user must make that was not apparent from the reviewer's original report.
+user must make — e.g., two approaches with meaningfully different user-visible consequences
+(behavior, API contract, data model). A choice between two plan approaches (validation step
+vs spike, inline vs separate task, etc.) is NOT a decision point — pick the more thorough one.
 
 ## Output
 

--- a/code-quality/skills/pr-review/references/reviewer-prompts.md
+++ b/code-quality/skills/pr-review/references/reviewer-prompts.md
@@ -408,7 +408,9 @@ Do NOT reclassify a finding to `needs-input` because:
 - The category is "Decisions Needed" — category describes the finding's nature, not its classification
 
 Only set `needs-input` when your investigation surfaced a specific, articulable decision the
-user must make that was not apparent from the reviewer's original report.
+user must make — e.g., two approaches with meaningfully different user-visible consequences
+(behavior, API contract, data model). A choice between two implementation approaches (regex
+vs schema, loop vs map, etc.) is NOT a decision point — pick the simpler one.
 
 ## Output
 

--- a/code-quality/skills/pr-review/references/reviewer-prompts.md
+++ b/code-quality/skills/pr-review/references/reviewer-prompts.md
@@ -396,6 +396,20 @@ Assign each finding to the category that best describes its nature:
 | Performance | Bottlenecks, N+1, memory issues |
 | Style & Conventions | CLAUDE.md violations, naming, code quality |
 
+## Classification Guidance
+
+Default classification to `needs-fix`. The reviewer already applied "default to needs-fix" —
+preserve the reviewer's classification unless your investigation reveals a NEW decision point
+the reviewer missed (e.g., you discovered two mutually exclusive fixes with different tradeoffs).
+
+Do NOT reclassify a finding to `needs-input` because:
+- You are uncertain whether the finding is valid — use verdict `needs_context` instead
+- The finding seems hard to fix — that is an LoE concern, not a classification concern
+- The category is "Decisions Needed" — category describes the finding's nature, not its classification
+
+Only set `needs-input` when your investigation surfaced a specific, articulable decision the
+user must make that was not apparent from the reviewer's original report.
+
 ## Output
 
 Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
@@ -417,9 +431,9 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
   {
     "finding_id": "perf-1",
     "verdict": "needs_context",
-    "category": "Decisions Needed",
-    "classification": "needs-input",
-    "investigation_summary": "N+1 query exists but dataset size is unclear. Could be 10 rows or 10,000 — performance impact depends on production data volume."
+    "category": "Performance",
+    "classification": "needs-fix",
+    "investigation_summary": "N+1 query exists but dataset size is unclear. Could be 10 rows or 10,000 — performance impact depends on production data volume. The fix (batching the query) is straightforward regardless of scale."
   }
 ]
 

--- a/code-quality/skills/quality-gate/references/subagent-prompts.md
+++ b/code-quality/skills/quality-gate/references/subagent-prompts.md
@@ -37,7 +37,11 @@ CHECKLIST:
 For each finding, report:
 - Vulnerability type and location (file:line)
 - Attack vector (how an adversary exploits it)
-- Classification and LoE per `code-quality/references/finding-classification.md`
+- Classification: needs-fix | needs-input. Default to needs-fix. Only use needs-input when a
+  genuine human decision is required (architectural choice, scope decision, UX tradeoff).
+  needs-input is NOT for: uncertain severity, stylistic preferences, or "could go either way"
+  situations — pick the better option and classify as needs-fix.
+- LoE: trivial | moderate | significant
 - Suggested fix (brief)
 
 If no issues found, say "No security findings." Do not fabricate issues.
@@ -71,7 +75,11 @@ CHECKLIST:
 For each finding, report:
 - What scenario or path lacks coverage
 - Risk if it goes untested
-- Classification and LoE per `code-quality/references/finding-classification.md`
+- Classification: needs-fix | needs-input. Default to needs-fix. Only use needs-input when a
+  genuine human decision is required (architectural choice, scope decision, UX tradeoff).
+  needs-input is NOT for: uncertain severity, stylistic preferences, or "could go either way"
+  situations — pick the better option and classify as needs-fix.
+- LoE: trivial | moderate | significant
 - Suggested test approach (brief)
 
 If coverage is adequate, say "No QA findings." Do not fabricate issues.
@@ -105,7 +113,11 @@ CHECKLIST:
 For each finding, report:
 - The performance problem and location (file:line)
 - Expected impact (scale at which it matters, latency/throughput effect)
-- Classification and LoE per `code-quality/references/finding-classification.md`
+- Classification: needs-fix | needs-input. Default to needs-fix. Only use needs-input when a
+  genuine human decision is required (architectural choice, scope decision, UX tradeoff).
+  needs-input is NOT for: uncertain severity, stylistic preferences, or "could go either way"
+  situations — pick the better option and classify as needs-fix.
+- LoE: trivial | moderate | significant
 - Suggested fix (brief)
 
 If no performance issues found, say "No performance findings." Do not fabricate issues.
@@ -140,7 +152,11 @@ CHECKLIST:
 For each finding, report:
 - The quality concern and location (file:line)
 - Why it matters for long-term maintainability
-- Classification and LoE per `code-quality/references/finding-classification.md`
+- Classification: needs-fix | needs-input. Default to needs-fix. Only use needs-input when a
+  genuine human decision is required (architectural choice, scope decision, UX tradeoff).
+  needs-input is NOT for: uncertain severity, stylistic preferences, or "could go either way"
+  situations — pick the better option and classify as needs-fix.
+- LoE: trivial | moderate | significant
 - Suggested improvement (brief)
 
 If code quality is good, say "No code quality findings." Do not fabricate issues.
@@ -234,7 +250,11 @@ PLAN FILE (if available):
 For each issue found, report:
 - What requirement or item is affected
 - What's missing or incomplete
-- Classification and LoE per `code-quality/references/finding-classification.md`
+- Classification: needs-fix | needs-input. Default to needs-fix. Only use needs-input when a
+  genuine human decision is required (architectural choice, scope decision, UX tradeoff).
+  needs-input is NOT for: uncertain severity, stylistic preferences, or "could go either way"
+  situations — pick the better option and classify as needs-fix.
+- LoE: trivial | moderate | significant
 
 Be thorough. Assume at least 2 completeness gaps exist. Find them.
 ```
@@ -303,7 +323,11 @@ FOCUS AREA FOR ALL WORK TYPES:
 For each issue found, report:
 - The specific problem
 - Why it matters (impact)
-- Classification and LoE per `code-quality/references/finding-classification.md`
+- Classification: needs-fix | needs-input. Default to needs-fix. Only use needs-input when a
+  genuine human decision is required (architectural choice, scope decision, UX tradeoff).
+  needs-input is NOT for: uncertain severity, stylistic preferences, or "could go either way"
+  situations — pick the better option and classify as needs-fix.
+- LoE: trivial | moderate | significant
 - Suggested fix (brief)
 
 This work has at least 3 real issues. Find them.

--- a/code-quality/skills/unfuck/references/implementation-agents.md
+++ b/code-quality/skills/unfuck/references/implementation-agents.md
@@ -141,6 +141,13 @@ Test failures encountered: F
   - ...
 ```
 
+Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/references/finding-classification.md`
+for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
+
+```
+SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+```
+
 ## Commit Message Format
 
 ```
@@ -261,6 +268,13 @@ Needs-input: R groups (collected in FixSummary needs_input_items, sent to Lead f
 Test failures encountered: F
   - <group>: <error message>
   - ...
+```
+
+Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/references/finding-classification.md`
+for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
+
+```
+SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -405,6 +419,13 @@ Secrets found and rotated: S
 Test failures encountered: F
   - <file>:<line> <fix attempted>: <error message>
   - ...
+```
+
+Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/references/finding-classification.md`
+for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
+
+```
+SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -593,6 +614,13 @@ Test failures encountered: F
   - ...
 ```
 
+Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/references/finding-classification.md`
+for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
+
+```
+SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+```
+
 ## Commit Message Format
 
 ```
@@ -725,6 +753,13 @@ Needs-input: R findings (collected in FixSummary needs_input_items, sent to Lead
 Test failures encountered: F
   - <change>: <error message>
   - ...
+```
+
+Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/references/finding-classification.md`
+for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
+
+```
+SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -873,6 +908,13 @@ Fixed: N documentation findings resolved
 Needs-input: R findings (collected in FixSummary needs_input_items, sent to Lead for user triage)
   - <finding ID>: LoE=<loe>. <description>. Input needed: <what decision>
   - ...
+```
+
+Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/references/finding-classification.md`
+for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
+
+```
+SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -1135,6 +1177,13 @@ Needs-input: Q findings (collected in FixSummary needs_input_items, sent to Lead
 Test failures encountered: F
   - <refactoring>: <error message>
   - ...
+```
+
+Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/references/finding-classification.md`
+for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
+
+```
+SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format

--- a/code-quality/skills/unfuck/references/implementation-agents.md
+++ b/code-quality/skills/unfuck/references/implementation-agents.md
@@ -145,7 +145,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -274,7 +274,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -425,7 +425,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -618,7 +618,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -759,7 +759,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -914,7 +914,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format
@@ -1183,7 +1183,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="orchestrator", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
 ```
 
 ## Commit Message Format

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
-  "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection",
-  "version": "1.52.0",
+  "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification",
+  "version": "1.53.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/README.md
+++ b/dev-guard/README.md
@@ -1,6 +1,6 @@
 # Dev Guard Plugin
 
-Development environment policy enforcement: tool selection guard, commit validation, and pre-push review.
+Development environment policy enforcement: tool selection guard, commit validation, pre-push review, and subagent completion verification.
 
 ## Hooks
 
@@ -31,6 +31,21 @@ Development environment policy enforcement: tool selection guard, commit validat
 - Checks subject line length (<72 chars, warn >50)
 - Blocks emoji and meta-commentary
 - **Exit 2** shows errors but commit already completed (PostToolUse limitation)
+
+### Stop: Quality Stop Gate
+
+**stop-hook.py** — Fires on every Stop event, performing deterministic triage (loop guard, transcript parsing, git diff, signal detection, question classification) and delegating to an LLM evaluator when quality checks are warranted.
+- **Zero-dependency fast triage** — Per-session state, transcript tail-read, git diff hash comparison
+- **LLM delegation** — Only invokes LLM when write signals, completion claims, or research activity detected
+- **Fail-open** — All errors exit 0 (allow stop) to avoid blocking legitimate exits
+
+### SubagentStop: FixSummary Validation
+
+**subagent-stop-hook.py** — Fires on every SubagentStop event. Validates FixSummary structural completeness when Fixer subagents stop.
+- **Transcript-based detection** — Tail-reads 512KB of the subagent transcript to find FixSummary JSON
+- **Structural validation** — Ensures `findings_fixed`, `needs_input_items`, and `user_deferred` arrays account for at least one finding
+- **Loop guard** — After 3 consecutive blocks for the same subagent, fails open (approves) to prevent infinite retries
+- **Fail-open** — All errors exit 0 (approve stop); best-effort enforcement only
 
 ## How Hooks Work
 

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Global hooks: git safety, commit validation, pre-push review, tool selection, quality stop gate",
+  "description": "Global hooks: git safety, commit validation, pre-push review, tool selection, quality stop gate, subagent completion verification",
   "hooks": {
     "SessionStart": [
       {
@@ -93,6 +93,17 @@
             "type": "command",
             "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/stop-hook.py",
             "timeout": 60
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/subagent-stop-hook.py",
+            "timeout": 30
           }
         ]
       }

--- a/dev-guard/hooks/subagent-stop-hook.py
+++ b/dev-guard/hooks/subagent-stop-hook.py
@@ -25,6 +25,8 @@ import time
 from pathlib import Path
 from typing import NoReturn
 
+_JSON_DECODER = json.JSONDecoder()
+
 # ── Constants ────────────────────────────────────────────────────────────────
 
 _MAX_INPUT = 10 * 1024 * 1024  # 10 MB
@@ -105,17 +107,21 @@ def _extract_text_from_content(content: object) -> str:
     return ""
 
 
+_MAX_BRACE_SCANS = 200  # iteration limit for raw_decode loop
+
+
 def _try_parse_fix_summary(text: str) -> dict | None:
     """Attempt to extract a FixSummary dict from a text fragment using raw_decode."""
-    decoder = json.JSONDecoder()
     pos = 0
-    while pos < len(text):
+    scans = 0
+    while pos < len(text) and scans < _MAX_BRACE_SCANS:
         # Scan for opening brace
         brace = text.find("{", pos)
         if brace == -1:
             break
+        scans += 1
         try:
-            obj, end = decoder.raw_decode(text, brace)
+            obj, end = _JSON_DECODER.raw_decode(text, brace)
             if isinstance(obj, dict) and (
                 obj.get("schema") == "FixSummary" or "findings_fixed" in obj
             ):
@@ -214,6 +220,20 @@ def _find_fix_summary(transcript_path: str) -> dict | None:
 # ── Validation ───────────────────────────────────────────────────────────────
 
 
+def _validate_items(items: list, field: str) -> tuple[bool, str]:
+    """Validate that each item in a FixSummary array is a non-empty string or dict."""
+    for item in items:
+        if isinstance(item, str):
+            if not item.strip():
+                return False, f"{field} contains whitespace-only string"
+        elif isinstance(item, dict):
+            if not item:
+                return False, f"{field} contains empty dict"
+        else:
+            return False, f"{field} contains unexpected type: {type(item).__name__}"
+    return True, "valid"
+
+
 def _validate_fix_summary(fix_summary: dict) -> tuple[bool, str]:
     """Validate FixSummary structural completeness.
 
@@ -230,43 +250,17 @@ def _validate_fix_summary(fix_summary: dict) -> tuple[bool, str]:
     if not isinstance(user_deferred, list):
         user_deferred = []
 
-    total_accounted = len(findings_fixed) + len(needs_input_items) + len(user_deferred)
-
-    if total_accounted == 0:
+    if len(findings_fixed) + len(needs_input_items) + len(user_deferred) == 0:
         return False, "all arrays empty — no findings accounted for"
 
-    # Validate findings_fixed items: must be non-empty strings
-    for item in findings_fixed:
-        if isinstance(item, str):
-            if not item.strip():
-                return False, "findings_fixed contains whitespace-only string"
-        elif isinstance(item, dict):
-            if not item:
-                return False, "findings_fixed contains empty dict"
-        else:
-            return False, f"findings_fixed contains unexpected type: {type(item).__name__}"
-
-    # Validate needs_input_items: must be non-empty dicts
-    for item in needs_input_items:
-        if isinstance(item, dict):
-            if not item:
-                return False, "needs_input_items contains empty dict"
-        elif isinstance(item, str):
-            if not item.strip():
-                return False, "needs_input_items contains whitespace-only string"
-        else:
-            return False, f"needs_input_items contains unexpected type: {type(item).__name__}"
-
-    # Validate user_deferred: must be non-empty dicts
-    for item in user_deferred:
-        if isinstance(item, dict):
-            if not item:
-                return False, "user_deferred contains empty dict"
-        elif isinstance(item, str):
-            if not item.strip():
-                return False, "user_deferred contains whitespace-only string"
-        else:
-            return False, f"user_deferred contains unexpected type: {type(item).__name__}"
+    for field, items in (
+        ("findings_fixed", findings_fixed),
+        ("needs_input_items", needs_input_items),
+        ("user_deferred", user_deferred),
+    ):
+        ok, msg = _validate_items(items, field)
+        if not ok:
+            return False, msg
 
     return True, "valid"
 
@@ -300,12 +294,14 @@ def _load_state() -> dict:
 
 
 def _save_state(state: dict) -> None:
-    """Save state file atomically. Silently ignores errors."""
+    """Save state file atomically with 0o600 permissions. Silently ignores errors."""
     try:
         _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        tmp = _STATE_PATH.with_suffix(f".{os.getpid()}.tmp")
-        tmp.write_text(json.dumps(state))
-        os.replace(tmp, _STATE_PATH)
+        tmp_path = str(_STATE_PATH.with_suffix(f".{os.getpid()}.tmp"))
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with open(fd, "w") as f:
+            json.dump(state, f)
+        os.replace(tmp_path, _STATE_PATH)
     except OSError:
         pass
 
@@ -339,11 +335,6 @@ def _record_block(state: dict, state_key: str) -> None:
         }
 
 
-def _record_pass(state: dict, state_key: str) -> None:
-    """Delete state_key entry if present (counter reset)."""
-    state.pop(state_key, None)
-
-
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 
@@ -369,7 +360,7 @@ def main() -> None:
     state = _load_state()
 
     if is_valid:
-        _record_pass(state, state_key)
+        state.pop(state_key, None)
         _save_state(state)
         _exit_approve()
 

--- a/dev-guard/hooks/subagent-stop-hook.py
+++ b/dev-guard/hooks/subagent-stop-hook.py
@@ -97,7 +97,11 @@ def _extract_text_from_content(content: object) -> str:
             elif block_type == "tool_use":
                 inp = block.get("input", {})
                 if isinstance(inp, dict):
-                    # Flatten tool_use input fields as JSON for FixSummary detection
+                    # Append raw string values for FixSummary detection in
+                    # JSON-encoded content (e.g. SendMessage message field)
+                    for v in inp.values():
+                        if isinstance(v, str) and v:
+                            parts.append(v)
                     parts.append(json.dumps(inp))
         return "\n".join(parts)
 
@@ -187,29 +191,29 @@ def _find_fix_summary(transcript_path: str) -> dict | None:
                 if isinstance(inp, dict):
                     if inp.get("schema") == "FixSummary" or "findings_fixed" in inp:
                         return inp
-                    # Check if input contains a FixSummary in a nested field (e.g. SendMessage)
-                    text = json.dumps(inp)
-                    if "FixSummary" in text or "findings_fixed" in text:
-                        result = _try_parse_fix_summary(text)
-                        if result is not None:
-                            return result
+                    # Unwrap JSON-encoded string values (e.g. SendMessage message field)
+                    for v in inp.values():
+                        if isinstance(v, str) and ("FixSummary" in v or "findings_fixed" in v):
+                            unwrapped = _try_parse_fix_summary(v)
+                            if unwrapped is not None:
+                                return unwrapped
 
             # Only examine assistant messages for FixSummary
             is_assistant = msg_type == "assistant" or role == "assistant"
             if not is_assistant:
                 continue
 
-            text = _extract_text_from_content(content)
-            if not text:
+            content_text = _extract_text_from_content(content)
+            if not content_text:
                 continue
 
             # Quick check before expensive parse
-            if "FixSummary" not in text and "findings_fixed" not in text:
+            if "FixSummary" not in content_text and "findings_fixed" not in content_text:
                 continue
 
-            result = _try_parse_fix_summary(text)
-            if result is not None:
-                return result
+            candidate = _try_parse_fix_summary(content_text)
+            if candidate is not None:
+                return candidate
 
     except (OSError, UnicodeDecodeError):
         return None
@@ -220,18 +224,29 @@ def _find_fix_summary(transcript_path: str) -> dict | None:
 # ── Validation ───────────────────────────────────────────────────────────────
 
 
-def _validate_items(items: list, field: str) -> tuple[bool, str]:
-    """Validate that each item in a FixSummary array is a non-empty string or dict."""
+def _validate_items(items: list, field: str, require_dict: bool = False) -> tuple[bool, str]:
+    """Validate items in a FixSummary array.
+
+    findings_fixed accepts non-empty strings or dicts.
+    needs_input_items and user_deferred require dicts with a non-empty 'id' field.
+    """
     for item in items:
-        if isinstance(item, str):
-            if not item.strip():
-                return False, f"{field} contains whitespace-only string"
-        elif isinstance(item, dict):
-            if not item:
-                return False, f"{field} contains empty dict"
+        if require_dict:
+            if not isinstance(item, dict):
+                return False, f"{field} item must be a dict, got {type(item).__name__}"
+            item_id = item.get("id", "")
+            if not isinstance(item_id, str) or not item_id.strip():
+                return False, f"{field} item missing non-empty 'id' field"
         else:
-            return False, f"{field} contains unexpected type: {type(item).__name__}"
-    return True, "valid"
+            if isinstance(item, str):
+                if not item.strip():
+                    return False, f"{field} contains whitespace-only string"
+            elif isinstance(item, dict):
+                if not item:
+                    return False, f"{field} contains empty dict"
+            else:
+                return False, f"{field} contains unexpected type: {type(item).__name__}"
+    return True, ""
 
 
 def _validate_fix_summary(fix_summary: dict) -> tuple[bool, str]:
@@ -253,16 +268,16 @@ def _validate_fix_summary(fix_summary: dict) -> tuple[bool, str]:
     if len(findings_fixed) + len(needs_input_items) + len(user_deferred) == 0:
         return False, "all arrays empty — no findings accounted for"
 
-    for field, items in (
-        ("findings_fixed", findings_fixed),
-        ("needs_input_items", needs_input_items),
-        ("user_deferred", user_deferred),
+    for field, items, require_dict in (
+        ("findings_fixed", findings_fixed, False),
+        ("needs_input_items", needs_input_items, True),
+        ("user_deferred", user_deferred, True),
     ):
-        ok, msg = _validate_items(items, field)
+        ok, msg = _validate_items(items, field, require_dict)
         if not ok:
             return False, msg
 
-    return True, "valid"
+    return True, ""
 
 
 # ── State Management ─────────────────────────────────────────────────────────
@@ -322,17 +337,11 @@ def _check_loop_guard(state: dict, state_key: str) -> tuple[bool, int]:
 def _record_block(state: dict, state_key: str) -> None:
     """Increment consecutive_blocks counter for state_key."""
     entry = state.get(state_key)
-    if isinstance(entry, dict):
-        count = entry.get("consecutive_blocks", 0)
-        state[state_key] = {
-            "consecutive_blocks": count + 1,
-            "last_block_timestamp": time.time(),
-        }
-    else:
-        state[state_key] = {
-            "consecutive_blocks": 1,
-            "last_block_timestamp": time.time(),
-        }
+    count = entry.get("consecutive_blocks", 0) if isinstance(entry, dict) else 0
+    state[state_key] = {
+        "consecutive_blocks": count + 1,
+        "last_block_timestamp": time.time(),
+    }
 
 
 # ── Main ─────────────────────────────────────────────────────────────────────
@@ -360,14 +369,13 @@ def main() -> None:
     state = _load_state()
 
     if is_valid:
-        state.pop(state_key, None)
-        _save_state(state)
+        if state_key in state:
+            state.pop(state_key)
+            _save_state(state)
         _exit_approve()
 
     should_fail_open, _ = _check_loop_guard(state, state_key)
     if should_fail_open:
-        _record_block(state, state_key)
-        _save_state(state)
         _exit_approve()  # Fail open after 3 consecutive blocks
 
     _record_block(state, state_key)

--- a/dev-guard/hooks/subagent-stop-hook.py
+++ b/dev-guard/hooks/subagent-stop-hook.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.13"
+# ///
+"""SubagentStop Hook -- validates FixSummary structural completeness.
+
+Fires on every SubagentStop event. Parses the subagent's transcript JSONL to
+find FixSummary content. If no FixSummary is found, the subagent is not a Fixer
+and the stop is approved. If a FixSummary is found, it validates structural
+completeness. Invalid FixSummary blocks the stop. A loop guard (3 consecutive
+blocks per state key) fails open (approves) to prevent infinite retries. All
+errors fail open.
+
+Exit codes:
+  0 -- always. Approve stop (plain exit) or block via JSON {"decision":"block","reason":"..."}
+
+State file: ~/.claude/subagent-stop-hook-state.json
+           (overridable via SUBAGENT_STOP_HOOK_STATE_PATH)
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import NoReturn
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+_MAX_INPUT = 10 * 1024 * 1024  # 10 MB
+_MAX_PARSE_BYTES = 512 * 1024  # 512 KB tail window for transcript
+_MAX_CONSECUTIVE_BLOCKS = 3
+_STATE_PATH = Path(
+    os.environ.get(
+        "SUBAGENT_STOP_HOOK_STATE_PATH",
+        str(Path.home() / ".claude" / "subagent-stop-hook-state.json"),
+    )
+)
+_STATE_TTL_SECONDS = 24 * 3600  # 24 hours
+
+
+# ── Exit Helpers ─────────────────────────────────────────────────────────────
+
+
+def _exit_approve() -> NoReturn:
+    """Exit 0, no output (approve the stop)."""
+    sys.exit(0)
+
+
+def _exit_block(message: str) -> NoReturn:
+    """Exit 0 with {decision: block, reason: ...} JSON on stdout."""
+    output = {"decision": "block", "reason": message}
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+# ── Stdin Parsing ────────────────────────────────────────────────────────────
+
+
+def _parse_hook_input() -> dict:
+    """Read and parse JSON hook payload from stdin. Exits 0 on failure."""
+    try:
+        raw = sys.stdin.buffer.read(_MAX_INPUT + 1)
+    except OSError:
+        sys.exit(0)
+    if len(raw) > _MAX_INPUT:
+        sys.exit(0)
+    try:
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            sys.exit(0)
+        return data
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+
+# ── Transcript Parsing ───────────────────────────────────────────────────────
+
+
+def _extract_text_from_content(content: object) -> str:
+    """Extract all text from a content value (string, list of blocks, or tool_use input)."""
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type", "")
+            if block_type == "text":
+                text = block.get("text", "")
+                if isinstance(text, str) and text:
+                    parts.append(text)
+            elif block_type == "tool_use":
+                inp = block.get("input", {})
+                if isinstance(inp, dict):
+                    # Flatten tool_use input fields as JSON for FixSummary detection
+                    parts.append(json.dumps(inp))
+        return "\n".join(parts)
+
+    if isinstance(content, dict):
+        return json.dumps(content)
+
+    return ""
+
+
+def _try_parse_fix_summary(text: str) -> dict | None:
+    """Attempt to extract a FixSummary dict from a text fragment using raw_decode."""
+    decoder = json.JSONDecoder()
+    pos = 0
+    while pos < len(text):
+        # Scan for opening brace
+        brace = text.find("{", pos)
+        if brace == -1:
+            break
+        try:
+            obj, end = decoder.raw_decode(text, brace)
+            if isinstance(obj, dict) and (
+                obj.get("schema") == "FixSummary" or "findings_fixed" in obj
+            ):
+                return obj
+            pos = end
+        except (json.JSONDecodeError, ValueError):
+            pos = brace + 1
+    return None
+
+
+def _find_fix_summary(transcript_path: str) -> dict | None:
+    """Tail-read transcript JSONL and search for FixSummary content.
+
+    Returns first valid FixSummary dict found (most recent first), or None.
+    """
+    try:
+        path = Path(transcript_path)
+        if not path.exists() or not path.is_file():
+            return None
+        file_size = path.stat().st_size
+        if file_size == 0:
+            return None
+
+        seek_to = max(0, file_size - _MAX_PARSE_BYTES)
+
+        lines: list[str] = []
+        with open(path, encoding="utf-8", errors="replace") as f:
+            if seek_to > 0:
+                f.seek(seek_to)
+                f.readline()  # discard partial first line after seek
+            while True:
+                line = f.readline()
+                if not line:
+                    break
+                line = line.strip()
+                if line:
+                    lines.append(line)
+
+        # Reverse iterate (most recent first)
+        for line in reversed(lines):
+            try:
+                entry = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if not isinstance(entry, dict):
+                continue
+
+            # Resolve content from either transcript format:
+            #   Real: {"type": "assistant", "message": {"role": "assistant", "content": ...}}
+            #   Test: {"role": "assistant", "content": ...}
+            message = entry.get("message")
+            if isinstance(message, dict):
+                role = message.get("role", "")
+                content = message.get("content", "")
+            else:
+                role = entry.get("role", "")
+                content = entry.get("content", "")
+
+            # Also check flat tool_use entries ({"type": "tool_use", "input": {...}})
+            msg_type = entry.get("type", "")
+            if msg_type == "tool_use":
+                inp = entry.get("input", {})
+                if isinstance(inp, dict):
+                    if inp.get("schema") == "FixSummary" or "findings_fixed" in inp:
+                        return inp
+                    # Check if input contains a FixSummary in a nested field (e.g. SendMessage)
+                    text = json.dumps(inp)
+                    if "FixSummary" in text or "findings_fixed" in text:
+                        result = _try_parse_fix_summary(text)
+                        if result is not None:
+                            return result
+
+            # Only examine assistant messages for FixSummary
+            is_assistant = msg_type == "assistant" or role == "assistant"
+            if not is_assistant:
+                continue
+
+            text = _extract_text_from_content(content)
+            if not text:
+                continue
+
+            # Quick check before expensive parse
+            if "FixSummary" not in text and "findings_fixed" not in text:
+                continue
+
+            result = _try_parse_fix_summary(text)
+            if result is not None:
+                return result
+
+    except (OSError, UnicodeDecodeError):
+        return None
+
+    return None
+
+
+# ── Validation ───────────────────────────────────────────────────────────────
+
+
+def _validate_fix_summary(fix_summary: dict) -> tuple[bool, str]:
+    """Validate FixSummary structural completeness.
+
+    Returns (is_valid, message).
+    """
+    findings_fixed = fix_summary.get("findings_fixed", [])
+    needs_input_items = fix_summary.get("needs_input_items", [])
+    user_deferred = fix_summary.get("user_deferred", [])
+
+    if not isinstance(findings_fixed, list):
+        findings_fixed = []
+    if not isinstance(needs_input_items, list):
+        needs_input_items = []
+    if not isinstance(user_deferred, list):
+        user_deferred = []
+
+    total_accounted = len(findings_fixed) + len(needs_input_items) + len(user_deferred)
+
+    if total_accounted == 0:
+        return False, "all arrays empty — no findings accounted for"
+
+    # Validate findings_fixed items: must be non-empty strings
+    for item in findings_fixed:
+        if isinstance(item, str):
+            if not item.strip():
+                return False, "findings_fixed contains whitespace-only string"
+        elif isinstance(item, dict):
+            if not item:
+                return False, "findings_fixed contains empty dict"
+        else:
+            return False, f"findings_fixed contains unexpected type: {type(item).__name__}"
+
+    # Validate needs_input_items: must be non-empty dicts
+    for item in needs_input_items:
+        if isinstance(item, dict):
+            if not item:
+                return False, "needs_input_items contains empty dict"
+        elif isinstance(item, str):
+            if not item.strip():
+                return False, "needs_input_items contains whitespace-only string"
+        else:
+            return False, f"needs_input_items contains unexpected type: {type(item).__name__}"
+
+    # Validate user_deferred: must be non-empty dicts
+    for item in user_deferred:
+        if isinstance(item, dict):
+            if not item:
+                return False, "user_deferred contains empty dict"
+        elif isinstance(item, str):
+            if not item.strip():
+                return False, "user_deferred contains whitespace-only string"
+        else:
+            return False, f"user_deferred contains unexpected type: {type(item).__name__}"
+
+    return True, "valid"
+
+
+# ── State Management ─────────────────────────────────────────────────────────
+
+
+def _load_state() -> dict:
+    """Load state file. Returns empty dict on missing or corrupted file.
+
+    Also prunes entries older than _STATE_TTL_SECONDS.
+    """
+    state: dict = {}
+    try:
+        if _STATE_PATH.exists():
+            text = _STATE_PATH.read_text()
+            data = json.loads(text)
+            if isinstance(data, dict):
+                state = data
+    except (OSError, json.JSONDecodeError, ValueError):
+        pass
+
+    # Prune stale entries
+    now = time.time()
+    cutoff = now - _STATE_TTL_SECONDS
+    return {
+        key: entry
+        for key, entry in state.items()
+        if isinstance(entry, dict) and entry.get("last_block_timestamp", 0) >= cutoff
+    }
+
+
+def _save_state(state: dict) -> None:
+    """Save state file atomically. Silently ignores errors."""
+    try:
+        _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _STATE_PATH.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(state))
+        os.replace(tmp, _STATE_PATH)
+    except OSError:
+        pass
+
+
+def _check_loop_guard(state: dict, state_key: str) -> tuple[bool, int]:
+    """Check consecutive block count for state_key.
+
+    Returns (should_fail_open, count) where should_fail_open means we've hit
+    the max and should approve instead of blocking.
+    """
+    entry = state.get(state_key)
+    if not isinstance(entry, dict):
+        return False, 0
+    count = entry.get("consecutive_blocks", 0)
+    return count >= _MAX_CONSECUTIVE_BLOCKS, count
+
+
+def _record_block(state: dict, state_key: str) -> None:
+    """Increment consecutive_blocks counter for state_key."""
+    entry = state.get(state_key)
+    if isinstance(entry, dict):
+        count = entry.get("consecutive_blocks", 0)
+        state[state_key] = {
+            "consecutive_blocks": count + 1,
+            "last_block_timestamp": time.time(),
+        }
+    else:
+        state[state_key] = {
+            "consecutive_blocks": 1,
+            "last_block_timestamp": time.time(),
+        }
+
+
+def _record_pass(state: dict, state_key: str) -> None:
+    """Delete state_key entry if present (counter reset)."""
+    state.pop(state_key, None)
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    data = _parse_hook_input()
+
+    session_id = data.get("session_id", "")
+    transcript_path = data.get("transcript_path", "")
+
+    # No transcript -> nothing to validate
+    if not transcript_path:
+        _exit_approve()
+
+    fix_summary = _find_fix_summary(transcript_path)
+
+    # No FixSummary -> not a Fixer subagent
+    if fix_summary is None:
+        _exit_approve()
+
+    is_valid, message = _validate_fix_summary(fix_summary)
+
+    state_key = f"{session_id}:{transcript_path}" if session_id else transcript_path
+    state = _load_state()
+
+    if is_valid:
+        _record_pass(state, state_key)
+        _save_state(state)
+        _exit_approve()
+
+    should_fail_open, _ = _check_loop_guard(state, state_key)
+    if should_fail_open:
+        _record_block(state, state_key)
+        _save_state(state)
+        _exit_approve()  # Fail open after 3 consecutive blocks
+
+    _record_block(state, state_key)
+    _save_state(state)
+    _exit_block(
+        f"FixSummary validation failed: {message}. "
+        "Review your FixSummary output and ensure all findings are accounted for."
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        sys.exit(0)

--- a/dev-guard/hooks/subagent-stop-hook.py
+++ b/dev-guard/hooks/subagent-stop-hook.py
@@ -32,6 +32,8 @@ _JSON_DECODER = json.JSONDecoder()
 _MAX_INPUT = 10 * 1024 * 1024  # 10 MB
 _MAX_PARSE_BYTES = 512 * 1024  # 512 KB tail window for transcript
 _MAX_CONSECUTIVE_BLOCKS = 3
+_MAX_BRACE_SCANS = 200  # iteration limit for raw_decode loop
+_STATE_KEY_SEP = "\x00"  # NUL cannot appear in session IDs or filesystem paths
 _STATE_PATH = Path(
     os.environ.get(
         "SUBAGENT_STOP_HOOK_STATE_PATH",
@@ -49,9 +51,9 @@ def _exit_approve() -> NoReturn:
     sys.exit(0)
 
 
-def _exit_block(message: str) -> NoReturn:
-    """Exit 0 with {decision: block, reason: ...} JSON on stdout."""
-    output = {"decision": "block", "reason": message}
+def _exit_block(reason: str) -> NoReturn:
+    """Exit 0 with {"decision": "block", "reason": "..."} JSON on stdout."""
+    output = {"decision": "block", "reason": reason}
     print(json.dumps(output))
     sys.exit(0)
 
@@ -97,11 +99,14 @@ def _extract_text_from_content(content: object) -> str:
             elif block_type == "tool_use":
                 inp = block.get("input", {})
                 if isinstance(inp, dict):
-                    # Append raw string values for FixSummary detection in
-                    # JSON-encoded content (e.g. SendMessage message field)
+                    # Two detection paths for FixSummary in tool_use inputs:
+                    # 1. Raw string values: catches JSON-encoded FixSummary in
+                    #    string params (e.g. SendMessage message field)
                     for v in inp.values():
                         if isinstance(v, str) and v:
                             parts.append(v)
+                    # 2. Serialized dict: catches FixSummary when inp itself IS
+                    #    the FixSummary dict (keys only visible after serialization)
                     parts.append(json.dumps(inp))
         return "\n".join(parts)
 
@@ -109,9 +114,6 @@ def _extract_text_from_content(content: object) -> str:
         return json.dumps(content)
 
     return ""
-
-
-_MAX_BRACE_SCANS = 200  # iteration limit for raw_decode loop
 
 
 def _try_parse_fix_summary(text: str) -> dict | None:
@@ -365,7 +367,7 @@ def main() -> None:
 
     is_valid, message = _validate_fix_summary(fix_summary)
 
-    state_key = f"{session_id}:{transcript_path}" if session_id else transcript_path
+    state_key = f"{session_id}{_STATE_KEY_SEP}{transcript_path}" if session_id else transcript_path
     state = _load_state()
 
     if is_valid:

--- a/dev-guard/hooks/subagent-stop-hook.py
+++ b/dev-guard/hooks/subagent-stop-hook.py
@@ -323,17 +323,12 @@ def _save_state(state: dict) -> None:
         pass
 
 
-def _check_loop_guard(state: dict, state_key: str) -> tuple[bool, int]:
-    """Check consecutive block count for state_key.
-
-    Returns (should_fail_open, count) where should_fail_open means we've hit
-    the max and should approve instead of blocking.
-    """
+def _check_loop_guard(state: dict, state_key: str) -> bool:
+    """Check if state_key has hit the consecutive block limit (should fail open)."""
     entry = state.get(state_key)
     if not isinstance(entry, dict):
-        return False, 0
-    count = entry.get("consecutive_blocks", 0)
-    return count >= _MAX_CONSECUTIVE_BLOCKS, count
+        return False
+    return entry.get("consecutive_blocks", 0) >= _MAX_CONSECUTIVE_BLOCKS
 
 
 def _record_block(state: dict, state_key: str) -> None:
@@ -376,7 +371,7 @@ def main() -> None:
             _save_state(state)
         _exit_approve()
 
-    should_fail_open, _ = _check_loop_guard(state, state_key)
+    should_fail_open = _check_loop_guard(state, state_key)
     if should_fail_open:
         _exit_approve()  # Fail open after 3 consecutive blocks
 

--- a/dev-guard/tests/test_subagent_stop_hook.py
+++ b/dev-guard/tests/test_subagent_stop_hook.py
@@ -49,6 +49,7 @@ def run_hook(
         capture_output=True,
         text=True,
         env=env,
+        timeout=30,
     )
 
 
@@ -112,6 +113,15 @@ class TestFastExit:
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
         assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
 
+    def test_empty_transcript_file_approves(self, tmp_path):
+        """Zero-byte transcript file -> file_size == 0 guard -> fail-open -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_bytes(b"")
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
 
 # ── TestFixSummaryDetection ───────────────────────────────────────────────────
 
@@ -169,7 +179,7 @@ class TestFixSummaryDetection:
         fix_summary = {
             "schema": "FixSummary",
             "findings_fixed": ["finding-001"],
-            "needs_input_items": ["finding-002"],
+            "needs_input_items": [{"id": "finding-002", "description": "Needs review"}],
             "user_deferred": [],
             "fixes": [{"id": "finding-001", "description": "Patched injection vector"}],
             "files_modified": ["src/db.py"],
@@ -183,6 +193,86 @@ class TestFixSummaryDetection:
         result = run_hook(payload, state_path=tmp_path / "state.json")
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
         assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_user_deferred_only_fix_summary_approves(self, tmp_path):
+        """FixSummary with only user_deferred non-empty -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [],
+            "needs_input_items": [],
+            "user_deferred": [{"id": "finding-001", "reason": "user deferred"}],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_fix_summary_in_nested_tool_use_approves(self, tmp_path):
+        """FixSummary in tool_use nested inside assistant message content -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "SendMessage",
+                            "input": {
+                                "to": "team-lead",
+                                "message": json.dumps(VALID_FIX_SUMMARY),
+                                "summary": "FixSummary handoff",
+                            },
+                        }
+                    ],
+                },
+            },
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_invalid_fix_summary_in_nested_tool_use_blocks(self, tmp_path):
+        """Invalid FixSummary in nested tool_use inside assistant message -> block."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "SendMessage",
+                            "input": {
+                                "to": "team-lead",
+                                "message": json.dumps(EMPTY_FIX_SUMMARY),
+                                "summary": "FixSummary handoff",
+                            },
+                        }
+                    ],
+                },
+            },
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block — invalid FixSummary in nested tool_use"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
 
     def test_fix_summary_embedded_in_prose_approves(self, tmp_path):
         """FixSummary JSON surrounded by prose text in assistant message -> detected -> approve."""
@@ -205,15 +295,34 @@ class TestFixSummaryDetection:
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
         assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
 
-    def test_fix_summary_in_tool_use_content_block_approves(self, tmp_path):
-        """FixSummary as JSON-encoded string inside SendMessage tool_use input -> approve.
+    def test_invalid_fix_summary_in_tool_use_string_blocks(self, tmp_path):
+        """Invalid FixSummary (all empty arrays) as JSON string in tool_use input -> block."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            {
+                "type": "tool_use",
+                "name": "SendMessage",
+                "id": "t1",
+                "input": {
+                    "to": "team-lead",
+                    "message": json.dumps(EMPTY_FIX_SUMMARY),
+                    "summary": "FixSummary handoff",
+                },
+            },
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON — invalid FixSummary detected"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
 
-        The hook cannot detect a FixSummary that is itself JSON-encoded as a string value
-        within a tool_use input field (e.g. message=json.dumps(VALID_FIX_SUMMARY)).
-        The raw_decode scan sees the outer input dict's JSON but the inner FixSummary
-        is escape-encoded as a string, not as a nested object. The hook finds no FixSummary
-        and approves via the "not a Fixer subagent" path, not via validation success.
-        """
+    def test_fix_summary_in_tool_use_content_block_approves(self, tmp_path):
+        """FixSummary as JSON-encoded string inside SendMessage tool_use input -> detected
+        via string value unwrapping -> validation passes -> approve."""
         transcript = tmp_path / "transcript.jsonl"
         entries = [
             {"role": "user", "content": "Fix findings."},
@@ -280,6 +389,131 @@ class TestValidationFailures:
         output = json.loads(result.stdout)
         assert output["decision"] == "block"
 
+    def test_empty_dict_item_in_findings_fixed_blocks(self, tmp_path):
+        """FixSummary with empty dict in findings_fixed -> block."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [{}],
+            "needs_input_items": [],
+            "user_deferred": [],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON output, got empty stdout"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "empty dict" in output["reason"]
+
+    def test_unexpected_type_item_in_findings_fixed_blocks(self, tmp_path):
+        """FixSummary with integer in findings_fixed -> block."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [42],
+            "needs_input_items": [],
+            "user_deferred": [],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON output, got empty stdout"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "unexpected type" in output["reason"]
+
+    def test_needs_input_item_missing_id_blocks(self, tmp_path):
+        """FixSummary with dict in needs_input_items missing 'id' field -> block."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [],
+            "needs_input_items": [{"description": "no id field"}],
+            "user_deferred": [],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON output, got empty stdout"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "missing non-empty 'id' field" in output["reason"]
+
+    def test_user_deferred_string_instead_of_dict_blocks(self, tmp_path):
+        """FixSummary with bare string in user_deferred (requires dict) -> block."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [],
+            "needs_input_items": [],
+            "user_deferred": ["finding-001"],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON output, got empty stdout"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "must be a dict" in output["reason"]
+
+    def test_needs_input_string_instead_of_dict_blocks(self, tmp_path):
+        """FixSummary with bare string in needs_input_items (requires dict) -> block."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": ["finding-001"],
+            "needs_input_items": ["finding-002"],
+            "user_deferred": [],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON output, got empty stdout"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "must be a dict" in output["reason"]
+
     def test_malformed_transcript_approves(self, tmp_path):
         """Transcript file with invalid JSONL content -> fail-open -> approve."""
         transcript = tmp_path / "transcript.jsonl"
@@ -339,6 +573,21 @@ class TestLoopGuard:
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
         assert result.stdout.strip() == "", (
             f"expected approve (empty stdout) on 4th block, got: {result.stdout!r}"
+        )
+
+        # 5th attempt -> still fails open (counter >= 3 persists)
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", (
+            f"expected approve (empty stdout) on 5th block, got: {result.stdout!r}"
+        )
+
+        # Verify counter did NOT grow past 3 (fail-open should not call _record_block)
+        state_data = json.loads(state_path.read_text())
+        state_key = f"{session_id}:{transcript}"
+        assert state_data[state_key]["consecutive_blocks"] == 3, (
+            f"counter should stay at 3 after fail-open, got {state_data[state_key]}"
         )
 
     def test_pass_through_resets_counter(self, tmp_path):
@@ -462,4 +711,74 @@ class TestEdgeCases:
         result = run_hook(payload, state_path=tmp_path / "state.json")
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
         # Valid FixSummary -> approve -> empty stdout
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_state_ttl_prunes_stale_entries(self, tmp_path):
+        """State entries older than 24h are pruned — stale loop guard counter resets."""
+        import time as _time
+
+        state_path = tmp_path / "state.json"
+        session_id = str(uuid.uuid4())
+        transcript = tmp_path / "transcript.jsonl"
+
+        # Write a stale state entry with consecutive_blocks=3 (would fail-open if not pruned)
+        stale_timestamp = _time.time() - (25 * 3600)  # 25 hours ago
+        stale_state = {
+            f"{session_id}:{transcript}": {
+                "consecutive_blocks": 3,
+                "last_block_timestamp": stale_timestamp,
+            }
+        }
+        state_path.write_text(json.dumps(stale_state))
+
+        # Write a bad transcript
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(EMPTY_FIX_SUMMARY),
+        ]
+        write_transcript(transcript, entries)
+
+        # Stale entry is pruned -> counter resets to 0 -> first block (not fail-open approve)
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", (
+            "expected block JSON — stale state should be pruned, counter reset to 0"
+        )
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+
+
+# ── TestStdinParsing ──────────────────────────────────────────────────────────
+
+
+class TestStdinParsing:
+    def test_invalid_json_stdin_exits_approve(self, tmp_path):
+        """Non-JSON stdin -> JSONDecodeError in _parse_hook_input -> exit 0, empty stdout."""
+        env = os.environ.copy()
+        env["SUBAGENT_STOP_HOOK_STATE_PATH"] = str(tmp_path / "state.json")
+        result = subprocess.run(
+            ["uv", "run", str(SCRIPT)],
+            input="not json at all",
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_json_array_stdin_exits_approve(self, tmp_path):
+        """JSON array (not dict) stdin -> isinstance check in _parse_hook_input -> exit 0."""
+        env = os.environ.copy()
+        env["SUBAGENT_STOP_HOOK_STATE_PATH"] = str(tmp_path / "state.json")
+        result = subprocess.run(
+            ["uv", "run", str(SCRIPT)],
+            input="[1, 2, 3]",
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
         assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"

--- a/dev-guard/tests/test_subagent_stop_hook.py
+++ b/dev-guard/tests/test_subagent_stop_hook.py
@@ -130,6 +130,26 @@ class TestFixSummaryDetection:
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
         assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
 
+    def test_real_transcript_format_approves(self, tmp_path):
+        """Real Claude Code transcript format with nested message dict -> detected -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {
+                "type": "assistant",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": json.dumps(VALID_FIX_SUMMARY)},
+                    ],
+                },
+            },
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
     def test_transcript_without_fix_summary_approves(self, tmp_path):
         """Transcript with only regular messages (no FixSummary) -> not a Fixer -> approve."""
         transcript = tmp_path / "transcript.jsonl"

--- a/dev-guard/tests/test_subagent_stop_hook.py
+++ b/dev-guard/tests/test_subagent_stop_hook.py
@@ -71,7 +71,16 @@ def make_fix_summary_entry(fix_summary: dict) -> dict:
     }
 
 
-# Reusable valid FixSummary dict with all required fields.
+# Reusable FixSummary dicts for tests.
+EMPTY_FIX_SUMMARY: dict = {
+    "schema": "FixSummary",
+    "findings_fixed": [],
+    "needs_input_items": [],
+    "user_deferred": [],
+    "fixes": [],
+    "files_modified": [],
+}
+
 VALID_FIX_SUMMARY: dict = {
     "schema": "FixSummary",
     "findings_fixed": ["finding-001", "finding-002"],
@@ -177,7 +186,14 @@ class TestFixSummaryDetection:
         assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
 
     def test_fix_summary_in_tool_use_content_block_approves(self, tmp_path):
-        """FixSummary in SendMessage tool_use input block -> detected -> approve."""
+        """FixSummary as JSON-encoded string inside SendMessage tool_use input -> approve.
+
+        The hook cannot detect a FixSummary that is itself JSON-encoded as a string value
+        within a tool_use input field (e.g. message=json.dumps(VALID_FIX_SUMMARY)).
+        The raw_decode scan sees the outer input dict's JSON but the inner FixSummary
+        is escape-encoded as a string, not as a nested object. The hook finds no FixSummary
+        and approves via the "not a Fixer subagent" path, not via validation success.
+        """
         transcript = tmp_path / "transcript.jsonl"
         entries = [
             {"role": "user", "content": "Fix findings."},
@@ -206,17 +222,9 @@ class TestValidationFailures:
     def test_empty_fix_summary_blocks(self, tmp_path):
         """FixSummary with all empty arrays (total_accounted=0) -> block with reason."""
         transcript = tmp_path / "transcript.jsonl"
-        fix_summary = {
-            "schema": "FixSummary",
-            "findings_fixed": [],
-            "needs_input_items": [],
-            "user_deferred": [],
-            "fixes": [],
-            "files_modified": [],
-        }
         entries = [
             {"role": "user", "content": "Fix findings."},
-            make_fix_summary_entry(fix_summary),
+            make_fix_summary_entry(EMPTY_FIX_SUMMARY),
         ]
         write_transcript(transcript, entries)
         session_id = str(uuid.uuid4())
@@ -269,17 +277,9 @@ class TestValidationFailures:
 class TestLoopGuard:
     def _make_empty_fix_summary_transcript(self, tmp_path: Path) -> Path:
         transcript = tmp_path / "transcript.jsonl"
-        fix_summary = {
-            "schema": "FixSummary",
-            "findings_fixed": [],
-            "needs_input_items": [],
-            "user_deferred": [],
-            "fixes": [],
-            "files_modified": [],
-        }
         entries = [
             {"role": "user", "content": "Fix findings."},
-            make_fix_summary_entry(fix_summary),
+            make_fix_summary_entry(EMPTY_FIX_SUMMARY),
         ]
         write_transcript(transcript, entries)
         return transcript
@@ -322,52 +322,51 @@ class TestLoopGuard:
         )
 
     def test_pass_through_resets_counter(self, tmp_path):
-        """Block twice, pass (valid FixSummary), block again -> normal block."""
+        """Block twice, pass (valid FixSummary), block again -> normal block.
+
+        Uses the SAME transcript path throughout. The state key is
+        session_id:transcript_path, so overwriting the file content changes what
+        the hook sees without changing the key.
+        """
         state_path = tmp_path / "state.json"
         session_id = str(uuid.uuid4())
+        transcript = tmp_path / "transcript.jsonl"
 
-        # Empty FixSummary transcript -> produces blocks
-        bad_transcript = tmp_path / "bad.jsonl"
-        bad_fix_summary = {
-            "schema": "FixSummary",
-            "findings_fixed": [],
-            "needs_input_items": [],
-            "user_deferred": [],
-            "fixes": [],
-            "files_modified": [],
-        }
+        # Phase 1: Block twice (counter = 2) with empty FixSummary
         write_transcript(
-            bad_transcript,
+            transcript,
             [
                 {"role": "user", "content": "Fix findings."},
-                make_fix_summary_entry(bad_fix_summary),
+                make_fix_summary_entry(EMPTY_FIX_SUMMARY),
             ],
         )
+        for _ in range(2):
+            payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+            result = run_hook(payload, state_path=state_path)
+            output = json.loads(result.stdout)
+            assert output["decision"] == "block"
 
-        # Valid FixSummary transcript -> produces approve
-        good_transcript = tmp_path / "good.jsonl"
+        # Phase 2: Overwrite with valid FixSummary -> approve -> counter reset for this key
         write_transcript(
-            good_transcript,
+            transcript,
             [
                 {"role": "user", "content": "Fix findings."},
                 make_fix_summary_entry(VALID_FIX_SUMMARY),
             ],
         )
-
-        # Block twice (counter = 2)
-        for _ in range(2):
-            payload = make_payload(session_id=session_id, transcript_path=str(bad_transcript))
-            result = run_hook(payload, state_path=state_path)
-            output = json.loads(result.stdout)
-            assert output["decision"] == "block"
-
-        # Pass (valid FixSummary) -> counter reset for bad_transcript state key
-        payload = make_payload(session_id=session_id, transcript_path=str(good_transcript))
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
         result = run_hook(payload, state_path=state_path)
         assert result.stdout.strip() == "", "expected approve after valid FixSummary"
 
-        # Block again with bad_transcript -> normal block (counter at 1)
-        payload = make_payload(session_id=session_id, transcript_path=str(bad_transcript))
+        # Phase 3: Overwrite back to empty FixSummary -> normal block (counter at 1)
+        write_transcript(
+            transcript,
+            [
+                {"role": "user", "content": "Fix findings."},
+                make_fix_summary_entry(EMPTY_FIX_SUMMARY),
+            ],
+        )
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
         result = run_hook(payload, state_path=state_path)
         assert result.returncode == 0
         assert result.stdout.strip() != "", "expected block after counter reset"
@@ -389,19 +388,11 @@ class TestEdgeCases:
 
         def make_bad_transcript(name: str) -> Path:
             path = tmp_path / name
-            fix_summary = {
-                "schema": "FixSummary",
-                "findings_fixed": [],
-                "needs_input_items": [],
-                "user_deferred": [],
-                "fixes": [],
-                "files_modified": [],
-            }
             write_transcript(
                 path,
                 [
                     {"role": "user", "content": "Fix findings."},
-                    make_fix_summary_entry(fix_summary),
+                    make_fix_summary_entry(EMPTY_FIX_SUMMARY),
                 ],
             )
             return path

--- a/dev-guard/tests/test_subagent_stop_hook.py
+++ b/dev-guard/tests/test_subagent_stop_hook.py
@@ -1,0 +1,454 @@
+"""Tests for subagent-stop-hook.py
+
+Black-box subprocess tests. Each test feeds JSON on stdin and asserts exit codes
+and stdout content. State file isolation via SUBAGENT_STOP_HOOK_STATE_PATH env var.
+
+Approve: exit 0 + empty stdout.
+Block:   exit 0 + {"decision": "block", "reason": "..."} JSON on stdout.
+"""
+
+import json
+import os
+import subprocess
+import uuid
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent / "hooks" / "subagent-stop-hook.py"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def make_payload(
+    *,
+    session_id: str | None = None,
+    transcript_path: str = "",
+    cwd: str = ".",
+    permission_mode: str = "default",
+) -> dict:
+    return {
+        "hook_event_name": "SubagentStop",
+        "session_id": session_id or str(uuid.uuid4()),
+        "transcript_path": transcript_path,
+        "cwd": cwd,
+        "permission_mode": permission_mode,
+    }
+
+
+def run_hook(
+    payload: dict,
+    *,
+    state_path: Path | None = None,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    if state_path is not None:
+        env["SUBAGENT_STOP_HOOK_STATE_PATH"] = str(state_path)
+    return subprocess.run(
+        ["uv", "run", str(SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def write_transcript(path: Path, entries: list[dict]) -> None:
+    """Write a list of dicts as JSONL to a transcript file."""
+    lines = [json.dumps(e) for e in entries]
+    path.write_text("\n".join(lines) + "\n")
+
+
+def make_fix_summary_entry(fix_summary: dict) -> dict:
+    """Create a transcript entry containing a FixSummary in assistant message content."""
+    return {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "text",
+                "text": json.dumps(fix_summary),
+            }
+        ],
+    }
+
+
+# Reusable valid FixSummary dict with all required fields.
+VALID_FIX_SUMMARY: dict = {
+    "schema": "FixSummary",
+    "findings_fixed": ["finding-001", "finding-002"],
+    "needs_input_items": [],
+    "user_deferred": [],
+    "fixes": [
+        {"id": "finding-001", "description": "Fixed null pointer"},
+        {"id": "finding-002", "description": "Added input validation"},
+    ],
+    "files_modified": ["src/auth.py"],
+}
+
+
+# ── TestFastExit ──────────────────────────────────────────────────────────────
+
+
+class TestFastExit:
+    def test_no_transcript_path_approves(self, tmp_path):
+        """Payload with empty transcript_path -> approve (exit 0, empty stdout)."""
+        payload = make_payload(transcript_path="")
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_missing_transcript_file_approves(self, tmp_path):
+        """Payload with nonexistent transcript_path -> approve (file missing, fail-open)."""
+        payload = make_payload(transcript_path="/nonexistent/path/transcript.jsonl")
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+
+# ── TestFixSummaryDetection ───────────────────────────────────────────────────
+
+
+class TestFixSummaryDetection:
+    def test_transcript_with_valid_fix_summary_approves(self, tmp_path):
+        """Transcript containing VALID_FIX_SUMMARY -> structural validation passes -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {"role": "user", "content": "Fix the findings."},
+            make_fix_summary_entry(VALID_FIX_SUMMARY),
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_transcript_without_fix_summary_approves(self, tmp_path):
+        """Transcript with only regular messages (no FixSummary) -> not a Fixer -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {"role": "user", "content": "Summarize the repo."},
+            {"role": "assistant", "content": "The repo contains 9 plugins."},
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_fix_summary_with_needs_input_items_approves(self, tmp_path):
+        """FixSummary with findings_fixed + needs_input_items (total > 0) -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": ["finding-001"],
+            "needs_input_items": ["finding-002"],
+            "user_deferred": [],
+            "fixes": [{"id": "finding-001", "description": "Patched injection vector"}],
+            "files_modified": ["src/db.py"],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_fix_summary_embedded_in_prose_approves(self, tmp_path):
+        """FixSummary JSON surrounded by prose text in assistant message -> detected -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary_json = json.dumps(VALID_FIX_SUMMARY)
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            {
+                "role": "assistant",
+                "content": (
+                    f"I have completed all fixes. Here is the summary:\n\n"
+                    f"{fix_summary_json}\n\n"
+                    f"All findings have been addressed."
+                ),
+            },
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_fix_summary_in_tool_use_content_block_approves(self, tmp_path):
+        """FixSummary in SendMessage tool_use input block -> detected -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            {
+                "type": "tool_use",
+                "name": "SendMessage",
+                "id": "t1",
+                "input": {
+                    "to": "team-lead",
+                    "message": json.dumps(VALID_FIX_SUMMARY),
+                    "summary": "FixSummary handoff",
+                },
+            },
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+
+# ── TestValidationFailures ────────────────────────────────────────────────────
+
+
+class TestValidationFailures:
+    def test_empty_fix_summary_blocks(self, tmp_path):
+        """FixSummary with all empty arrays (total_accounted=0) -> block with reason."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [],
+            "needs_input_items": [],
+            "user_deferred": [],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON output, got empty stdout"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert output["reason"]  # non-empty reason
+
+    def test_whitespace_only_ids_blocks(self, tmp_path):
+        """FixSummary with whitespace-only string in findings_fixed -> block."""
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": ["   ", "\t"],
+            "needs_input_items": [],
+            "user_deferred": [],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON output, got empty stdout"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+
+    def test_malformed_transcript_approves(self, tmp_path):
+        """Transcript file with invalid JSONL content -> fail-open -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text("NOT JSON AT ALL\n{broken: json\n")
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        # Fail-open: malformed transcript is treated as no FixSummary found
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+
+# ── TestLoopGuard ─────────────────────────────────────────────────────────────
+
+
+class TestLoopGuard:
+    def _make_empty_fix_summary_transcript(self, tmp_path: Path) -> Path:
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [],
+            "needs_input_items": [],
+            "user_deferred": [],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        return transcript
+
+    def test_first_three_blocks_produce_block_json(self, tmp_path):
+        """Run 3 times with empty FixSummary, same session_id, same state_path -> all 3 block."""
+        transcript = self._make_empty_fix_summary_transcript(tmp_path)
+        session_id = str(uuid.uuid4())
+        state_path = tmp_path / "state.json"
+
+        for attempt in range(1, 4):
+            payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+            result = run_hook(payload, state_path=state_path)
+            assert result.returncode == 0, f"attempt {attempt} stderr: {result.stderr!r}"
+            assert result.stdout.strip() != "", (
+                f"attempt {attempt}: expected block JSON, got empty stdout"
+            )
+            output = json.loads(result.stdout)
+            assert output["decision"] == "block", (
+                f"attempt {attempt}: expected 'block', got {output['decision']!r}"
+            )
+
+    def test_fourth_block_approves(self, tmp_path):
+        """After 3 consecutive blocks, 4th attempt fails open -> approve (empty stdout)."""
+        transcript = self._make_empty_fix_summary_transcript(tmp_path)
+        session_id = str(uuid.uuid4())
+        state_path = tmp_path / "state.json"
+
+        # First 3 attempts -> block
+        for _ in range(3):
+            payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+            run_hook(payload, state_path=state_path)
+
+        # 4th attempt -> fail-open -> approve
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", (
+            f"expected approve (empty stdout) on 4th block, got: {result.stdout!r}"
+        )
+
+    def test_pass_through_resets_counter(self, tmp_path):
+        """Block twice, pass (valid FixSummary), block again -> normal block."""
+        state_path = tmp_path / "state.json"
+        session_id = str(uuid.uuid4())
+
+        # Empty FixSummary transcript -> produces blocks
+        bad_transcript = tmp_path / "bad.jsonl"
+        bad_fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [],
+            "needs_input_items": [],
+            "user_deferred": [],
+            "fixes": [],
+            "files_modified": [],
+        }
+        write_transcript(
+            bad_transcript,
+            [
+                {"role": "user", "content": "Fix findings."},
+                make_fix_summary_entry(bad_fix_summary),
+            ],
+        )
+
+        # Valid FixSummary transcript -> produces approve
+        good_transcript = tmp_path / "good.jsonl"
+        write_transcript(
+            good_transcript,
+            [
+                {"role": "user", "content": "Fix findings."},
+                make_fix_summary_entry(VALID_FIX_SUMMARY),
+            ],
+        )
+
+        # Block twice (counter = 2)
+        for _ in range(2):
+            payload = make_payload(session_id=session_id, transcript_path=str(bad_transcript))
+            result = run_hook(payload, state_path=state_path)
+            output = json.loads(result.stdout)
+            assert output["decision"] == "block"
+
+        # Pass (valid FixSummary) -> counter reset for bad_transcript state key
+        payload = make_payload(session_id=session_id, transcript_path=str(good_transcript))
+        result = run_hook(payload, state_path=state_path)
+        assert result.stdout.strip() == "", "expected approve after valid FixSummary"
+
+        # Block again with bad_transcript -> normal block (counter at 1)
+        payload = make_payload(session_id=session_id, transcript_path=str(bad_transcript))
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() != "", "expected block after counter reset"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+
+
+# ── TestEdgeCases ─────────────────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_different_transcript_paths_independent(self, tmp_path):
+        """Block 3 times for transcript A (same session_id), then block for transcript B.
+
+        Transcript B's loop guard counter is independent -> normal block (not approve).
+        """
+        state_path = tmp_path / "state.json"
+        session_id = str(uuid.uuid4())
+
+        def make_bad_transcript(name: str) -> Path:
+            path = tmp_path / name
+            fix_summary = {
+                "schema": "FixSummary",
+                "findings_fixed": [],
+                "needs_input_items": [],
+                "user_deferred": [],
+                "fixes": [],
+                "files_modified": [],
+            }
+            write_transcript(
+                path,
+                [
+                    {"role": "user", "content": "Fix findings."},
+                    make_fix_summary_entry(fix_summary),
+                ],
+            )
+            return path
+
+        transcript_a = make_bad_transcript("transcript_a.jsonl")
+        transcript_b = make_bad_transcript("transcript_b.jsonl")
+
+        # Block 3 times for transcript A -> loop guard exhausted for A
+        for _ in range(3):
+            payload = make_payload(session_id=session_id, transcript_path=str(transcript_a))
+            run_hook(payload, state_path=state_path)
+
+        # 4th attempt for transcript A -> approve (fail-open)
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript_a))
+        result_a4 = run_hook(payload, state_path=state_path)
+        assert result_a4.stdout.strip() == "", "transcript A 4th attempt should approve"
+
+        # Transcript B (same session) -> normal block (independent counter)
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript_b))
+        result_b1 = run_hook(payload, state_path=state_path)
+        assert result_b1.returncode == 0, f"stderr: {result_b1.stderr!r}"
+        assert result_b1.stdout.strip() != "", (
+            "transcript B first block should produce block JSON (independent counter)"
+        )
+        output = json.loads(result_b1.stdout)
+        assert output["decision"] == "block"
+
+    def test_stdin_payload_parsing(self, tmp_path):
+        """Verify hook correctly extracts session_id and transcript_path from stdin JSON.
+
+        Uses a valid FixSummary scenario to confirm end-to-end parsing works.
+        """
+        transcript = tmp_path / "transcript.jsonl"
+        session_id = str(uuid.uuid4())
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(VALID_FIX_SUMMARY),
+        ]
+        write_transcript(transcript, entries)
+
+        payload = make_payload(
+            session_id=session_id,
+            transcript_path=str(transcript),
+            cwd=str(tmp_path),
+            permission_mode="acceptEdits",
+        )
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        # Valid FixSummary -> approve -> empty stdout
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"

--- a/dev-guard/tests/test_subagent_stop_hook.py
+++ b/dev-guard/tests/test_subagent_stop_hook.py
@@ -15,6 +15,9 @@ from pathlib import Path
 
 SCRIPT = Path(__file__).parent.parent / "hooks" / "subagent-stop-hook.py"
 
+# Must match _STATE_KEY_SEP in subagent-stop-hook.py
+_STATE_KEY_SEP = "\x00"
+
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -57,6 +60,24 @@ def write_transcript(path: Path, entries: list[dict]) -> None:
     """Write a list of dicts as JSONL to a transcript file."""
     lines = [json.dumps(e) for e in entries]
     path.write_text("\n".join(lines) + "\n")
+
+
+def write_large_transcript(path: Path, entries: list[dict], target_size: int = 600 * 1024) -> None:
+    """Write a transcript padded with filler lines to exceed target_size bytes.
+
+    Padding lines are valid JSONL but contain no FixSummary markers, so they
+    don't affect detection. The real entries are appended AFTER the padding,
+    placing them in the tail window when target_size > _MAX_PARSE_BYTES.
+    """
+    filler_line = json.dumps({"role": "user", "content": "x" * 400}) + "\n"
+    filler_bytes = filler_line.encode("utf-8")
+    lines_needed = (target_size // len(filler_bytes)) + 1
+
+    with path.open("w", encoding="utf-8") as f:
+        for _ in range(lines_needed):
+            f.write(filler_line)
+        for entry in entries:
+            f.write(json.dumps(entry) + "\n")
 
 
 def make_fix_summary_entry(fix_summary: dict) -> dict:
@@ -343,6 +364,114 @@ class TestFixSummaryDetection:
         assert result.returncode == 0, f"stderr: {result.stderr!r}"
         assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
 
+    def test_flat_tool_use_with_direct_dict_fix_summary_approves(self, tmp_path):
+        """Flat tool_use entry where input IS the FixSummary dict -> direct dict match
+        at lines 192-193 -> detected -> validation passes -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            {
+                "type": "tool_use",
+                "name": "ReportFixSummary",
+                "id": "t1",
+                "input": VALID_FIX_SUMMARY,
+            },
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
+
+    def test_flat_tool_use_with_direct_dict_invalid_fix_summary_blocks(self, tmp_path):
+        """Flat tool_use entry where input IS an invalid FixSummary dict -> direct dict
+        match -> detected -> validation fails -> block."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            {
+                "type": "tool_use",
+                "name": "ReportFixSummary",
+                "id": "t1",
+                "input": EMPTY_FIX_SUMMARY,
+            },
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", (
+            "expected block JSON — invalid FixSummary as direct input dict"
+        )
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+
+    def test_large_transcript_fix_summary_in_tail_detected(self, tmp_path):
+        """Transcript >512KB with FixSummary at the END -> tail seek detects it -> approve."""
+        transcript = tmp_path / "transcript.jsonl"
+        tail_entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(VALID_FIX_SUMMARY),
+        ]
+        write_large_transcript(transcript, tail_entries, target_size=600 * 1024)
+        assert transcript.stat().st_size > 512 * 1024, (
+            f"test setup error: transcript is only {transcript.stat().st_size} bytes"
+        )
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", (
+            f"expected approve — FixSummary in tail window should be detected: {result.stdout!r}"
+        )
+
+    def test_large_transcript_fix_summary_only_in_head_not_detected(self, tmp_path):
+        """Transcript >512KB with FixSummary ONLY at the START -> tail seek skips it -> approve
+        (fail-open: no FixSummary found, subagent treated as non-Fixer)."""
+        transcript = tmp_path / "transcript.jsonl"
+        head_entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(VALID_FIX_SUMMARY),
+        ]
+        head_lines = [json.dumps(e) + "\n" for e in head_entries]
+        filler_line = json.dumps({"role": "user", "content": "x" * 400}) + "\n"
+        filler_bytes_needed = 600 * 1024
+        lines_needed = (filler_bytes_needed // len(filler_line.encode("utf-8"))) + 1
+        with transcript.open("w", encoding="utf-8") as f:
+            for line in head_lines:
+                f.write(line)
+            for _ in range(lines_needed):
+                f.write(filler_line)
+        assert transcript.stat().st_size > 512 * 1024
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", (
+            f"expected approve — FixSummary outside tail window not detected: {result.stdout!r}"
+        )
+
+    def test_fix_summary_keyword_without_json_approves(self, tmp_path):
+        """Assistant message contains 'FixSummary' keyword but no parseable JSON -> approve.
+
+        Exercises: keyword quick-check passes, _try_parse_fix_summary returns None,
+        _find_fix_summary returns None, hook treats subagent as non-Fixer.
+        """
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {"role": "user", "content": "Fix the findings."},
+            {
+                "role": "assistant",
+                "content": "I will output a FixSummary next with all findings_fixed.",
+            },
+        ]
+        write_transcript(transcript, entries)
+        payload = make_payload(transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() == "", (
+            f"expected approve — keyword present but no JSON: {result.stdout!r}"
+        )
+
 
 # ── TestValidationFailures ────────────────────────────────────────────────────
 
@@ -514,6 +643,90 @@ class TestValidationFailures:
         assert output["decision"] == "block"
         assert "must be a dict" in output["reason"]
 
+    def test_needs_input_item_whitespace_id_blocks(self, tmp_path):
+        """FixSummary with whitespace-only 'id' in needs_input_items -> block.
+
+        Exercises the require_dict=True path: item_id.strip() is falsy.
+        """
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [],
+            "needs_input_items": [{"id": "   ", "description": "spaces only"}],
+            "user_deferred": [],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON — whitespace-only id"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "missing non-empty 'id' field" in output["reason"]
+
+    def test_user_deferred_whitespace_id_blocks(self, tmp_path):
+        """FixSummary with whitespace-only 'id' in user_deferred -> block.
+
+        Exercises the require_dict=True path: item_id.strip() is falsy.
+        """
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": [],
+            "needs_input_items": [],
+            "user_deferred": [{"id": "\t", "reason": "tab only"}],
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block JSON — whitespace-only id"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "missing non-empty 'id' field" in output["reason"]
+
+    def test_non_list_fields_coerced_to_empty_blocks(self, tmp_path):
+        """FixSummary with non-list findings_fixed (string) -> coerced to [] -> all empty -> block.
+
+        Exercises the isinstance guard at _validate_fix_summary lines 259-264.
+        """
+        transcript = tmp_path / "transcript.jsonl"
+        fix_summary = {
+            "schema": "FixSummary",
+            "findings_fixed": "finding-001",  # string, not list
+            "needs_input_items": None,  # null, not list
+            "user_deferred": 42,  # int, not list
+            "fixes": [],
+            "files_modified": [],
+        }
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(fix_summary),
+        ]
+        write_transcript(transcript, entries)
+        session_id = str(uuid.uuid4())
+        payload = make_payload(session_id=session_id, transcript_path=str(transcript))
+        result = run_hook(payload, state_path=tmp_path / "state.json")
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", "expected block — non-list fields coerced to []"
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+        assert "all arrays empty" in output["reason"]
+
     def test_malformed_transcript_approves(self, tmp_path):
         """Transcript file with invalid JSONL content -> fail-open -> approve."""
         transcript = tmp_path / "transcript.jsonl"
@@ -528,19 +741,21 @@ class TestValidationFailures:
 # ── TestLoopGuard ─────────────────────────────────────────────────────────────
 
 
-class TestLoopGuard:
-    def _make_empty_fix_summary_transcript(self, tmp_path: Path) -> Path:
-        transcript = tmp_path / "transcript.jsonl"
-        entries = [
-            {"role": "user", "content": "Fix findings."},
-            make_fix_summary_entry(EMPTY_FIX_SUMMARY),
-        ]
-        write_transcript(transcript, entries)
-        return transcript
+def make_empty_fix_summary_transcript(tmp_path: Path) -> Path:
+    """Create a transcript with an empty (invalid) FixSummary for block-testing."""
+    transcript = tmp_path / "transcript.jsonl"
+    entries = [
+        {"role": "user", "content": "Fix findings."},
+        make_fix_summary_entry(EMPTY_FIX_SUMMARY),
+    ]
+    write_transcript(transcript, entries)
+    return transcript
 
+
+class TestLoopGuard:
     def test_first_three_blocks_produce_block_json(self, tmp_path):
         """Run 3 times with empty FixSummary, same session_id, same state_path -> all 3 block."""
-        transcript = self._make_empty_fix_summary_transcript(tmp_path)
+        transcript = make_empty_fix_summary_transcript(tmp_path)
         session_id = str(uuid.uuid4())
         state_path = tmp_path / "state.json"
 
@@ -558,7 +773,7 @@ class TestLoopGuard:
 
     def test_fourth_block_approves(self, tmp_path):
         """After 3 consecutive blocks, 4th attempt fails open -> approve (empty stdout)."""
-        transcript = self._make_empty_fix_summary_transcript(tmp_path)
+        transcript = make_empty_fix_summary_transcript(tmp_path)
         session_id = str(uuid.uuid4())
         state_path = tmp_path / "state.json"
 
@@ -585,7 +800,7 @@ class TestLoopGuard:
 
         # Verify counter did NOT grow past 3 (fail-open should not call _record_block)
         state_data = json.loads(state_path.read_text())
-        state_key = f"{session_id}:{transcript}"
+        state_key = f"{session_id}{_STATE_KEY_SEP}{transcript}"
         assert state_data[state_key]["consecutive_blocks"] == 3, (
             f"counter should stay at 3 after fail-open, got {state_data[state_key]}"
         )
@@ -594,7 +809,7 @@ class TestLoopGuard:
         """Block twice, pass (valid FixSummary), block again -> normal block.
 
         Uses the SAME transcript path throughout. The state key is
-        session_id:transcript_path, so overwriting the file content changes what
+        session_id + NUL + transcript_path, so overwriting the file content changes what
         the hook sees without changing the key.
         """
         state_path = tmp_path / "state.json"
@@ -713,6 +928,42 @@ class TestEdgeCases:
         # Valid FixSummary -> approve -> empty stdout
         assert result.stdout.strip() == "", f"unexpected stdout: {result.stdout!r}"
 
+    def test_missing_session_id_uses_transcript_path_as_state_key(self, tmp_path):
+        """Payload with session_id="" -> else branch -> state key is transcript_path only."""
+        transcript = tmp_path / "transcript.jsonl"
+        entries = [
+            {"role": "user", "content": "Fix findings."},
+            make_fix_summary_entry(EMPTY_FIX_SUMMARY),
+        ]
+        write_transcript(transcript, entries)
+        state_path = tmp_path / "state.json"
+
+        # Construct payload directly — make_payload would replace "" with uuid4()
+        payload = {
+            "hook_event_name": "SubagentStop",
+            "session_id": "",
+            "transcript_path": str(transcript),
+            "cwd": ".",
+            "permission_mode": "default",
+        }
+
+        result = run_hook(payload, state_path=state_path)
+        assert result.returncode == 0, f"stderr: {result.stderr!r}"
+        assert result.stdout.strip() != "", (
+            "expected block JSON — empty session_id, invalid FixSummary"
+        )
+        output = json.loads(result.stdout)
+        assert output["decision"] == "block"
+
+        # Verify state key is transcript_path alone (not ":transcript_path")
+        state_data = json.loads(state_path.read_text())
+        expected_key = str(transcript)
+        assert expected_key in state_data, (
+            f"state key should be transcript_path alone when session_id is empty; "
+            f"got keys: {list(state_data.keys())}"
+        )
+        assert state_data[expected_key]["consecutive_blocks"] == 1
+
     def test_state_ttl_prunes_stale_entries(self, tmp_path):
         """State entries older than 24h are pruned — stale loop guard counter resets."""
         import time as _time
@@ -724,7 +975,7 @@ class TestEdgeCases:
         # Write a stale state entry with consecutive_blocks=3 (would fail-open if not pruned)
         stale_timestamp = _time.time() - (25 * 3600)  # 25 hours ago
         stale_state = {
-            f"{session_id}:{transcript}": {
+            f"{session_id}{_STATE_KEY_SEP}{transcript}": {
                 "consecutive_blocks": 3,
                 "last_block_timestamp": stale_timestamp,
             }


### PR DESCRIPTION
## Summary
- Adds SubagentStop hook (subagent-stop-hook.py) that validates FixSummary structural completeness when findings-related subagents stop, providing a best-effort safety net for the finding-classification anti-deferral system
- Adapted from the original TaskCompleted plan after discovering TaskCompleted is not a supported Claude Code hook event; uses SubagentStop with transcript-based detection instead of keyword matching
- Includes 29 black-box subprocess tests, hook registration, version bump to 1.53.0, and documentation updates across all surfaces