### PR TITLE
fix(test-plan): adds framework-aware BDD research and user decision provenance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.55.0",
+      "version": "1.56.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification",
       "category": "quality",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/references/finding-classification.md
+++ b/code-quality/references/finding-classification.md
@@ -41,7 +41,7 @@ Two-tier taxonomy:
 - "Two valid architectures exist (X vs Y) with different tradeoffs" — genuine design decision
 - "This changes user-facing behavior — should the API return 404 or 200 with empty body?" — UX decision
 - "This requires choosing between backward compatibility and correctness" — scope decision
-- "The BDD annotation says Cucumber.js but the project uses Vitest" inside a PROVENANCE block
+- "The BDD annotation says Cucumber.js but the project uses Vitest" in a PROVENANCE-marked section
   — user-confirmed decision, must escalate not auto-fix
 
 **What is NOT `needs-input`:**

--- a/code-quality/references/finding-classification.md
+++ b/code-quality/references/finding-classification.md
@@ -29,9 +29,10 @@ Two-tier taxonomy:
   specific decision the user must make and why the agent cannot make it.
 - `needs-input` is NOT a way to defer work. Using `needs-input` to avoid implementing a fix you
   could make yourself is deferral-by-classification — a violation of the Anti-Deferral Principle.
-- **Provenance override:** Findings that propose changing fields inside a `<!-- PROVENANCE: ... -->`
-  block indicating user confirmation MUST be classified as `needs-input`. These fields represent
-  decisions the user already made via explicit checkpoints (e.g., AskUserQuestion in `/test-plan`).
+- **Provenance override:** Findings that propose changing fields in a section marked with a
+  `<!-- PROVENANCE: ... -->` comment MUST be classified as `needs-input`. The comment marks all
+  fields that follow it as user-confirmed decisions made via explicit checkpoints (e.g.,
+  AskUserQuestion in `/test-plan`).
   Overwriting them without re-confirming with the user violates the decision chain. If you believe
   a user-confirmed decision is wrong (e.g., incompatible framework choice), surface the conflict
   as `needs-input` with your evidence — let the user reconcile, don't auto-fix.

--- a/code-quality/references/finding-classification.md
+++ b/code-quality/references/finding-classification.md
@@ -41,8 +41,8 @@ Two-tier taxonomy:
 - "Two valid architectures exist (X vs Y) with different tradeoffs" — genuine design decision
 - "This changes user-facing behavior — should the API return 404 or 200 with empty body?" — UX decision
 - "This requires choosing between backward compatibility and correctness" — scope decision
-- "The BDD annotation says Cucumber.js but the project uses Vitest" in a PROVENANCE-marked section
-  — user-confirmed decision, must escalate not auto-fix
+- A downstream skill proposes changing a field in a PROVENANCE-marked section (e.g., "the annotation
+  says Cucumber.js but the project uses Vitest") — user-confirmed decision, must escalate not auto-fix
 
 **What is NOT `needs-input`:**
 - "I'm not sure if this is worth fixing" → `needs-fix`. Your opinion of worth is irrelevant.

--- a/code-quality/references/finding-classification.md
+++ b/code-quality/references/finding-classification.md
@@ -29,11 +29,19 @@ Two-tier taxonomy:
   specific decision the user must make and why the agent cannot make it.
 - `needs-input` is NOT a way to defer work. Using `needs-input` to avoid implementing a fix you
   could make yourself is deferral-by-classification — a violation of the Anti-Deferral Principle.
+- **Provenance override:** Findings that propose changing fields inside a `<!-- PROVENANCE: ... -->`
+  block indicating user confirmation MUST be classified as `needs-input`. These fields represent
+  decisions the user already made via explicit checkpoints (e.g., AskUserQuestion in `/test-plan`).
+  Overwriting them without re-confirming with the user violates the decision chain. If you believe
+  a user-confirmed decision is wrong (e.g., incompatible framework choice), surface the conflict
+  as `needs-input` with your evidence — let the user reconcile, don't auto-fix.
 
 **What IS `needs-input`:**
 - "Two valid architectures exist (X vs Y) with different tradeoffs" — genuine design decision
 - "This changes user-facing behavior — should the API return 404 or 200 with empty body?" — UX decision
 - "This requires choosing between backward compatibility and correctness" — scope decision
+- "The BDD annotation says Cucumber.js but the project uses Vitest" inside a PROVENANCE block
+  — user-confirmed decision, must escalate not auto-fix
 
 **What is NOT `needs-input`:**
 - "I'm not sure if this is worth fixing" → `needs-fix`. Your opinion of worth is irrelevant.

--- a/code-quality/skills/test-plan/SKILL.md
+++ b/code-quality/skills/test-plan/SKILL.md
@@ -616,7 +616,7 @@ Append to the end of `{plan_file}` using the Edit tool:
      overwrite user decisions. -->
 
 **Test Plan:** {output_path}
-**Mode:** {mode} (one of: Manual UAT, UAT + BDD (feature files only), UAT + BDD (native integration), UAT + BDD (standalone))
+**Mode:** {Manual UAT | UAT + BDD (feature files only) | UAT + BDD (native integration) | UAT + BDD (standalone)}
 **Feature Files:** {memory_dir}/test-plans/{run-id}-features/ (omit line if Manual UAT)
 **BDD Setup Needed:** {yes | no} (if yes: `{bdd_install_cmd}`)
 **BDD Scaffold Command:** `{bdd_scaffold_cmd}` (omit line if Manual UAT or specification-only)
@@ -666,9 +666,14 @@ Mode: {mode}
 Scenarios: {N} ({primary_count} primary, {edge_case_count} edge case)
 Tasks covered: {M} of {total_user_facing_tasks} user-facing tasks
 
-{if BDD:}
+{if BDD (native integration or standalone):}
 Feature files: {feature_dir} ({file_count} files)
-BDD setup needed: {yes | no} ({framework} — /swarm will handle installation)
+BDD setup needed: yes ({framework} — /swarm will handle installation)
+{end if}
+
+{if BDD (feature files only — specification-only):}
+Feature files: {feature_dir} ({file_count} files, specification only)
+BDD setup needed: no (Gherkin specifications — tests in {test_runner})
 {end if}
 
 {if exploratory charters:}

--- a/code-quality/skills/test-plan/SKILL.md
+++ b/code-quality/skills/test-plan/SKILL.md
@@ -92,7 +92,30 @@ Read and parse the input plan file before doing anything else.
    - Tasks marked as "internal refactor" or "infrastructure" with no user-visible changes
      are noted but do not generate scenarios
 
-6. **Detect BDD infrastructure** — Search project dependency files for BDD tooling:
+6. **Detect test runner and BDD infrastructure** — Search project dependency files for both
+   the project's test runner and any existing BDD tooling. Both are needed: the test runner
+   informs Phase 3's BDD framework recommendations; the BDD detection determines whether
+   Phase 3 auto-selects or asks the user.
+
+   **Test runner detection:**
+
+   | File | Pattern | Test Runner |
+   |---|---|---|
+   | `package.json` | `vitest` | Vitest |
+   | `package.json` | `jest` or `@jest/` | Jest |
+   | `package.json` | `mocha` | Mocha |
+   | `pyproject.toml` / `requirements*.txt` | `pytest` | pytest |
+   | `go.mod` | (Go convention) | go test |
+   | `Cargo.toml` | (Rust convention) | cargo test |
+   | `build.gradle` / `pom.xml` | `junit` or `testng` | JUnit / TestNG |
+   | `Gemfile` | `rspec` | RSpec |
+   | `Gemfile` | `minitest` | Minitest |
+
+   Search using Grep with `output_mode: "files_with_matches"`. Record `test_runner`
+   (or `unknown`). If multiple match, prefer the one in test scripts
+   (e.g., `"test": "vitest"` in `package.json` scripts).
+
+   **BDD infrastructure detection:**
 
    | File | Pattern | Framework |
    |---|---|---|
@@ -104,8 +127,8 @@ Read and parse the input plan file before doing anything else.
    | `build.gradle` or `pom.xml` | `cucumber-java` | Java/Cucumber-JVM |
    | `Gemfile` | `cucumber` | Ruby/Cucumber |
 
-   Search using Grep with `output_mode: "files_with_matches"`. Record detected framework
-   (or `none`) and the detected file path for Phase 5 (BDD Staging).
+   Search using Grep with `output_mode: "files_with_matches"`. Record detected BDD
+   framework (or `none`) and the detected file path for Phase 5 (BDD Staging).
 
 7. **Print ingestion summary:**
 
@@ -114,6 +137,7 @@ Read and parse the input plan file before doing anything else.
    Goal: {goal}
    Branch: {branch}
    Tech stack: {tech_stack}
+   Test runner: {test_runner | unknown}
    User-facing tasks: {N} of {total_tasks}
    BDD infra: {framework | none detected}
    ```
@@ -281,28 +305,65 @@ BDD infra detected ({framework} in {file}). Generating UAT document + .feature f
 ```
 
 **If NO BDD infra detected:**
-Ask via `AskUserQuestion`:
 
-"No BDD framework detected in this project. How should I generate the test plan?
+Before presenting options, research BDD integration options that are compatible with the
+project's actual test runner. This prevents recommending frameworks that conflict with the
+existing test setup (e.g., suggesting Cucumber.js for a Vitest project).
 
-Options:
-A) Manual UAT checklist only (recommended for most projects)
+```
+Skill("deep-research", "External: BDD and Gherkin integration options for {test_runner}
+in {tech_stack} projects. Compare: (1) native BDD plugins that integrate directly with
+{test_runner} (e.g., vitest-cucumber-plugin for Vitest, jest-cucumber for Jest, pytest-bdd
+for pytest), (2) standalone BDD frameworks (Cucumber.js, godog, cucumber-rs) and their
+compatibility with {test_runner}, (3) using Gherkin .feature files as specification-only
+documentation (not executable). For each viable option: package name, registry page,
+last release date, open issues count, compatibility notes with {test_runner}, setup
+complexity. Exclude options unmaintained (no release in 12+ months) or incompatible
+with {test_runner}.")
+```
+
+Use the research findings to build a project-aware options list. Present via `AskUserQuestion`:
+
+"No BDD framework detected. Your project uses **{test_runner}** for testing.
+
+Based on research, here are the BDD options compatible with {test_runner}:
+
+A) **Manual UAT checklist only** (no BDD)
    — Human-readable walkthrough with pass/fail checkboxes. No BDD setup required.
 
-B) UAT + generate .feature files only (set up BDD later)
-   — Adds Gherkin .feature files to the test plan doc. BDD framework not installed.
-   — Requires BDD setup before scenarios can be executed automatically.
+B) **Gherkin specification files only** (documentation, not executable)
+   — Generates .feature files as living specifications. Tests remain in {test_runner}.
+   — No additional framework needed.
 
-C) UAT + set up BDD + generate .feature files
-   — Records the BDD framework install command for /swarm to run on the feature branch.
-   — {framework recommendation based on tech stack}
+{If research found a native {test_runner} BDD plugin:}
+C) **{test_runner}-native BDD** ({plugin_name})
+   — {1-sentence from research: what it does, maintenance status}
+   — Tests run through {test_runner}. No second test runner.
 
-Which option? (A/B/C)"
+{If research found a compatible standalone BDD framework:}
+D) **Standalone BDD framework** ({standalone_name})
+   — Adds a separate test runner alongside {test_runner}.
+   — {1-sentence from research: tradeoffs}
+
+{Omit C if no viable native plugin found. Omit D if no compatible standalone found.
+If neither C nor D is viable, note this and explain why.}
+
+Recommendation: {research-informed — prefer native integration (C) over standalone (D)
+over specification-only (B). Recommend A if the plan is simple and BDD adds no value.}
+
+Which option?"
 
 Record the selected mode as `mode`:
 - A → `Manual UAT`
-- B → `UAT + BDD (feature files only)`
-- C → `UAT + BDD (full setup)`
+- B → `UAT + BDD (feature files only)` — set `bdd_framework: none (specification only)`,
+  `BDD Setup Needed: no`. Omit install/scaffold/test commands from annotation.
+- C → `UAT + BDD (native integration)` — use the researched plugin's install/scaffold/test
+  commands. Record `bdd_framework` as the plugin name.
+- D → `UAT + BDD (standalone)` — use the standalone framework's commands.
+
+Store the research-derived `bdd_install_cmd`, `bdd_scaffold_cmd`, `bdd_test_cmd`,
+`bdd_framework`, `bdd_feature_dir`, and `bdd_step_dir` from the selected option.
+For option B, these are all empty/none — Phase 6 handles this format.
 
 ### Exploratory Charter Decision
 
@@ -447,7 +508,8 @@ Write the document to `{output_path}` using the Write tool.
 
 **Skip this phase entirely if mode is `Manual UAT`.**
 
-Run only when mode is `UAT + BDD (feature files only)` or `UAT + BDD (full setup)`.
+Run when mode is any BDD variant: `UAT + BDD (feature files only)`,
+`UAT + BDD (native integration)`, or `UAT + BDD (standalone)`.
 
 ### Feature File Generation
 
@@ -481,7 +543,12 @@ Write each `.feature` file using the Write tool.
 
 ### BDD Toolchain Reference
 
-Record the appropriate scaffold command based on the detected (or user-selected) framework:
+**If Phase 3 ran /deep-research** (no existing BDD infra): use the research-derived values
+stored in Phase 3. The research already identified the correct framework, install commands,
+and compatibility with the project's test runner. Skip this section.
+
+**If Phase 3 auto-selected BDD** (existing BDD infra detected in Phase 0): derive values
+from the detected framework using this fallback table:
 
 | Language | Framework | Install Command | Scaffold Command | Test Command |
 |---|---|---|---|---|
@@ -492,10 +559,13 @@ Record the appropriate scaffold command based on the detected (or user-selected)
 | Java | Cucumber-JVM | `<dependency>io.cucumber:cucumber-java</dependency>` | Run features — auto-generates snippets | `mvn test` |
 | Ruby | Cucumber | `gem install cucumber` | `cucumber --dry-run` — generates undefined step snippets | `bundle exec cucumber` |
 
+This table is a fallback for projects that already have BDD installed. For new BDD setups,
+Phase 3's /deep-research provides test-runner-aware recommendations that supersede this table.
+
 Record:
-- `bdd_install_cmd` — the install command for the detected framework (with version pinning if known)
+- `bdd_install_cmd` — the install command (from research or fallback table)
 - `bdd_scaffold_cmd` — the scaffold command to generate step definition skeletons
-- `bdd_test_cmd` — the command to run the BDD test suite (from the Test Command column above)
+- `bdd_test_cmd` — the command to run the BDD test suite
 - `bdd_framework` — the framework name
 - `bdd_feature_dir` — where `.feature` files will live in the source tree (e.g., `features/`, `tests/acceptance/`)
 - `bdd_step_dir` — where step definitions will live (e.g., `steps/`, `step_definitions/`, `*_test.go`)
@@ -520,15 +590,24 @@ Append to the end of `{plan_file}` using the Edit tool:
 ```markdown
 ## Test Plan
 
+<!-- PROVENANCE: Generated by /test-plan with explicit user confirmation at checkpoints:
+     - Personas: confirmed Phase 1 (AskUserQuestion)
+     - Scenarios: confirmed Phase 2 (AskUserQuestion checkpoint + per-scenario review)
+     - Output Mode & BDD decisions: confirmed Phase 3 (AskUserQuestion)
+     All fields below reflect user-confirmed decisions.
+     Downstream skills: if you disagree with a choice here, classify as needs-input
+     (require user confirmation before changing), not needs-fix. Do not silently
+     overwrite user decisions. -->
+
 **Test Plan:** {output_path}
 **Mode:** {Manual UAT | UAT + BDD}
 **Feature Files:** {memory_dir}/test-plans/{run-id}-features/ (omit line if UAT-only)
 **BDD Setup Needed:** {yes | no} (if yes: `{bdd_install_cmd}`)
-**BDD Scaffold Command:** `{bdd_scaffold_cmd}` (omit line if UAT-only)
-**BDD Test Command:** `{bdd_test_cmd}` (omit line if UAT-only)
+**BDD Scaffold Command:** `{bdd_scaffold_cmd}` (omit line if UAT-only or specification-only)
+**BDD Test Command:** `{bdd_test_cmd}` (omit line if UAT-only or specification-only)
 **BDD Framework:** {bdd_framework} (omit line if UAT-only)
 **BDD Feature Dir:** {bdd_feature_dir} (omit line if UAT-only)
-**BDD Step Dir:** {bdd_step_dir} (omit line if UAT-only)
+**BDD Step Dir:** {bdd_step_dir} (omit line if UAT-only or specification-only)
 **Scenarios:** {total scenario count}
 **Personas:** {Primary Persona Name}, {Edge Case Persona Name}
 
@@ -543,6 +622,13 @@ Append to the end of `{plan_file}` using the Edit tool:
 
 **Field label format is fixed.** Downstream skills match on exact bold field names
 (`**Test Plan:**`, `**Mode:**`, `**Feature Files:**`, etc.). Do not reorder or rename.
+
+**Specification-only mode** (Phase 3 option B): When the user chose Gherkin files as
+documentation only (not executable), write:
+- `**BDD Setup Needed:** no (feature files are Gherkin specifications; tests implemented in {test_runner})`
+- `**BDD Framework:** none (specification only)`
+- Include `**BDD Feature Dir:**` (files still exist for documentation)
+- Omit: `**BDD Scaffold Command:**`, `**BDD Test Command:**`, `**BDD Step Dir:**`
 
 The `**BDD Setup Needed:** yes` signal is what `/swarm` Phase 0 uses to decide whether to
 install the BDD framework on the feature branch.
@@ -584,12 +670,13 @@ this test plan from the plan file annotation.
 
 ```
 ### Phase Flow
-Phase 0: Ingest plan file → Phase 1: Map user journeys →
+Phase 0: Ingest plan file (detect test runner + BDD infra) →
+Phase 1: Map user journeys →
 Phase 2: Write scenarios + user checkpoint →
-Phase 3: Select output mode (BDD or UAT-only) →
+Phase 3: Select output mode (/deep-research for BDD compatibility) →
 Phase 4: Write test plan document →
 Phase 5: Generate .feature files (BDD only) →
-Phase 6: Annotate plan file → Completion report
+Phase 6: Annotate plan file (with provenance markers) → Completion report
 
 ### Output Paths (two-stage fallback)
 1. {memory_dir}/test-plans/{run-id}.md          — test plan document
@@ -603,6 +690,8 @@ Phase 6: Annotate plan file → Completion report
 **Scenarios:** | **Personas:** | ### Scenario-Task Mapping
 
 ### BDD Toolchain
+Research-driven (Phase 3 /deep-research) when no existing BDD infra.
+Fallback table (Phase 5) when BDD already installed:
 Python: pytest-bdd | Go: godog+gherkingen | Node.js: Cucumber.js
 Rust: cucumber-rs | Java: Cucumber-JVM | Ruby: Cucumber
 

--- a/code-quality/skills/test-plan/SKILL.md
+++ b/code-quality/skills/test-plan/SKILL.md
@@ -618,7 +618,7 @@ Append to the end of `{plan_file}` using the Edit tool:
 **Test Plan:** {output_path}
 **Mode:** {Manual UAT | UAT + BDD (feature files only) | UAT + BDD (native integration) | UAT + BDD (standalone)}
 **Feature Files:** {memory_dir}/test-plans/{run-id}-features/ (omit line if Manual UAT)
-**BDD Setup Needed:** {yes | no} (if yes: `{bdd_install_cmd}`)
+**BDD Setup Needed:** {yes | no} (if yes: `{bdd_install_cmd}`) (omit line if Manual UAT)
 **BDD Scaffold Command:** `{bdd_scaffold_cmd}` (omit line if Manual UAT or specification-only)
 **BDD Test Command:** `{bdd_test_cmd}` (omit line if Manual UAT or specification-only)
 **BDD Framework:** {bdd_framework} (omit line if Manual UAT)

--- a/code-quality/skills/test-plan/SKILL.md
+++ b/code-quality/skills/test-plan/SKILL.md
@@ -310,6 +310,11 @@ Before presenting options, research BDD integration options that are compatible 
 project's actual test runner. This prevents recommending frameworks that conflict with the
 existing test setup (e.g., suggesting Cucumber.js for a Vitest project).
 
+**If `test_runner` is `unknown`:** ask the user first via `AskUserQuestion`:
+"I couldn't detect your test runner automatically. What test framework does this project use?
+(e.g., Vitest, Jest, pytest, go test)" — then use the answer as `test_runner` for the
+research query below.
+
 ```
 Skill("deep-research", "External: BDD and Gherkin integration options for {test_runner}
 in {tech_stack} projects. Compare: (1) native BDD plugins that integrate directly with
@@ -321,6 +326,11 @@ last release date, open issues count, compatibility notes with {test_runner}, se
 complexity. Exclude options unmaintained (no release in 12+ months) or incompatible
 with {test_runner}.")
 ```
+
+**Fallback:** If `/deep-research` is unavailable, errors, or returns no viable options,
+fall back to the static BDD Toolchain Reference table in Phase 5. Present options A and B
+only (no C/D), noting: "BDD framework research was inconclusive. Options C/D omitted.
+If you know which BDD framework you want, choose A now and set it up manually."
 
 Use the research findings to build a project-aware options list. Present via `AskUserQuestion`:
 
@@ -600,14 +610,14 @@ Append to the end of `{plan_file}` using the Edit tool:
      overwrite user decisions. -->
 
 **Test Plan:** {output_path}
-**Mode:** {Manual UAT | UAT + BDD}
-**Feature Files:** {memory_dir}/test-plans/{run-id}-features/ (omit line if UAT-only)
+**Mode:** {mode} (one of: Manual UAT, UAT + BDD (feature files only), UAT + BDD (native integration), UAT + BDD (standalone))
+**Feature Files:** {memory_dir}/test-plans/{run-id}-features/ (omit line if Manual UAT)
 **BDD Setup Needed:** {yes | no} (if yes: `{bdd_install_cmd}`)
-**BDD Scaffold Command:** `{bdd_scaffold_cmd}` (omit line if UAT-only or specification-only)
-**BDD Test Command:** `{bdd_test_cmd}` (omit line if UAT-only or specification-only)
-**BDD Framework:** {bdd_framework} (omit line if UAT-only)
-**BDD Feature Dir:** {bdd_feature_dir} (omit line if UAT-only)
-**BDD Step Dir:** {bdd_step_dir} (omit line if UAT-only or specification-only)
+**BDD Scaffold Command:** `{bdd_scaffold_cmd}` (omit line if Manual UAT or specification-only)
+**BDD Test Command:** `{bdd_test_cmd}` (omit line if Manual UAT or specification-only)
+**BDD Framework:** {bdd_framework} (omit line if Manual UAT)
+**BDD Feature Dir:** {bdd_feature_dir} (omit line if Manual UAT)
+**BDD Step Dir:** {bdd_step_dir} (omit line if Manual UAT or specification-only)
 **Scenarios:** {total scenario count}
 **Personas:** {Primary Persona Name}, {Edge Case Persona Name}
 

--- a/code-quality/skills/test-plan/SKILL.md
+++ b/code-quality/skills/test-plan/SKILL.md
@@ -105,15 +105,21 @@ Read and parse the input plan file before doing anything else.
    | `package.json` | `jest` or `@jest/` | Jest |
    | `package.json` | `mocha` | Mocha |
    | `pyproject.toml` / `requirements*.txt` | `pytest` | pytest |
-   | `go.mod` | (Go convention) | go test |
-   | `Cargo.toml` | (Rust convention) | cargo test |
+   | `go.mod` | file exists (Glob) | go test |
+   | `Cargo.toml` | file exists (Glob) | cargo test |
    | `build.gradle` / `pom.xml` | `junit` or `testng` | JUnit / TestNG |
    | `Gemfile` | `rspec` | RSpec |
    | `Gemfile` | `minitest` | Minitest |
 
-   Search using Grep with `output_mode: "files_with_matches"`. Record `test_runner`
-   (or `unknown`). If multiple match, prefer the one in test scripts
-   (e.g., `"test": "vitest"` in `package.json` scripts).
+   For rows with a grep pattern: use Grep with `output_mode: "files_with_matches"`.
+   For rows marked "file exists (Glob)": use Glob to check whether the file exists in the
+   project root (e.g., `Glob("go.mod")`). Record `test_runner` (or `unknown`). If multiple
+   match, resolve by this priority ladder:
+   1. **scripts.test contains a runner name** (e.g., `"test": "vitest run"`) → that runner wins,
+      even if the scripts value uses a prefix or flags (substring match is sufficient).
+   2. **No scripts match or scripts key absent** → fall back to the order of appearance in the
+      detection table above (earlier rows win — package.json patterns before file-existence rows).
+   3. **Still ambiguous** → record `unknown`; Step 7 will ask the user.
 
    **BDD infrastructure detection:**
 
@@ -130,14 +136,25 @@ Read and parse the input plan file before doing anything else.
    Search using Grep with `output_mode: "files_with_matches"`. Record detected BDD
    framework (or `none`) and the detected file path for Phase 5 (BDD Staging).
 
-7. **Print ingestion summary:**
+7. **Resolve unknown test runner** — If `test_runner` is still `unknown` after the detection
+   tables above, ask via `AskUserQuestion` before proceeding:
+   "I couldn't detect your test runner automatically. What test framework does this project use?
+   (e.g., Vitest, Jest, pytest, go test, cargo test)"
+   Use the answer as `test_runner` for all subsequent phases. Before writing `test_runner` into
+   any annotation field, sanitize the value: collapse to a single line (strip newlines), strip
+   markdown bold markers (`**`), backtick sequences, HTML comment delimiters (`<!--`, `-->`),
+   and pipe characters (`|`). Store only the sanitized value.
+   This resolution happens once in Phase 0 so both the BDD auto-select branch (when BDD infra
+   exists) and the research branch (when no BDD infra exists) receive a known test_runner value.
+
+8. **Print ingestion summary:**
 
    ```
    Plan ingested: {plan_file}
    Goal: {goal}
    Branch: {branch}
    Tech stack: {tech_stack}
-   Test runner: {test_runner | unknown}
+   Test runner: {test_runner}
    User-facing tasks: {N} of {total_tasks}
    BDD infra: {framework | none detected}
    ```
@@ -309,6 +326,12 @@ detected BDD framework is a plugin for `test_runner` (e.g., `pytest-bdd` for pyt
 `jest-cucumber` for Jest), set `mode` to `UAT + BDD (native integration)`. If it is a
 standalone framework (e.g., `godog`, `Cucumber.js`, `cucumber-rs`), set `mode` to
 `UAT + BDD (standalone)`.
+Set `BDD Setup Needed: no` — the framework is already installed. Scan the project for
+existing `.feature` files and step definitions to determine `bdd_feature_dir` and `bdd_step_dir`.
+If none found, use the framework's conventional defaults: Python/pytest-bdd → `tests/features/`,
+`tests/step_defs/`; Go/godog → `features/`, `features/`; Node.js/Cucumber.js → `features/`,
+`features/step_definitions/`; Rust/cucumber-rs → `tests/features/`, `tests/`; Java/Cucumber-JVM
+→ `src/test/resources/`, `src/test/java/`; Ruby/Cucumber → `features/`, `features/step_definitions/`.
 
 **If NO BDD infra detected:**
 
@@ -316,10 +339,7 @@ Before presenting options, research BDD integration options that are compatible 
 project's actual test runner. This prevents recommending frameworks that conflict with the
 existing test setup (e.g., suggesting Cucumber.js for a Vitest project).
 
-**If `test_runner` is `unknown`:** ask the user first via `AskUserQuestion`:
-"I couldn't detect your test runner automatically. What test framework does this project use?
-(e.g., Vitest, Jest, pytest, go test)" — then use the answer as `test_runner` for the
-research query below.
+(`test_runner` is always known at this point — unknown was resolved in Phase 0 Step 7.)
 
 ```
 Skill("deep-research", "BDD and Gherkin integration options for {test_runner}
@@ -334,11 +354,17 @@ with {test_runner}. Mode: External")
 ```
 
 **Fallback:** If `/deep-research` is unavailable, errors, or returns no viable options,
-fall back to the static BDD Toolchain Reference table in Phase 5. Present options A and B
-only (no C/D), noting: "BDD framework research was inconclusive. Options C/D omitted.
-If you know which BDD framework you want, choose A now and set it up manually."
+present options A and B only (no C/D), with this note:
+"BDD framework research was inconclusive — viable framework and install commands could not be
+determined for {test_runner}. Options C/D require confirmed package compatibility and have been
+omitted. Choose A (no BDD) or B (specification-only .feature files). If you know which BDD
+framework you want, set it up manually after the plan is complete."
+Do NOT fall back to the Phase 5 BDD Toolchain Reference table — that table applies only to
+projects that already have BDD installed; it does not provide install commands suitable for
+fresh BDD setup on arbitrary test runners.
 
-Use the research findings to build a project-aware options list. Present via `AskUserQuestion`:
+**If research succeeds:** Use the research findings to build a project-aware options list.
+Present via `AskUserQuestion`:
 
 "No BDD framework detected. Your project uses **{test_runner}** for testing.
 
@@ -583,8 +609,8 @@ Record:
 - `bdd_scaffold_cmd` — the scaffold command to generate step definition skeletons
 - `bdd_test_cmd` — the command to run the BDD test suite
 - `bdd_framework` — the framework name
-- `bdd_feature_dir` — where `.feature` files will live in the source tree (e.g., `features/`, `tests/acceptance/`)
-- `bdd_step_dir` — where step definitions will live (e.g., `steps/`, `step_definitions/`, `*_test.go`)
+- `bdd_feature_dir` — where `.feature` files will live (from Phase 3 project scan or research; not in the fallback table)
+- `bdd_step_dir` — where step definitions will live (from Phase 3 project scan or research; not in the fallback table)
 
 These values are written into the plan file annotation in Phase 6 so `/swarm` Phase 0 knows
 what to install and run without re-detecting.
@@ -620,13 +646,14 @@ Append to the end of `{plan_file}` using the Edit tool:
 
 **Test Plan:** {output_path}
 **Mode:** {Manual UAT | UAT + BDD (feature files only) | UAT + BDD (native integration) | UAT + BDD (standalone)}
-**Feature Files:** {memory_dir}/test-plans/{run-id}-features/ (omit line if Manual UAT)
+**Test Runner:** {test_runner}
+**Feature Files:** {memory_dir}/test-plans/{run-id}-features/ (omit line if Manual UAT or UAT + BDD (feature files only))
 **BDD Setup Needed:** {yes | no} (if yes: `{bdd_install_cmd}`) (omit line if Manual UAT)
-**BDD Scaffold Command:** `{bdd_scaffold_cmd}` (omit line if Manual UAT or specification-only)
-**BDD Test Command:** `{bdd_test_cmd}` (omit line if Manual UAT or specification-only)
+**BDD Scaffold Command:** `{bdd_scaffold_cmd}` (omit line if Manual UAT or UAT + BDD (feature files only))
+**BDD Test Command:** `{bdd_test_cmd}` (omit line if Manual UAT or UAT + BDD (feature files only))
 **BDD Framework:** {bdd_framework} (omit line if Manual UAT)
 **BDD Feature Dir:** {bdd_feature_dir} (omit line if Manual UAT)
-**BDD Step Dir:** {bdd_step_dir} (omit line if Manual UAT or specification-only)
+**BDD Step Dir:** {bdd_step_dir} (omit line if Manual UAT or UAT + BDD (feature files only))
 **Scenarios:** {total scenario count}
 **Personas:** {Primary Persona Name}, {Edge Case Persona Name}
 
@@ -647,7 +674,12 @@ documentation only (not executable), write:
 - `**BDD Setup Needed:** no (feature files are Gherkin specifications; tests implemented in {test_runner})`
 - `**BDD Framework:** none (specification only)`
 - Include `**BDD Feature Dir:**` (files still exist for documentation)
-- Omit: `**BDD Scaffold Command:**`, `**BDD Test Command:**`, `**BDD Step Dir:**`
+- Omit: `**Feature Files:**`, `**BDD Scaffold Command:**`, `**BDD Test Command:**`, `**BDD Step Dir:**`
+
+Note: `**Feature Files:**` is intentionally omitted for specification-only mode. Swarm Phase 3.5
+(BDD-Step-Writer) is triggered by the presence of `**Feature Files:**`; spec-only has no executable
+BDD infrastructure and must not trigger step generation. The `.feature` file location is still
+recorded in `**BDD Feature Dir:**` for documentation reference.
 
 The `**BDD Setup Needed:** yes` signal is what `/swarm` Phase 0 uses to decide whether to
 install the BDD framework on the feature branch.
@@ -671,7 +703,7 @@ Tasks covered: {M} of {total_user_facing_tasks} user-facing tasks
 
 {if BDD (native integration or standalone):}
 Feature files: {feature_dir} ({file_count} files)
-BDD setup needed: yes ({framework} — /swarm will handle installation)
+BDD setup needed: {yes | no} ({framework}{if yes: — /swarm will handle installation}{if no: — already installed})
 {end if}
 
 {if BDD (feature files only — specification-only):}
@@ -709,7 +741,7 @@ Phase 6: Annotate plan file (with provenance markers) → Completion report
    ~/.claude/test-plans/{run-id}-features/      — fallback (BDD only)
 
 ### Plan File Annotation Fields (exact labels — never rename)
-**Test Plan:** | **Mode:** | **Feature Files:** | **BDD Setup Needed:**
+**Test Plan:** | **Mode:** | **Test Runner:** | **Feature Files:** | **BDD Setup Needed:**
 **BDD Scaffold Command:** | **BDD Test Command:** | **BDD Framework:** | **BDD Feature Dir:** | **BDD Step Dir:**
 **Scenarios:** | **Personas:** | ### Scenario-Task Mapping
 

--- a/code-quality/skills/test-plan/SKILL.md
+++ b/code-quality/skills/test-plan/SKILL.md
@@ -174,8 +174,8 @@ requirements, or domain-specific workflows not obvious from the tech stack), inv
 `/deep-research` in Bridged mode before defining personas:
 
 ```
-Skill("deep-research", "Bridged: Research {domain} user journeys and acceptance criteria
-patterns to inform user personas for {goal}")
+Skill("deep-research", "Research {domain} user journeys and acceptance criteria
+patterns to inform user personas for {goal}. Mode: Bridged")
 ```
 
 Feed research findings into persona definitions.
@@ -316,7 +316,7 @@ existing test setup (e.g., suggesting Cucumber.js for a Vitest project).
 research query below.
 
 ```
-Skill("deep-research", "External: BDD and Gherkin integration options for {test_runner}
+Skill("deep-research", "BDD and Gherkin integration options for {test_runner}
 in {tech_stack} projects. Compare: (1) native BDD plugins that integrate directly with
 {test_runner} (e.g., vitest-cucumber-plugin for Vitest, jest-cucumber for Jest, pytest-bdd
 for pytest), (2) standalone BDD frameworks (Cucumber.js, godog, cucumber-rs) and their
@@ -324,7 +324,7 @@ compatibility with {test_runner}, (3) using Gherkin .feature files as specificat
 documentation (not executable). For each viable option: package name, registry page,
 last release date, open issues count, compatibility notes with {test_runner}, setup
 complexity. Exclude options unmaintained (no release in 12+ months) or incompatible
-with {test_runner}.")
+with {test_runner}. Mode: External")
 ```
 
 **Fallback:** If `/deep-research` is unavailable, errors, or returns no viable options,
@@ -377,7 +377,7 @@ For option B, these are all empty/none — Phase 6 handles this format.
 
 ### Exploratory Charter Decision
 
-Ask as a follow-up (or combine with the above if UAT-only):
+Ask as a follow-up (or combine with the above if Manual UAT):
 
 "Should I include exploratory test charters for any high-uncertainty areas?
 Exploratory charters are brief mission statements for manual testing sessions where
@@ -432,7 +432,7 @@ Write the complete test plan document using this exact format:
 **Source Plan:** {plan_file_path}
 **Branch:** {branch from plan header}
 **Date:** {YYYY-MM-DD}
-**Mode:** {Manual UAT | UAT + BDD}
+**Mode:** {mode}
 
 ---
 

--- a/code-quality/skills/test-plan/SKILL.md
+++ b/code-quality/skills/test-plan/SKILL.md
@@ -601,6 +601,9 @@ what all downstream skills parse — field labels must match exactly.
 
 ### Annotation Format
 
+**Read the full Phase 6 section (including the Specification-only mode overrides below
+the template) before writing.** For option B, field values differ from the generic template.
+
 Append to the end of `{plan_file}` using the Edit tool:
 
 ```markdown

--- a/code-quality/skills/test-plan/SKILL.md
+++ b/code-quality/skills/test-plan/SKILL.md
@@ -304,6 +304,12 @@ so `.feature` files are expected. Print:
 BDD infra detected ({framework} in {file}). Generating UAT document + .feature files.
 ```
 
+Record `mode` based on the detected framework's relationship to the test runner: if the
+detected BDD framework is a plugin for `test_runner` (e.g., `pytest-bdd` for pytest,
+`jest-cucumber` for Jest), set `mode` to `UAT + BDD (native integration)`. If it is a
+standalone framework (e.g., `godog`, `Cucumber.js`, `cucumber-rs`), set `mode` to
+`UAT + BDD (standalone)`.
+
 **If NO BDD infra detected:**
 
 Before presenting options, research BDD integration options that are compatible with the

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/tests/test_provenance_rule_integrity.py
+++ b/dev-guard/tests/test_provenance_rule_integrity.py
@@ -1,0 +1,80 @@
+"""Structural tests for PROVENANCE rule integrity.
+
+Verifies that:
+1. finding-classification.md contains the PROVENANCE override rule.
+2. test-plan/SKILL.md generates PROVENANCE markers (the only producer).
+3. All downstream consumer skills that reference finding-classification.md
+   do so via the shared reference file (not duplicating or overriding the rule).
+
+These are grep-based lint tests — no LLM calls, no subprocess execution.
+They guard against accidental deletion of the provenance rule and against
+consumers that silently bypass it by not loading the canonical reference.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+CODE_QUALITY = REPO_ROOT / "code-quality"
+FINDING_CLASSIFICATION = CODE_QUALITY / "references" / "finding-classification.md"
+TEST_PLAN_SKILL = CODE_QUALITY / "skills" / "test-plan" / "SKILL.md"
+
+# Downstream consumers that reference finding-classification.md and must
+# transitively inherit the PROVENANCE rule.
+DOWNSTREAM_CONSUMERS = [
+    CODE_QUALITY / "skills" / "quality-gate" / "SKILL.md",
+    CODE_QUALITY / "skills" / "swarm" / "SKILL.md",
+    CODE_QUALITY / "skills" / "pr-review" / "SKILL.md",
+    CODE_QUALITY / "skills" / "fix" / "SKILL.md",
+    CODE_QUALITY / "skills" / "unfuck" / "SKILL.md",
+    CODE_QUALITY / "skills" / "bug-investigation" / "SKILL.md",
+]
+
+
+class TestProvenanceRuleIntegrity:
+    """Structural tests that the PROVENANCE classification rule is correctly anchored."""
+
+    def test_finding_classification_contains_provenance_rule(self):
+        """finding-classification.md must contain the PROVENANCE override rule."""
+        content = FINDING_CLASSIFICATION.read_text()
+        assert "PROVENANCE" in content, (
+            f"{FINDING_CLASSIFICATION} does not contain 'PROVENANCE'. "
+            "The provenance override rule was deleted or renamed."
+        )
+        assert "needs-input" in content, (
+            f"{FINDING_CLASSIFICATION} does not contain 'needs-input'. "
+            "The classification taxonomy appears to have been removed."
+        )
+
+    def test_provenance_rule_appears_in_definition_and_example(self):
+        """The PROVENANCE keyword must appear in at least the rule and one example."""
+        content = FINDING_CLASSIFICATION.read_text()
+        lines = content.splitlines()
+        provenance_line_indices = [i for i, ln in enumerate(lines) if "PROVENANCE" in ln]
+        assert len(provenance_line_indices) >= 2, (
+            "Expected PROVENANCE to appear in at least the rule definition and one example. "
+            f"Found only {len(provenance_line_indices)} occurrence(s)."
+        )
+
+    def test_test_plan_skill_generates_provenance_markers(self):
+        """test-plan/SKILL.md must include PROVENANCE marker generation."""
+        content = TEST_PLAN_SKILL.read_text()
+        assert "PROVENANCE" in content, (
+            f"{TEST_PLAN_SKILL} does not contain 'PROVENANCE'. "
+            "The test-plan skill must generate <!-- PROVENANCE: ... --> markers "
+            "so that downstream consumers can apply the provenance override rule."
+        )
+
+    def test_downstream_consumers_reference_finding_classification(self):
+        """Each downstream consumer skill must reference finding-classification.md."""
+        missing = []
+        for skill_path in DOWNSTREAM_CONSUMERS:
+            assert skill_path.exists(), f"Expected skill file not found: {skill_path}"
+            content = skill_path.read_text()
+            if "finding-classification" not in content:
+                missing.append(str(skill_path.relative_to(REPO_ROOT)))
+
+        assert not missing, (
+            "The following downstream consumer skills do not reference "
+            "finding-classification.md and may bypass the PROVENANCE rule:\n"
+            + "\n".join(f"  - {p}" for p in missing)
+        )


### PR DESCRIPTION
## Summary
- Adds test runner detection in Phase 0 so BDD recommendations account for the project actual test framework (e.g., Vitest, Jest, pytest)
- Replaces Phase 3 static language-to-BDD-framework table with /deep-research driven recommendations compatible with the detected test runner
- Adds provenance override to finding-classification.md so all downstream skills (quality-gate, pr-review, swarm, etc.) MUST classify changes to user-confirmed annotations as needs-input, not needs-fix