### PR TITLE
feat(dev-guard): adds decision persistence hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.57.0",
+      "version": "1.58.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence",
       "category": "quality",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.17.0",
+      "version": "3.18.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
       "category": "quality",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,7 +68,7 @@
       "name": "dev-guard",
       "version": "1.57.0",
       "source": "./dev-guard",
-      "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification",
+      "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence",
       "category": "quality",
       "tags": ["hooks", "git", "validation", "policies"],
       "author": {

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/references/finding-classification.md
+++ b/code-quality/references/finding-classification.md
@@ -149,7 +149,7 @@ How the Fixer processes findings:
    - Present each needs-input item individually via AskUserQuestion (one question per finding,
      batch up to 4 per call). Each question includes full context:
      ```
-     question: "[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}"
+     question: "[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={reviewer},skill={skill_name}"
      header: "{id}"
      options: [
        {"label": "Fix", "description": "{suggested_action}"},

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -348,7 +348,7 @@ question with full context. Batch up to 4 per call:
 ```
 AskUserQuestion(questions=[
   {
-    "question": "[{file}:{issue_type}] {action}\n\nDiagnostic: {diagnostic_level}\nDecision needed: {input_needed}",
+    "question": "[{file}:{issue_type}] {action}\n\nDiagnostic: {diagnostic_level}\nDecision needed: {input_needed}\n▸dp:file={file},line=0,cat={issue_type},skill=file-audit",
     "header": "{file}",
     "options": [
       {"label": "Fix", "description": "Confirm this needs work — promoted to needs-fix"},

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -152,7 +152,7 @@ LEAD (you)
 2. **For analysis workloads:** present the synthesized summary and `needs-fix` findings to the
    user. For `needs-input` findings: present each individually via AskUserQuestion (one question
    per finding, batch up to 4 per call). Each question includes full context:
-   `"[{id}] [{category}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}"` with
+   `"[{id}] [{category}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={category},skill=map-reduce"` with
    options "Fix" (promoted to `needs-fix`) and "Defer" (`user-deferred`). `multiSelect: false`.
    Do NOT exit with unresolved `needs-input` findings. If AskUserQuestion is unavailable, treat
    all `needs-input` findings as `needs_context` in the final report (surface them, don't hide
@@ -163,7 +163,7 @@ LEAD (you)
      test failure.
    - For `needs-input` findings: present each individually via AskUserQuestion (one question
      per finding, batch up to 4 per call). Each question includes full context:
-     `"[{id}] [{category}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}"`
+     `"[{id}] [{category}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={category},skill=map-reduce"`
      with options "Fix" (apply change) and "Defer" (`user-deferred`). `multiSelect: false`.
      Selected items are applied, then tests re-run. Do NOT apply `needs-input` changes without
      user approval. If AskUserQuestion is unavailable, treat all `needs-input` findings as

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -322,7 +322,7 @@ per AskUserQuestion call (the tool's question limit):
 ```
 AskUserQuestion(questions=[
   {
-    "question": "[{id}] [{Reviewer}] {description}\n\nLocation: {location}\nDecision needed: {input_needed}",
+    "question": "[{id}] [{Reviewer}] {description}\n\nLocation: {location}\nDecision needed: {input_needed}\n▸dp:file={plan_file},line=0,cat={Reviewer},skill=plan-review",
     "header": "{id}",
     "options": [
       {"label": "Fix", "description": "Confirm this finding needs work — promoted to needs-fix"},

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -361,7 +361,7 @@ per AskUserQuestion call (the tool's question limit):
 ```
 AskUserQuestion(questions=[
   {
-    "question": "[{id}] [{Reviewer}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}",
+    "question": "[{id}] [{Reviewer}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={Reviewer},skill=pr-review",
     "header": "{id}",
     "options": [
       {"label": "Fix", "description": "Confirm this finding needs work — promoted to needs-fix"},

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -313,8 +313,10 @@ After all 4 reviewers complete, synthesize findings by classification
 2. Fix all `needs-fix` findings immediately. Do not carry them forward.
 3. For `needs-input` findings: present each individually via AskUserQuestion (one question
    per finding, batch up to 4 per call). Each question includes full context:
-   `"[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}"`
+   `"[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={reviewer},skill=quality-gate"`
    with options "Fix" and "Defer". `multiSelect: false`. User decides per-finding.
+   The `▸dp:` metadata suffix enables cross-session decision persistence via the
+   decision-persistence hook. Use the finding's file, line, and reviewer category.
    Fix approved items. Record deferred items with user's reason.
 4. Do NOT proceed to Layer 2 until all `needs-fix` items are fixed and all
    `needs-input` items are resolved via user decision.

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -315,8 +315,6 @@ After all 4 reviewers complete, synthesize findings by classification
    per finding, batch up to 4 per call). Each question includes full context:
    `"[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={reviewer},skill=quality-gate"`
    with options "Fix" and "Defer". `multiSelect: false`. User decides per-finding.
-   The `▸dp:` metadata suffix enables cross-session decision persistence via the
-   decision-persistence hook. Use the finding's file, line, and reviewer category.
    Fix approved items. Record deferred items with user's reason.
 4. Do NOT proceed to Layer 2 until all `needs-fix` items are fixed and all
    `needs-input` items are resolved via user decision.

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1639,7 +1639,7 @@ structural verification:
 1. Read `needs_input_items` from the FixSummary
 2. If non-empty, present each item individually via AskUserQuestion (one question per finding,
    batch up to 4 per call). Each question includes full context:
-   `"[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}"`
+   `"[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={reviewer},skill=swarm"`
    with options: "Fix" (`{suggested_action}`) and "Defer" ("Skip for now"). `multiSelect: false`.
 3. Fix selected: send back to Fixer for resolution (or fix inline if trivial), add to `findings_fixed`
 4. Defer selected: recorded in `user_deferred` with reason "User declined via triage"
@@ -1868,8 +1868,9 @@ The Docs Reviewer writes findings to `{run_dir}/reviews/docs-review.json`. If it
 3. Docs Reviewer re-reviews (max 1 iteration)
 
 If `needs-input` findings: present each individually via AskUserQuestion (one question per
-finding, batch up to 4 per call, `multiSelect: false`) with options "Fix" and "Defer" before
-proceeding.
+finding, batch up to 4 per call, `multiSelect: false`) with options "Fix" and "Defer". Each
+question includes `▸dp:file={file},line={line},cat=docs,skill=swarm` metadata suffix for
+decision persistence. Proceed after all resolved.
 If no `needs-fix` findings, proceed.
 
 ### Step 6.6: Shutdown Docs Agent

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
-  "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification",
+  "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence",
   "version": "1.57.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -7,7 +7,7 @@
 PreToolUse: checks stored decisions and auto-answers AskUserQuestion via updatedInput.
 PostToolUse: captures Fix/Defer decisions to {memory_dir}/review-decisions.json.
 
-Decisions are persisted as fingerprinted records (file + category + line window) so
+Decisions are persisted as fingerprinted records (file + category + line + skill) so
 that repeated reviews of the same finding auto-apply the prior Fix/Defer decision
 without re-prompting the user.
 """
@@ -118,7 +118,7 @@ def _save_decisions(path: Path, data: dict) -> None:
     except OSError as exc:
         tmp.unlink(missing_ok=True)
         print(
-            f"[decision-persistence] WARNING: failed to save decisions to {path}: {exc}",
+            f"[decision-persistence] WARNING: failed to save decisions to {path.name}: {exc}",
             file=sys.stderr,
         )
 
@@ -161,7 +161,7 @@ def _compute_code_hash(file_path: str, line: str = "0") -> str | None:
 
     try:
         window_lines: list[str] = []
-        with open(resolved) as f:
+        with open(canonical) as f:
             for i, file_line in enumerate(f):
                 if i >= end:
                     break
@@ -307,7 +307,7 @@ def _handle_pre_tool_use(data: dict) -> None:
 
         if fp in stored:
             prior = stored[fp]
-            decision = prior["decision"]
+            decision = prior.get("decision")
             if decision not in VALID_DECISIONS:
                 all_matched = False
                 break  # corrupted/unexpected stored value — re-ask
@@ -339,9 +339,9 @@ def _handle_pre_tool_use(data: dict) -> None:
     for q_text, decision in answers.items():
         meta = parsed.get(q_text)
         if meta is not None:
-            context_lines.append(
-                f"  {meta['file']}:{meta.get('line', '?')} [{meta['cat']}] → {decision}"
-            )
+            safe_line = re.sub(r"[^\w./_-]", "_", str(meta.get("line", "?")))
+            safe_cat = re.sub(r"[^\w./_-]", "_", meta["cat"])
+            context_lines.append(f"  {meta['file']}:{safe_line} [{safe_cat}] → {decision}")
 
     output = {
         "hookSpecificOutput": {
@@ -374,14 +374,16 @@ def _handle_post_tool_use(data: dict) -> None:
     # first would re-capture already-stored decisions with a fresh timestamp,
     # misleading future staleness detection.
     answers = {}
-    answers_from_tool_response = True
+    answers_from_tool_response = False
     if isinstance(tool_response, dict):
-        answers = tool_response.get("answers", {})
+        tool_response_answers = tool_response.get("answers", {})
+        if tool_response_answers:
+            answers = tool_response_answers
+            answers_from_tool_response = True
     if not answers:
         # Fallback: may contain auto-applied answers from PreToolUse updatedInput.
         # Flag so we can skip re-capture of unchanged decisions below.
         answers = tool_input.get("answers", {})
-        answers_from_tool_response = False
 
     if not questions or not answers:
         sys.exit(0)

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.13"
+# ///
+"""Decision Persistence Hook — remembers Fix/Defer decisions across sessions.
+
+PreToolUse: checks stored decisions and auto-answers AskUserQuestion via updatedInput.
+PostToolUse: captures Fix/Defer decisions to {memory_dir}/review-decisions.json.
+
+Spike implementation — validates the updatedInput + answers mechanism for
+auto-resolving previously-decided review findings.
+"""
+
+import hashlib
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+# ── Constants ──
+
+METADATA_PREFIX = "▸dp:"
+DECISIONS_FILENAME = "review-decisions.json"
+MEMORY_DIR_CANDIDATES = ("hack", ".local", "scratch", ".dev")
+
+
+# ── Memory directory detection ──
+
+
+def _find_memory_dir() -> Path | None:
+    """Find the project memory directory (hack/, .local/, scratch/, .dev/).
+
+    Walks from CWD up to git root looking for a memory dir candidate.
+    """
+    cwd = Path.cwd()
+    # Find git root
+    git_root = cwd
+    while git_root != git_root.parent:
+        if (git_root / ".git").exists():
+            break
+        git_root = git_root.parent
+    else:
+        git_root = cwd  # fallback to cwd if no git root
+
+    for candidate in MEMORY_DIR_CANDIDATES:
+        candidate_path = git_root / candidate
+        if candidate_path.is_dir():
+            return candidate_path
+    return None
+
+
+def _decisions_path() -> Path | None:
+    """Return the path to the decisions file, or None if no memory dir."""
+    mem_dir = _find_memory_dir()
+    if mem_dir is None:
+        return None
+    return mem_dir / DECISIONS_FILENAME
+
+
+# ── Decision storage ──
+
+
+def _load_decisions(path: Path) -> dict:
+    """Load decisions from the JSON file."""
+    if not path.exists():
+        return {"version": 1, "decisions": []}
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {"version": 1, "decisions": []}
+
+
+def _save_decisions(path: Path, data: dict) -> None:
+    """Save decisions to the JSON file."""
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _fingerprint(file: str, category: str, description_snippet: str) -> str:
+    """Create a stable fingerprint for a finding.
+
+    Uses file + category + first 60 chars of description (lowered, stripped).
+    """
+    normalized = f"{file}|{category}|{description_snippet[:60].lower().strip()}"
+    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+# ── Metadata parsing ──
+
+
+def _parse_metadata(question_text: str) -> dict | None:
+    """Extract structured metadata from a question's ▸dp: suffix.
+
+    Expected format: ▸dp:file=path,line=N,cat=Category,skill=skill-name
+    Returns dict with keys: file, line, cat, skill, or None if not found.
+    """
+    if METADATA_PREFIX not in question_text:
+        return None
+
+    _, _, meta_str = question_text.partition(METADATA_PREFIX)
+    meta_str = meta_str.strip()
+
+    result = {}
+    for pair in meta_str.split(","):
+        if "=" not in pair:
+            continue
+        key, _, value = pair.partition("=")
+        result[key.strip()] = value.strip()
+
+    if not result.get("file") or not result.get("cat"):
+        return None
+    return result
+
+
+def _extract_description_snippet(question_text: str) -> str:
+    """Extract the description portion of the question text.
+
+    Strips the leading [id] [category] prefix and the ▸dp: suffix,
+    then takes the first line as the description snippet.
+    """
+    # Remove metadata suffix
+    text = question_text.split(METADATA_PREFIX)[0].strip()
+    # Remove leading [bracketed] prefixes
+    first_line = text.split("\n")[0].strip()
+    # Strip [id] and [Category] prefixes
+    while first_line.startswith("["):
+        close = first_line.find("]")
+        if close == -1:
+            break
+        first_line = first_line[close + 1 :].strip()
+    return first_line
+
+
+def _is_fix_defer_question(question: dict) -> bool:
+    """Check if a question has Fix/Defer options (our target pattern)."""
+    options = question.get("options", [])
+    if len(options) < 2:
+        return False
+    labels = {opt.get("label", "").lower() for opt in options}
+    return "fix" in labels and "defer" in labels
+
+
+# ── PreToolUse handler ──
+
+
+def _handle_pre_tool_use(data: dict) -> None:
+    """Check stored decisions and auto-answer if all questions have prior decisions."""
+    tool_input = data.get("tool_input", {})
+    questions = tool_input.get("questions", [])
+
+    if not questions:
+        sys.exit(0)  # passthrough
+
+    # Only process Fix/Defer questions
+    fix_defer_questions = [q for q in questions if _is_fix_defer_question(q)]
+    if not fix_defer_questions:
+        sys.exit(0)  # passthrough — not our kind of question
+
+    # Check if ALL Fix/Defer questions have metadata
+    all_have_metadata = all(
+        _parse_metadata(q.get("question", "")) is not None for q in fix_defer_questions
+    )
+    if not all_have_metadata:
+        # Some questions lack metadata — can't reliably match, passthrough
+        sys.exit(0)
+
+    # Load stored decisions
+    dec_path = _decisions_path()
+    if dec_path is None:
+        sys.exit(0)  # no memory dir — passthrough
+
+    decisions_data = _load_decisions(dec_path)
+    stored = {
+        d["fingerprint"]: d for d in decisions_data.get("decisions", []) if "fingerprint" in d
+    }
+
+    if not stored:
+        sys.exit(0)  # no prior decisions — passthrough
+
+    # Try to match each Fix/Defer question
+    answers = {}
+    all_matched = True
+
+    for q in fix_defer_questions:
+        q_text = q.get("question", "")
+        meta = _parse_metadata(q_text)
+        if meta is None:
+            all_matched = False
+            break
+        snippet = _extract_description_snippet(q_text)
+        fp = _fingerprint(meta["file"], meta["cat"], snippet)
+
+        if fp in stored:
+            prior = stored[fp]
+            answers[q_text] = prior["decision"]
+        else:
+            all_matched = False
+            break
+
+    if not all_matched:
+        # Can't auto-answer partial batches reliably — passthrough for all
+        # TODO(v2): test whether partial answers work with AskUserQuestion
+        sys.exit(0)
+
+    # All questions matched — build context message
+    context_lines = [
+        f"Decision persistence: auto-applying {len(answers)} prior decision(s).",
+    ]
+    for q_text, decision in answers.items():
+        meta = _parse_metadata(q_text)
+        if meta is not None:
+            context_lines.append(
+                f"  {meta['file']}:{meta.get('line', '?')} [{meta['cat']}] → {decision}"
+            )
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "updatedInput": {
+                "questions": questions,  # echo back original questions
+                "answers": answers,
+            },
+            "additionalContext": "\n".join(context_lines),
+        }
+    }
+
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+# ── PostToolUse handler ──
+
+
+def _handle_post_tool_use(data: dict) -> None:
+    """Capture Fix/Defer decisions from AskUserQuestion responses."""
+    tool_input = data.get("tool_input", {})
+    tool_response = data.get("tool_response", {})
+
+    questions = tool_input.get("questions", [])
+    # Answers come from tool_input.answers (populated by user interaction)
+    # or from tool_response depending on Claude Code version
+    answers = tool_input.get("answers", {})
+    if not answers and isinstance(tool_response, dict):
+        answers = tool_response.get("answers", {})
+
+    if not questions or not answers:
+        sys.exit(0)
+
+    # Find the decisions file
+    dec_path = _decisions_path()
+    if dec_path is None:
+        sys.exit(0)  # no memory dir — can't persist
+
+    decisions_data = _load_decisions(dec_path)
+    stored = decisions_data.get("decisions", [])
+    existing_fps = {d["fingerprint"] for d in stored if "fingerprint" in d}
+
+    new_decisions = []
+    for q in questions:
+        if not _is_fix_defer_question(q):
+            continue
+
+        q_text = q.get("question", "")
+        meta = _parse_metadata(q_text)
+        if meta is None:
+            continue
+
+        answer = answers.get(q_text)
+        if answer is None:
+            continue
+
+        snippet = _extract_description_snippet(q_text)
+        fp = _fingerprint(meta["file"], meta["cat"], snippet)
+
+        decision_record = {
+            "fingerprint": fp,
+            "file": meta["file"],
+            "line": meta.get("line"),
+            "category": meta["cat"],
+            "skill": meta.get("skill", "unknown"),
+            "decision": answer,
+            "description_snippet": snippet[:80],
+            "decided_at": datetime.now(UTC).isoformat(),
+        }
+
+        if fp in existing_fps:
+            # Update existing decision
+            stored = [d if d.get("fingerprint") != fp else decision_record for d in stored]
+        else:
+            new_decisions.append(decision_record)
+            existing_fps.add(fp)
+
+    if new_decisions:
+        stored.extend(new_decisions)
+
+    decisions_data["decisions"] = stored
+    _save_decisions(dec_path, decisions_data)
+    sys.exit(0)
+
+
+# ── Entrypoint ──
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        if not raw.strip():
+            sys.exit(0)
+        data = json.loads(raw)
+    except (json.JSONDecodeError, OSError):
+        sys.exit(0)  # passthrough on parse failure
+
+    tool_name = data.get("tool_name", "")
+    if tool_name != "AskUserQuestion":
+        sys.exit(0)  # not our tool — passthrough
+
+    hook_event = data.get("hook_event_name", "")
+
+    if hook_event == "PreToolUse":
+        _handle_pre_tool_use(data)
+    elif hook_event == "PostToolUse":
+        _handle_post_tool_use(data)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -183,7 +183,7 @@ def _sanitize_path_field(value: str) -> str:
     Rejects path traversal sequences and absolute paths. Strips
     non-path characters and enforces a length limit.
     """
-    if ".." in value or value.startswith("/"):
+    if any(part == ".." for part in Path(value).parts) or value.startswith("/"):
         return "<invalid>"
     clean = re.sub(r"[^\w./_-]", "_", value)
     return clean[:_MAX_FIELD_LEN]

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -126,15 +126,15 @@ def _save_decisions(path: Path, data: dict) -> None:
 def _fingerprint(file: str, category: str, line: str = "0", skill: str = "unknown") -> str:
     """Create a stable fingerprint for a finding.
 
-    Uses file + category + line_window + skill. All fields come from
-    deterministic ▸dp: metadata, not LLM prose. The line_window groups
-    nearby lines so minor line shifts don't invalidate a decision
-    (e.g., line 42 and 47 both map to window 40). The skill field
-    prevents cross-skill collisions (e.g., pr-review and quality-gate
-    both reporting Security findings on the same file/line window).
+    Uses file + category + line_number + skill. All fields come from
+    deterministic ▸dp: metadata, not LLM prose. Uses exact line numbers
+    (not windowed) to prevent collisions between distinct findings at
+    nearby lines. Code-hash staleness handles minor line shifts caused
+    by edits above the finding — the hash changes, the decision is
+    invalidated, and the user is re-prompted.
     """
-    line_window = (int(line) // 10) * 10 if line.isdigit() else 0
-    normalized = f"{file}|{category}|{line_window}|{skill}"
+    line_num = int(line) if line.isdigit() else 0
+    normalized = f"{file}|{category}|{line_num}|{skill}"
     return hashlib.sha256(normalized.encode()).hexdigest()[:32]
 
 

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -7,8 +7,9 @@
 PreToolUse: checks stored decisions and auto-answers AskUserQuestion via updatedInput.
 PostToolUse: captures Fix/Defer decisions to {memory_dir}/review-decisions.json.
 
-Spike implementation — validates the updatedInput + answers mechanism for
-auto-resolving previously-decided review findings.
+Decisions are persisted as fingerprinted records (file + category + line window) so
+that repeated reviews of the same finding auto-apply the prior Fix/Defer decision
+without re-prompting the user.
 """
 
 import hashlib
@@ -16,13 +17,14 @@ import json
 import os
 import re
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 # ── Constants ──
 
 VALID_DECISIONS: frozenset[str] = frozenset({"Fix", "Defer"})
 _MAX_FIELD_LEN = 512
+_MAX_DECISION_AGE_DAYS = 30
 
 METADATA_PREFIX = "▸dp:"
 DECISIONS_FILENAME = "review-decisions.json"
@@ -35,7 +37,7 @@ MEMORY_DIR_CANDIDATES = ("hack", ".local", "scratch", ".dev")
 def _find_memory_dir() -> Path | None:
     """Find the project memory directory (hack/, .local/, scratch/, .dev/).
 
-    Walks from CWD up to git root looking for a memory dir candidate.
+    Finds git root by walking up from CWD, then checks for candidates at root level.
     """
     cwd = Path.cwd()
     # Find git root
@@ -45,11 +47,16 @@ def _find_memory_dir() -> Path | None:
             break
         git_root = git_root.parent
     else:
-        git_root = cwd  # fallback to cwd if no git root
+        git_root = cwd  # reset to cwd after exhausting walk (no .git found)
+
+    core_files = ("PROJECT.md", "TODO.md", "SESSIONS.md", "NEXT.md", "LESSONS.md")
 
     for candidate in MEMORY_DIR_CANDIDATES:
         candidate_path = git_root / candidate
         if candidate_path.is_dir():
+            core_count = sum(1 for f in core_files if (candidate_path / f).is_file())
+            if core_count < 2:
+                continue  # not a validated memory directory
             return candidate_path
     return None
 
@@ -81,25 +88,26 @@ def _save_decisions(path: Path, data: dict) -> None:
     try:
         tmp.write_text(json.dumps(data, indent=2) + "\n")
         os.replace(tmp, path)
-    except OSError:
+    except OSError as exc:
         tmp.unlink(missing_ok=True)
+        print(
+            f"[decision-persistence] WARNING: failed to save decisions to {path}: {exc}",
+            file=sys.stderr,
+        )
 
 
-def _fingerprint(file: str, category: str, line: str = "0") -> str:
+def _fingerprint(file: str, category: str, line: str = "0", skill: str = "unknown") -> str:
     """Create a stable fingerprint for a finding.
 
-    Uses file + category + line_window (rounded to nearest 10 lines).
-    All three fields come from deterministic ▸dp: metadata, not LLM prose.
-    The line_window groups nearby lines so minor line shifts don't
-    invalidate a decision (e.g., line 42 and 47 both map to window 40).
-
-    Note: `category` comes from ▸dp:cat= which carries different semantics
-    per skill — reviewer name (pr-review, plan-review, quality-gate) vs
-    issue type (map-reduce, file-audit). Decisions are scoped per-skill
-    so cross-skill collisions don't occur in practice.
+    Uses file + category + line_window + skill. All fields come from
+    deterministic ▸dp: metadata, not LLM prose. The line_window groups
+    nearby lines so minor line shifts don't invalidate a decision
+    (e.g., line 42 and 47 both map to window 40). The skill field
+    prevents cross-skill collisions (e.g., pr-review and quality-gate
+    both reporting Security findings on the same file/line window).
     """
     line_window = (int(line) // 10) * 10 if line.isdigit() else 0
-    normalized = f"{file}|{category}|{line_window}"
+    normalized = f"{file}|{category}|{line_window}|{skill}"
     return hashlib.sha256(normalized.encode()).hexdigest()[:16]
 
 
@@ -131,7 +139,7 @@ def _parse_metadata(question_text: str) -> dict | None:
     if METADATA_PREFIX not in question_text:
         return None
 
-    _, _, meta_str = question_text.partition(METADATA_PREFIX)
+    _, _, meta_str = question_text.rpartition(METADATA_PREFIX)
     meta_str = meta_str.strip()
 
     result = {}
@@ -158,8 +166,8 @@ def _extract_description_snippet(question_text: str) -> str:
     Strips the leading [id] [category] prefix and the ▸dp: suffix,
     then takes the first line as the description snippet.
     """
-    # Remove metadata suffix
-    text = question_text.split(METADATA_PREFIX)[0].strip()
+    # Remove metadata suffix (last occurrence, consistent with rpartition in _parse_metadata)
+    text = question_text.rsplit(METADATA_PREFIX, 1)[0].strip()
     # Remove leading [bracketed] prefixes
     first_line = text.split("\n")[0].strip()
     # Strip [id] and [Category] prefixes
@@ -191,12 +199,14 @@ def _handle_pre_tool_use(data: dict) -> None:
     if not questions:
         sys.exit(0)  # passthrough
 
-    # Only process Fix/Defer questions
+    # Only process Fix/Defer questions — bail if batch is mixed-type
     fix_defer_questions = [q for q in questions if _is_fix_defer_question(q)]
     if not fix_defer_questions:
         sys.exit(0)  # passthrough — not our kind of question
+    if len(fix_defer_questions) != len(questions):
+        sys.exit(0)  # mixed-type batch: answers dict would only cover Fix/Defer subset
 
-    # Parse metadata for all Fix/Defer questions (single pass, cached)
+    # Parse metadata for all Fix/Defer questions (deduplicated per question text)
     parsed: dict[str, dict] = {}
     for q in fix_defer_questions:
         q_text = q.get("question", "")
@@ -211,12 +221,15 @@ def _handle_pre_tool_use(data: dict) -> None:
         sys.exit(0)  # no memory dir — passthrough
 
     decisions_data = _load_decisions(dec_path)
+    cutoff = (datetime.now(UTC) - timedelta(days=_MAX_DECISION_AGE_DAYS)).isoformat()
     stored = {
-        d["fingerprint"]: d for d in decisions_data.get("decisions", []) if "fingerprint" in d
+        d["fingerprint"]: d
+        for d in decisions_data.get("decisions", [])
+        if "fingerprint" in d and d.get("decided_at", "") >= cutoff
     }
 
     if not stored:
-        sys.exit(0)  # no prior decisions — passthrough
+        sys.exit(0)  # no prior decisions (or all expired) — passthrough
 
     # Try to match each Fix/Defer question
     answers = {}
@@ -225,7 +238,8 @@ def _handle_pre_tool_use(data: dict) -> None:
     for q in fix_defer_questions:
         q_text = q.get("question", "")
         meta = parsed[q_text]
-        fp = _fingerprint(meta["file"], meta["cat"], meta.get("line", "0"))
+        skill = meta.get("skill", "unknown")
+        fp = _fingerprint(meta["file"], meta["cat"], meta.get("line", "0"), skill)
 
         if fp in stored:
             prior = stored[fp]
@@ -279,20 +293,32 @@ def _handle_post_tool_use(data: dict) -> None:
     tool_response = data.get("tool_response", {})
 
     questions = tool_input.get("questions", [])
-    # Answers come from tool_input.answers (populated by user interaction)
-    # or from tool_response depending on Claude Code version
-    answers = tool_input.get("answers", {})
-    if not answers and isinstance(tool_response, dict):
+    # Answers come from tool_response (user's actual answers).
+    # tool_input.answers is populated by PreToolUse updatedInput — those are
+    # auto-applied decisions, not new user decisions. Reading from tool_input
+    # first would re-capture already-stored decisions with a fresh timestamp,
+    # misleading future staleness detection.
+    answers = {}
+    answers_from_user = True
+    if isinstance(tool_response, dict):
         answers = tool_response.get("answers", {})
+    if not answers:
+        # Fallback: may contain auto-applied answers from PreToolUse updatedInput.
+        # Flag so we can skip re-capture of unchanged decisions below.
+        answers = tool_input.get("answers", {})
+        answers_from_user = False
 
     if not questions or not answers:
         sys.exit(0)
 
-    # Pre-scan: any capturable Fix/Defer questions with metadata?
-    capturable = any(
-        _is_fix_defer_question(q) and _parse_metadata(q.get("question", "")) is not None
-        for q in questions
-    )
+    # Pre-scan: parse metadata for all Fix/Defer questions (deduplicated)
+    parsed: dict[str, dict | None] = {}
+    for q in questions:
+        if _is_fix_defer_question(q):
+            q_text = q.get("question", "")
+            parsed[q_text] = _parse_metadata(q_text)
+
+    capturable = any(meta is not None for meta in parsed.values())
     if not capturable:
         sys.exit(0)  # nothing to capture — skip disk I/O
 
@@ -302,17 +328,18 @@ def _handle_post_tool_use(data: dict) -> None:
         sys.exit(0)  # no memory dir — can't persist
 
     decisions_data = _load_decisions(dec_path)
-    stored = decisions_data.get("decisions", [])
-    existing_fps = {d["fingerprint"] for d in stored if "fingerprint" in d}
+    # Use a dict keyed by fingerprint for O(1) upserts
+    stored_by_fp: dict[str, dict] = {
+        d["fingerprint"]: d for d in decisions_data.get("decisions", []) if "fingerprint" in d
+    }
 
-    new_decisions = []
     mutated = False
     for q in questions:
         if not _is_fix_defer_question(q):
             continue
 
         q_text = q.get("question", "")
-        meta = _parse_metadata(q_text)
+        meta = parsed.get(q_text)
         if meta is None:
             continue
 
@@ -320,34 +347,38 @@ def _handle_post_tool_use(data: dict) -> None:
         if answer is None or answer not in VALID_DECISIONS:
             continue  # discard unexpected answers
 
-        fp = _fingerprint(meta["file"], meta["cat"], meta.get("line", "0"))
+        skill = meta.get("skill", "unknown")
+        fp = _fingerprint(meta["file"], meta["cat"], meta.get("line", "0"), skill)
+
+        # Skip re-capture of auto-applied decisions (prevents timestamp refresh)
+        already_stored = fp in stored_by_fp and stored_by_fp[fp].get("decision") == answer
+        if not answers_from_user and already_stored:
+            continue
+
         snippet = _extract_description_snippet(q_text)
 
         decision_record = {
             "fingerprint": fp,
             "file": meta["file"],
-            "line": meta.get("line"),
-            "category": meta["cat"][:_MAX_FIELD_LEN],
-            "skill": meta.get("skill", "unknown")[:_MAX_FIELD_LEN],
+            "line": meta.get("line", "0")[:_MAX_FIELD_LEN] if meta.get("line") else "0",
+            "category": re.sub(r"[^\w./_-]", "_", meta["cat"])[:_MAX_FIELD_LEN],
+            "skill": re.sub(r"[^\w./_-]", "_", meta.get("skill", "unknown"))[:_MAX_FIELD_LEN],
             "decision": answer,
             "description_snippet": snippet[:80],
             "decided_at": datetime.now(UTC).isoformat(),
         }
 
-        if fp in existing_fps:
-            stored = [d if d.get("fingerprint") != fp else decision_record for d in stored]
-        else:
-            new_decisions.append(decision_record)
-            existing_fps.add(fp)
+        stored_by_fp[fp] = decision_record  # O(1) upsert
         mutated = True
 
     if not mutated:
         sys.exit(0)  # no mutations — skip unnecessary write
 
-    if new_decisions:
-        stored.extend(new_decisions)
+    # Prune expired decisions on write
+    cutoff = (datetime.now(UTC) - timedelta(days=_MAX_DECISION_AGE_DAYS)).isoformat()
+    stored_by_fp = {fp: d for fp, d in stored_by_fp.items() if d.get("decided_at", "") >= cutoff}
 
-    decisions_data["decisions"] = stored
+    decisions_data["decisions"] = list(stored_by_fp.values())
     _save_decisions(dec_path, decisions_data)
     sys.exit(0)
 

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -13,11 +13,16 @@ auto-resolving previously-decided review findings.
 
 import hashlib
 import json
+import os
+import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
 # ── Constants ──
+
+VALID_DECISIONS: frozenset[str] = frozenset({"Fix", "Defer"})
+_MAX_FIELD_LEN = 512
 
 METADATA_PREFIX = "▸dp:"
 DECISIONS_FILENAME = "review-decisions.json"
@@ -71,8 +76,13 @@ def _load_decisions(path: Path) -> dict:
 
 
 def _save_decisions(path: Path, data: dict) -> None:
-    """Save decisions to the JSON file."""
-    path.write_text(json.dumps(data, indent=2) + "\n")
+    """Save decisions to the JSON file (atomic write via tmp + rename)."""
+    tmp = path.with_suffix(f".{os.getpid()}.tmp")
+    try:
+        tmp.write_text(json.dumps(data, indent=2) + "\n")
+        os.replace(tmp, path)
+    except OSError:
+        tmp.unlink(missing_ok=True)
 
 
 def _fingerprint(file: str, category: str, line: str = "0") -> str:
@@ -82,6 +92,11 @@ def _fingerprint(file: str, category: str, line: str = "0") -> str:
     All three fields come from deterministic ▸dp: metadata, not LLM prose.
     The line_window groups nearby lines so minor line shifts don't
     invalidate a decision (e.g., line 42 and 47 both map to window 40).
+
+    Note: `category` comes from ▸dp:cat= which carries different semantics
+    per skill — reviewer name (pr-review, plan-review, quality-gate) vs
+    issue type (map-reduce, file-audit). Decisions are scoped per-skill
+    so cross-skill collisions don't occur in practice.
     """
     line_window = (int(line) // 10) * 10 if line.isdigit() else 0
     normalized = f"{file}|{category}|{line_window}"
@@ -91,11 +106,27 @@ def _fingerprint(file: str, category: str, line: str = "0") -> str:
 # ── Metadata parsing ──
 
 
+def _sanitize_path_field(value: str) -> str:
+    """Normalize and bound a file path field from metadata.
+
+    Rejects path traversal sequences and absolute paths. Strips
+    non-path characters and enforces a length limit.
+    """
+    if ".." in value or value.startswith("/"):
+        return "<invalid>"
+    clean = re.sub(r"[^\w./_-]", "_", value)
+    return clean[:_MAX_FIELD_LEN]
+
+
 def _parse_metadata(question_text: str) -> dict | None:
     """Extract structured metadata from a question's ▸dp: suffix.
 
     Expected format: ▸dp:file=path,line=N,cat=Category,skill=skill-name
     Returns dict with keys: file, line, cat, skill, or None if not found.
+
+    NOTE: file paths containing commas will cause parse failure because
+    the metadata format uses comma-delimited key=value pairs. Producer
+    skills must avoid commas in file paths.
     """
     if METADATA_PREFIX not in question_text:
         return None
@@ -112,6 +143,12 @@ def _parse_metadata(question_text: str) -> dict | None:
 
     if not result.get("file") or not result.get("cat"):
         return None
+
+    # Sanitize path-like fields
+    result["file"] = _sanitize_path_field(result["file"])
+    if result["file"] == "<invalid>":
+        return None
+
     return result
 
 
@@ -194,7 +231,11 @@ def _handle_pre_tool_use(data: dict) -> None:
 
         if fp in stored:
             prior = stored[fp]
-            answers[q_text] = prior["decision"]
+            decision = prior["decision"]
+            if decision not in VALID_DECISIONS:
+                all_matched = False
+                break  # corrupted/unexpected stored value — re-ask
+            answers[q_text] = decision
         else:
             all_matched = False
             break
@@ -259,6 +300,7 @@ def _handle_post_tool_use(data: dict) -> None:
     existing_fps = {d["fingerprint"] for d in stored if "fingerprint" in d}
 
     new_decisions = []
+    mutated = False
     for q in questions:
         if not _is_fix_defer_question(q):
             continue
@@ -269,8 +311,8 @@ def _handle_post_tool_use(data: dict) -> None:
             continue
 
         answer = answers.get(q_text)
-        if answer is None:
-            continue
+        if answer is None or answer not in VALID_DECISIONS:
+            continue  # discard unexpected answers
 
         fp = _fingerprint(meta["file"], meta["cat"], meta.get("line", "0"))
         snippet = _extract_description_snippet(q_text)
@@ -279,19 +321,22 @@ def _handle_post_tool_use(data: dict) -> None:
             "fingerprint": fp,
             "file": meta["file"],
             "line": meta.get("line"),
-            "category": meta["cat"],
-            "skill": meta.get("skill", "unknown"),
+            "category": meta["cat"][:_MAX_FIELD_LEN],
+            "skill": meta.get("skill", "unknown")[:_MAX_FIELD_LEN],
             "decision": answer,
             "description_snippet": snippet[:80],
             "decided_at": datetime.now(UTC).isoformat(),
         }
 
         if fp in existing_fps:
-            # Update existing decision
             stored = [d if d.get("fingerprint") != fp else decision_record for d in stored]
         else:
             new_decisions.append(decision_record)
             existing_fps.add(fp)
+        mutated = True
+
+    if not mutated:
+        sys.exit(0)  # no mutations — skip unnecessary write
 
     if new_decisions:
         stored.extend(new_decisions)

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -34,26 +34,43 @@ _CODE_HASH_WINDOW = 5  # ±N lines around finding location for staleness detecti
 
 # ── Git root detection ──
 
+_cached_git_root: Path | None = None
+
 
 def _find_git_root() -> Path:
-    """Find the git root by walking up from CWD. Falls back to CWD if no .git found."""
+    """Find the git root by walking up from CWD. Falls back to CWD if no .git found.
+
+    Cached per-process — CWD cannot change within a hook subprocess invocation.
+    """
+    global _cached_git_root  # noqa: PLW0603
+    if _cached_git_root is not None:
+        return _cached_git_root
     cwd = Path.cwd()
     git_root = cwd
     while git_root != git_root.parent:
         if (git_root / ".git").exists():
+            _cached_git_root = git_root
             return git_root
         git_root = git_root.parent
+    _cached_git_root = cwd
     return cwd  # no .git found — fall back to CWD
 
 
 # ── Memory directory detection ──
+
+_memory_dir_resolved = False
+_cached_memory_dir: Path | None = None
 
 
 def _find_memory_dir() -> Path | None:
     """Find the project memory directory (hack/, .local/, scratch/, .dev/).
 
     Finds git root by walking up from CWD, then checks for candidates at root level.
+    Cached per-process alongside _find_git_root.
     """
+    global _memory_dir_resolved, _cached_memory_dir  # noqa: PLW0603
+    if _memory_dir_resolved:
+        return _cached_memory_dir
     git_root = _find_git_root()
 
     core_files = ("PROJECT.md", "TODO.md", "SESSIONS.md", "NEXT.md", "LESSONS.md")
@@ -64,7 +81,10 @@ def _find_memory_dir() -> Path | None:
             core_count = sum(1 for f in core_files if (candidate_path / f).is_file())
             if core_count < 2:
                 continue  # not a validated memory directory
+            _cached_memory_dir = candidate_path
+            _memory_dir_resolved = True
             return candidate_path
+    _memory_dir_resolved = True
     return None
 
 
@@ -115,32 +135,43 @@ def _fingerprint(file: str, category: str, line: str = "0", skill: str = "unknow
     """
     line_window = (int(line) // 10) * 10 if line.isdigit() else 0
     normalized = f"{file}|{category}|{line_window}|{skill}"
-    return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+    return hashlib.sha256(normalized.encode()).hexdigest()[:32]
 
 
 def _compute_code_hash(file_path: str, line: str = "0") -> str | None:
     """Hash ±N lines around a finding location for staleness detection.
 
-    Returns a 16-char hex digest, or None if the file can't be read.
-    When the code around a finding changes, the hash changes, invalidating
-    the stored decision so the user is re-prompted.
+    Returns a 32-char hex digest, or None if the file can't be read.
+    Only reads lines in the target window (not the full file).
+    Rejects paths that resolve outside the git root (symlink boundary check).
     """
     git_root = _find_git_root()
     resolved = git_root / file_path
     try:
-        lines = resolved.read_text().splitlines()
-    except (OSError, UnicodeDecodeError):
-        return None
-    if not lines:
+        canonical = resolved.resolve()
+        if not canonical.is_relative_to(git_root.resolve()):
+            return None
+    except (OSError, ValueError):
         return None
 
     target = int(line) if line.isdigit() else 0
-    # 0-indexed target line
     center = max(0, target - 1)  # line numbers are 1-based
     start = max(0, center - _CODE_HASH_WINDOW)
-    end = min(len(lines), center + _CODE_HASH_WINDOW + 1)
-    window = "\n".join(lines[start:end])
-    return hashlib.sha256(window.encode()).hexdigest()[:16]
+    end = center + _CODE_HASH_WINDOW + 1
+
+    try:
+        window_lines: list[str] = []
+        with open(resolved) as f:
+            for i, file_line in enumerate(f):
+                if i >= end:
+                    break
+                if i >= start:
+                    window_lines.append(file_line.rstrip("\n"))
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not window_lines:
+        return None
+    return hashlib.sha256("\n".join(window_lines).encode()).hexdigest()[:32]
 
 
 # ── Metadata parsing ──
@@ -266,6 +297,7 @@ def _handle_pre_tool_use(data: dict) -> None:
     # Try to match each Fix/Defer question
     answers = {}
     all_matched = True
+    code_hash_cache: dict[tuple[str, str], str | None] = {}
 
     for q in fix_defer_questions:
         q_text = q.get("question", "")
@@ -282,7 +314,10 @@ def _handle_pre_tool_use(data: dict) -> None:
             # Staleness check: verify code hasn't changed since decision was made
             stored_hash = prior.get("code_hash")
             if stored_hash is not None:
-                current_hash = _compute_code_hash(meta["file"], meta.get("line", "0"))
+                cache_key = (meta["file"], meta.get("line", "0"))
+                if cache_key not in code_hash_cache:
+                    code_hash_cache[cache_key] = _compute_code_hash(*cache_key)
+                current_hash = code_hash_cache[cache_key]
                 if current_hash != stored_hash:
                     all_matched = False
                     break  # code changed — decision is stale, re-ask
@@ -339,14 +374,14 @@ def _handle_post_tool_use(data: dict) -> None:
     # first would re-capture already-stored decisions with a fresh timestamp,
     # misleading future staleness detection.
     answers = {}
-    answers_from_user = True
+    answers_from_tool_response = True
     if isinstance(tool_response, dict):
         answers = tool_response.get("answers", {})
     if not answers:
         # Fallback: may contain auto-applied answers from PreToolUse updatedInput.
         # Flag so we can skip re-capture of unchanged decisions below.
         answers = tool_input.get("answers", {})
-        answers_from_user = False
+        answers_from_tool_response = False
 
     if not questions or not answers:
         sys.exit(0)
@@ -374,6 +409,7 @@ def _handle_post_tool_use(data: dict) -> None:
     }
 
     mutated = False
+    code_hash_cache: dict[tuple[str, str], str | None] = {}
     for q in questions:
         if not _is_fix_defer_question(q):
             continue
@@ -392,12 +428,15 @@ def _handle_post_tool_use(data: dict) -> None:
 
         # Skip re-capture of auto-applied decisions (prevents timestamp refresh)
         already_stored = fp in stored_by_fp and stored_by_fp[fp].get("decision") == answer
-        if not answers_from_user and already_stored:
+        if not answers_from_tool_response and already_stored:
             continue
 
         snippet = _extract_description_snippet(q_text)
         line_val = re.sub(r"[^\d]", "", meta.get("line", "0"))[:_MAX_FIELD_LEN] or "0"
-        code_hash = _compute_code_hash(meta["file"], meta.get("line", "0"))
+        cache_key = (meta["file"], meta.get("line", "0"))
+        if cache_key not in code_hash_cache:
+            code_hash_cache[cache_key] = _compute_code_hash(*cache_key)
+        code_hash = code_hash_cache[cache_key]
 
         decision_record = {
             "fingerprint": fp,

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -196,13 +196,14 @@ def _handle_pre_tool_use(data: dict) -> None:
     if not fix_defer_questions:
         sys.exit(0)  # passthrough — not our kind of question
 
-    # Check if ALL Fix/Defer questions have metadata
-    all_have_metadata = all(
-        _parse_metadata(q.get("question", "")) is not None for q in fix_defer_questions
-    )
-    if not all_have_metadata:
-        # Some questions lack metadata — can't reliably match, passthrough
-        sys.exit(0)
+    # Parse metadata for all Fix/Defer questions (single pass, cached)
+    parsed: dict[str, dict] = {}
+    for q in fix_defer_questions:
+        q_text = q.get("question", "")
+        meta = _parse_metadata(q_text)
+        if meta is None:
+            sys.exit(0)  # some questions lack metadata — passthrough
+        parsed[q_text] = meta
 
     # Load stored decisions
     dec_path = _decisions_path()
@@ -223,10 +224,7 @@ def _handle_pre_tool_use(data: dict) -> None:
 
     for q in fix_defer_questions:
         q_text = q.get("question", "")
-        meta = _parse_metadata(q_text)
-        if meta is None:
-            all_matched = False
-            break
+        meta = parsed[q_text]
         fp = _fingerprint(meta["file"], meta["cat"], meta.get("line", "0"))
 
         if fp in stored:
@@ -250,7 +248,7 @@ def _handle_pre_tool_use(data: dict) -> None:
         f"Decision persistence: auto-applying {len(answers)} prior decision(s).",
     ]
     for q_text, decision in answers.items():
-        meta = _parse_metadata(q_text)
+        meta = parsed.get(q_text)
         if meta is not None:
             context_lines.append(
                 f"  {meta['file']}:{meta.get('line', '?')} [{meta['cat']}] → {decision}"
@@ -289,6 +287,14 @@ def _handle_post_tool_use(data: dict) -> None:
 
     if not questions or not answers:
         sys.exit(0)
+
+    # Pre-scan: any capturable Fix/Defer questions with metadata?
+    capturable = any(
+        _is_fix_defer_question(q) and _parse_metadata(q.get("question", "")) is not None
+        for q in questions
+    )
+    if not capturable:
+        sys.exit(0)  # nothing to capture — skip disk I/O
 
     # Find the decisions file
     dec_path = _decisions_path()

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -75,12 +75,16 @@ def _save_decisions(path: Path, data: dict) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n")
 
 
-def _fingerprint(file: str, category: str, description_snippet: str) -> str:
+def _fingerprint(file: str, category: str, line: str = "0") -> str:
     """Create a stable fingerprint for a finding.
 
-    Uses file + category + first 60 chars of description (lowered, stripped).
+    Uses file + category + line_window (rounded to nearest 10 lines).
+    All three fields come from deterministic ▸dp: metadata, not LLM prose.
+    The line_window groups nearby lines so minor line shifts don't
+    invalidate a decision (e.g., line 42 and 47 both map to window 40).
     """
-    normalized = f"{file}|{category}|{description_snippet[:60].lower().strip()}"
+    line_window = (int(line) // 10) * 10 if line.isdigit() else 0
+    normalized = f"{file}|{category}|{line_window}"
     return hashlib.sha256(normalized.encode()).hexdigest()[:16]
 
 
@@ -186,8 +190,7 @@ def _handle_pre_tool_use(data: dict) -> None:
         if meta is None:
             all_matched = False
             break
-        snippet = _extract_description_snippet(q_text)
-        fp = _fingerprint(meta["file"], meta["cat"], snippet)
+        fp = _fingerprint(meta["file"], meta["cat"], meta.get("line", "0"))
 
         if fp in stored:
             prior = stored[fp]
@@ -269,8 +272,8 @@ def _handle_post_tool_use(data: dict) -> None:
         if answer is None:
             continue
 
+        fp = _fingerprint(meta["file"], meta["cat"], meta.get("line", "0"))
         snippet = _extract_description_snippet(q_text)
-        fp = _fingerprint(meta["file"], meta["cat"], snippet)
 
         decision_record = {
             "fingerprint": fp,

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -29,6 +29,21 @@ _MAX_DECISION_AGE_DAYS = 30
 METADATA_PREFIX = "▸dp:"
 DECISIONS_FILENAME = "review-decisions.json"
 MEMORY_DIR_CANDIDATES = ("hack", ".local", "scratch", ".dev")
+_CODE_HASH_WINDOW = 5  # ±N lines around finding location for staleness detection
+
+
+# ── Git root detection ──
+
+
+def _find_git_root() -> Path:
+    """Find the git root by walking up from CWD. Falls back to CWD if no .git found."""
+    cwd = Path.cwd()
+    git_root = cwd
+    while git_root != git_root.parent:
+        if (git_root / ".git").exists():
+            return git_root
+        git_root = git_root.parent
+    return cwd  # no .git found — fall back to CWD
 
 
 # ── Memory directory detection ──
@@ -39,15 +54,7 @@ def _find_memory_dir() -> Path | None:
 
     Finds git root by walking up from CWD, then checks for candidates at root level.
     """
-    cwd = Path.cwd()
-    # Find git root
-    git_root = cwd
-    while git_root != git_root.parent:
-        if (git_root / ".git").exists():
-            break
-        git_root = git_root.parent
-    else:
-        git_root = cwd  # reset to cwd after exhausting walk (no .git found)
+    git_root = _find_git_root()
 
     core_files = ("PROJECT.md", "TODO.md", "SESSIONS.md", "NEXT.md", "LESSONS.md")
 
@@ -109,6 +116,31 @@ def _fingerprint(file: str, category: str, line: str = "0", skill: str = "unknow
     line_window = (int(line) // 10) * 10 if line.isdigit() else 0
     normalized = f"{file}|{category}|{line_window}|{skill}"
     return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+
+
+def _compute_code_hash(file_path: str, line: str = "0") -> str | None:
+    """Hash ±N lines around a finding location for staleness detection.
+
+    Returns a 16-char hex digest, or None if the file can't be read.
+    When the code around a finding changes, the hash changes, invalidating
+    the stored decision so the user is re-prompted.
+    """
+    git_root = _find_git_root()
+    resolved = git_root / file_path
+    try:
+        lines = resolved.read_text().splitlines()
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not lines:
+        return None
+
+    target = int(line) if line.isdigit() else 0
+    # 0-indexed target line
+    center = max(0, target - 1)  # line numbers are 1-based
+    start = max(0, center - _CODE_HASH_WINDOW)
+    end = min(len(lines), center + _CODE_HASH_WINDOW + 1)
+    window = "\n".join(lines[start:end])
+    return hashlib.sha256(window.encode()).hexdigest()[:16]
 
 
 # ── Metadata parsing ──
@@ -247,14 +279,22 @@ def _handle_pre_tool_use(data: dict) -> None:
             if decision not in VALID_DECISIONS:
                 all_matched = False
                 break  # corrupted/unexpected stored value — re-ask
+            # Staleness check: verify code hasn't changed since decision was made
+            stored_hash = prior.get("code_hash")
+            if stored_hash is not None:
+                current_hash = _compute_code_hash(meta["file"], meta.get("line", "0"))
+                if current_hash != stored_hash:
+                    all_matched = False
+                    break  # code changed — decision is stale, re-ask
             answers[q_text] = decision
         else:
             all_matched = False
             break
 
     if not all_matched:
-        # Can't auto-answer partial batches reliably — passthrough for all
-        # TODO(v2): test whether partial answers work with AskUserQuestion
+        # Partial batch auto-answer is architecturally blocked: updatedInput
+        # requires permissionDecision to take effect (anthropics/claude-code#32060),
+        # so there's no "allow some, prompt for rest" mode. Passthrough all.
         sys.exit(0)
 
     # All questions matched — build context message
@@ -356,17 +396,21 @@ def _handle_post_tool_use(data: dict) -> None:
             continue
 
         snippet = _extract_description_snippet(q_text)
+        line_val = re.sub(r"[^\d]", "", meta.get("line", "0"))[:_MAX_FIELD_LEN] or "0"
+        code_hash = _compute_code_hash(meta["file"], meta.get("line", "0"))
 
         decision_record = {
             "fingerprint": fp,
             "file": meta["file"],
-            "line": meta.get("line", "0")[:_MAX_FIELD_LEN] if meta.get("line") else "0",
+            "line": line_val,
             "category": re.sub(r"[^\w./_-]", "_", meta["cat"])[:_MAX_FIELD_LEN],
             "skill": re.sub(r"[^\w./_-]", "_", meta.get("skill", "unknown"))[:_MAX_FIELD_LEN],
             "decision": answer,
-            "description_snippet": snippet[:80],
+            "description_snippet": re.sub(r"[\x00-\x1f\x7f]", " ", snippet)[:80],
             "decided_at": datetime.now(UTC).isoformat(),
         }
+        if code_hash is not None:
+            decision_record["code_hash"] = code_hash
 
         stored_by_fp[fp] = decision_record  # O(1) upsert
         mutated = True

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -84,6 +84,15 @@
             "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py"
           }
         ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/decision-persistence.py"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -148,6 +157,15 @@
           {
             "type": "command",
             "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py"
+          }
+        ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/decision-persistence.py"
           }
         ]
       }

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Global hooks: git safety, commit validation, pre-push review, tool selection, quality stop gate, subagent completion verification",
+  "description": "Global hooks: git safety, commit validation, pre-push review, tool selection, quality stop gate, subagent completion verification, decision persistence",
   "hooks": {
     "SessionStart": [
       {

--- a/dev-guard/tests/test_decision_persistence.py
+++ b/dev-guard/tests/test_decision_persistence.py
@@ -360,6 +360,14 @@ class TestSanitizePathField:
     def test_absolute_path_root_rejected(self):
         assert _MOD._sanitize_path_field("/") == "<invalid>"
 
+    def test_double_dot_in_filename_accepted(self):
+        """foo..bar.py is a valid filename — not a traversal."""
+        assert _MOD._sanitize_path_field("foo..bar.py") == "foo..bar.py"
+
+    def test_double_dot_in_directory_accepted(self):
+        """pkg..v2/ is a valid directory name — not a traversal."""
+        assert _MOD._sanitize_path_field("pkg..v2/file.py") == "pkg..v2/file.py"
+
     def test_valid_relative_path_accepted(self):
         assert _MOD._sanitize_path_field("src/auth.py") == "src/auth.py"
 

--- a/dev-guard/tests/test_decision_persistence.py
+++ b/dev-guard/tests/test_decision_persistence.py
@@ -1,0 +1,813 @@
+"""Tests for decision-persistence.py
+
+Tests are organized in two groups:
+- Unit tests (importlib): pure functions _fingerprint, _sanitize_path_field,
+  _parse_metadata, _save_decisions (OSError path).
+- Integration tests (subprocess black-box): full hook invocations via stdin JSON,
+  using tmp_path for filesystem isolation. CWD is controlled via subprocess cwd= to
+  exercise _find_memory_dir git-root walking and fallback behavior.
+
+Exit semantics for this hook:
+  exit 0 + empty stdout  → passthrough (no stored decision matched)
+  exit 0 + JSON stdout   → PreToolUse auto-answer (permissionDecision: allow + updatedInput)
+  PostToolUse: always exit 0, side effect is decision written to decisions file.
+"""
+
+import importlib.util
+import json
+import subprocess
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPT = Path(__file__).parent.parent / "hooks" / "decision-persistence.py"
+
+METADATA_PREFIX = "▸dp:"
+
+
+# ── Module loader ─────────────────────────────────────────────────────────────
+
+
+def _load_module():
+    """Import decision-persistence.py as a module for unit testing internal functions."""
+    spec = importlib.util.spec_from_file_location("decision_persistence", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── Subprocess helpers ────────────────────────────────────────────────────────
+
+
+def run_hook(
+    payload: dict | None = None,
+    *,
+    cwd: Path | None = None,
+    raw_input: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Invoke the hook with the given payload on stdin.
+
+    Use payload= for normal JSON payloads. Use raw_input= for non-JSON tests.
+    """
+    stdin = raw_input if raw_input is not None else json.dumps(payload)
+    return subprocess.run(
+        ["uv", "run", str(SCRIPT)],
+        input=stdin,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd) if cwd is not None else None,
+        timeout=30,
+    )
+
+
+def make_pre_payload(questions: list[dict]) -> dict:
+    """Build a PreToolUse AskUserQuestion payload."""
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "AskUserQuestion",
+        "tool_input": {"questions": questions},
+    }
+
+
+def make_post_payload(
+    questions: list[dict],
+    answers: dict,
+    *,
+    source: str = "tool_input",
+) -> dict:
+    """Build a PostToolUse AskUserQuestion payload.
+
+    source='tool_input': answers in tool_input (fallback path).
+    source='tool_response': answers in tool_response (primary path).
+    """
+    if source == "tool_response":
+        return {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "AskUserQuestion",
+            "tool_input": {"questions": questions},
+            "tool_response": {"answers": answers},
+        }
+    return {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "AskUserQuestion",
+        "tool_input": {"questions": questions, "answers": answers},
+        "tool_response": {},
+    }
+
+
+def make_fix_defer_question(q_text: str) -> dict:
+    """Return an AskUserQuestion question dict with Fix/Defer options."""
+    return {"question": q_text, "options": [{"label": "Fix"}, {"label": "Defer"}]}
+
+
+def make_dp_question(
+    description: str,
+    *,
+    file: str = "src/auth.py",
+    line: str = "42",
+    cat: str = "Security",
+    skill: str = "pr-review",
+) -> dict:
+    """Return a Fix/Defer question with a valid ▸dp: metadata suffix."""
+    q_text = f"{description} {METADATA_PREFIX}file={file},line={line},cat={cat},skill={skill}"
+    return make_fix_defer_question(q_text)
+
+
+def seed_decisions_file(path: Path, decisions: list[dict]) -> None:
+    """Write a decisions JSON file with the given records."""
+    data = {"version": 1, "decisions": decisions}
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+_MOD = _load_module()
+
+
+def make_decision_record(
+    *,
+    file: str = "src/auth.py",
+    line: str = "42",
+    cat: str = "Security",
+    skill: str = "pr-review",
+    decision: str = "Fix",
+    decided_at: str | None = None,
+) -> dict:
+    """Build a stored decision record with a matching fingerprint."""
+    fp = _MOD._fingerprint(file, cat, line, skill)
+    return {
+        "fingerprint": fp,
+        "file": file,
+        "line": line,
+        "category": cat,
+        "skill": skill,
+        "decision": decision,
+        "description_snippet": "Test finding",
+        "decided_at": decided_at or datetime.now(UTC).isoformat(),
+    }
+
+
+def setup_project_with_hack(tmp_path: Path, *, with_git: bool = True) -> Path:
+    """Create a minimal project directory with hack/ + core memory files."""
+    hack = tmp_path / "hack"
+    hack.mkdir()
+    # core_count >= 2 required for validated memory dir
+    (hack / "PROJECT.md").write_text("# Project\n")
+    (hack / "TODO.md").write_text("# TODO\n")
+    if with_git:
+        (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+# ── pr-test-8: _find_memory_dir git-root walking ──────────────────────────────
+
+
+class TestFindMemoryDir:
+    """Integration tests for _find_memory_dir via subprocess cwd control."""
+
+    def test_hack_at_git_root_found(self, tmp_path):
+        """hack/ at git root is detected when CWD is a subdirectory."""
+        project = setup_project_with_hack(tmp_path, with_git=True)
+        sub = project / "src" / "app"
+        sub.mkdir(parents=True)
+        hack = project / "hack"
+
+        q = make_dp_question("SQL injection in login handler")
+        record = make_decision_record()
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=sub)
+        assert result.returncode == 0
+        assert result.stdout.strip() != "", (
+            "expected auto-answer JSON when hack/ is found via git root walk"
+        )
+        output = json.loads(result.stdout)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+    def test_no_git_root_falls_back_to_cwd(self, tmp_path):
+        """Without .git, _find_memory_dir falls back to CWD and still finds hack/ there."""
+        project = setup_project_with_hack(tmp_path, with_git=False)
+        hack = project / "hack"
+
+        q = make_dp_question("Unvalidated redirect")
+        record = make_decision_record(cat="Security")
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+        assert result.stdout.strip() != "", (
+            "expected auto-answer JSON when hack/ found via CWD fallback (no .git)"
+        )
+        output = json.loads(result.stdout)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+    def test_no_hack_dir_passthroughs(self, tmp_path):
+        """No hack/ (or .local/, scratch/, .dev/) → passthrough."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+
+        q = make_dp_question("Missing input validation")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "", (
+            "expected passthrough (empty stdout) when no memory dir exists"
+        )
+
+    def test_hack_without_core_files_rejected(self, tmp_path):
+        """hack/ with decisions file but <2 core files → rejected (not used)."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+        hack = project / "hack"
+        hack.mkdir()
+        # Only 1 core file (need >= 2)
+        (hack / "PROJECT.md").write_text("# Project\n")
+        # Seed decisions file — if core_count guard fails, hook would auto-answer
+        q = make_dp_question("SQL injection", file="src/auth.py", line="42", cat="Security")
+        record = make_decision_record()
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "", (
+            "expected passthrough when hack/ has <2 core files, even with decisions seeded"
+        )
+
+
+# ── pr-test-7: _save_decisions OSError cleanup ───────────────────────────────
+
+
+class TestSaveDecisionsOSError:
+    """Unit tests for _save_decisions OSError cleanup path."""
+
+    def setup_method(self):
+        self.mod = _load_module()
+
+    def test_oserror_during_write_cleans_up_tmp(self, tmp_path):
+        """If write_text raises OSError, the .tmp file is removed."""
+        decisions_path = tmp_path / "review-decisions.json"
+        data = {"version": 1, "decisions": []}
+
+        with patch.object(Path, "write_text", side_effect=OSError("disk full")):
+            self.mod._save_decisions(decisions_path, data)
+
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert tmp_files == [], f"unexpected .tmp files left: {tmp_files}"
+        assert not decisions_path.exists()
+
+    def test_oserror_during_replace_cleans_up_tmp(self, tmp_path):
+        """If os.replace raises, the tmp file written by write_text is cleaned up."""
+        decisions_path = tmp_path / "review-decisions.json"
+        data = {"version": 1, "decisions": []}
+
+        with patch("os.replace", side_effect=OSError("cross-device link")):
+            self.mod._save_decisions(decisions_path, data)
+
+        tmp_files = list(tmp_path.glob("*.tmp"))
+        assert tmp_files == [], f"orphaned .tmp files: {tmp_files}"
+        assert not decisions_path.exists()
+
+    def test_successful_write_produces_valid_json(self, tmp_path):
+        """Happy path: _save_decisions writes valid JSON atomically."""
+        decisions_path = tmp_path / "review-decisions.json"
+        data = {"version": 1, "decisions": [{"fingerprint": "abc123", "decision": "Fix"}]}
+        self.mod._save_decisions(decisions_path, data)
+
+        assert decisions_path.exists()
+        loaded = json.loads(decisions_path.read_text())
+        assert loaded == data
+        assert list(tmp_path.glob("*.tmp")) == []
+
+
+# ── pr-test-2: _fingerprint line windowing ────────────────────────────────────
+
+
+class TestFingerprint:
+    """Unit tests for _fingerprint windowing behavior."""
+
+    def setup_method(self):
+        self.mod = _load_module()
+
+    @pytest.mark.parametrize(
+        "line_a,line_b,same_window",
+        [
+            ("42", "47", True),  # same window: 40
+            ("40", "49", True),  # boundary edges, same window: 40
+            ("39", "40", False),  # cross-window: 30 vs 40
+            ("49", "50", False),  # cross-window: 40 vs 50
+            ("0", "9", True),  # window 0
+            ("10", "19", True),  # window 10
+        ],
+    )
+    def test_line_windowing(self, line_a, line_b, same_window):
+        fp_a = self.mod._fingerprint("src/auth.py", "Security", line_a)
+        fp_b = self.mod._fingerprint("src/auth.py", "Security", line_b)
+        if same_window:
+            assert fp_a == fp_b, f"lines {line_a} and {line_b} should map to the same window"
+        else:
+            assert fp_a != fp_b, f"lines {line_a} and {line_b} should map to different windows"
+
+    def test_non_digit_line_uses_zero_window(self):
+        """Non-digit line string falls back to window 0."""
+        fp_non_digit = self.mod._fingerprint("src/auth.py", "Security", "N/A")
+        fp_zero = self.mod._fingerprint("src/auth.py", "Security", "0")
+        assert fp_non_digit == fp_zero
+
+    def test_empty_string_line_uses_zero_window(self):
+        """Empty string line is non-digit → window 0."""
+        fp_empty = self.mod._fingerprint("src/auth.py", "Security", "")
+        fp_zero = self.mod._fingerprint("src/auth.py", "Security", "0")
+        assert fp_empty == fp_zero
+
+    def test_different_categories_different_fingerprints(self):
+        fp_a = self.mod._fingerprint("src/auth.py", "Security", "42")
+        fp_b = self.mod._fingerprint("src/auth.py", "Performance", "42")
+        assert fp_a != fp_b
+
+    def test_different_files_different_fingerprints(self):
+        fp_a = self.mod._fingerprint("src/auth.py", "Security", "42")
+        fp_b = self.mod._fingerprint("src/other.py", "Security", "42")
+        assert fp_a != fp_b
+
+    def test_fingerprint_length_is_16(self):
+        fp = self.mod._fingerprint("src/auth.py", "Security", "42")
+        assert len(fp) == 16
+        assert all(c in "0123456789abcdef" for c in fp)
+
+    def test_default_line_argument(self):
+        fp_default = self.mod._fingerprint("src/auth.py", "Security")
+        fp_explicit = self.mod._fingerprint("src/auth.py", "Security", "0")
+        assert fp_default == fp_explicit
+
+    def test_different_skills_different_fingerprints(self):
+        """Same file/cat/line but different skill → different fingerprint."""
+        fp_a = self.mod._fingerprint("src/auth.py", "Security", "42", "pr-review")
+        fp_b = self.mod._fingerprint("src/auth.py", "Security", "42", "quality-gate")
+        assert fp_a != fp_b
+
+
+# ── pr-test-3: _sanitize_path_field security boundaries ──────────────────────
+
+
+class TestSanitizePathField:
+    """Unit tests for _sanitize_path_field path traversal and injection rejection."""
+
+    def setup_method(self):
+        self.mod = _load_module()
+
+    def test_path_traversal_rejected(self):
+        assert self.mod._sanitize_path_field("../../etc/passwd") == "<invalid>"
+
+    def test_path_traversal_in_middle_rejected(self):
+        assert self.mod._sanitize_path_field("src/../../../etc/shadow") == "<invalid>"
+
+    def test_absolute_path_rejected(self):
+        assert self.mod._sanitize_path_field("/absolute/path") == "<invalid>"
+
+    def test_absolute_path_root_rejected(self):
+        assert self.mod._sanitize_path_field("/") == "<invalid>"
+
+    def test_valid_relative_path_accepted(self):
+        assert self.mod._sanitize_path_field("src/auth.py") == "src/auth.py"
+
+    def test_valid_nested_path_accepted(self):
+        result = self.mod._sanitize_path_field("deep/nested/path/file.py")
+        assert result == "deep/nested/path/file.py"
+
+    def test_non_path_characters_normalized(self):
+        result = self.mod._sanitize_path_field("src/file with spaces.py")
+        assert result == "src/file_with_spaces.py"
+
+    def test_long_string_truncated_at_512(self):
+        long_path = "a/b/" + "x" * 600
+        result = self.mod._sanitize_path_field(long_path)
+        assert len(result) <= 512
+
+    def test_empty_string_accepted(self):
+        assert self.mod._sanitize_path_field("") == ""
+
+
+# ── pr-test-4: _parse_metadata edge cases ────────────────────────────────────
+
+
+class TestParseMetadata:
+    """Unit tests for _parse_metadata format edge cases."""
+
+    def setup_method(self):
+        self.mod = _load_module()
+
+    def test_valid_full_metadata(self):
+        text = f"Question {METADATA_PREFIX}file=src/a.py,line=42,cat=Sec,skill=pr-review"
+        result = self.mod._parse_metadata(text)
+        assert result is not None
+        assert result["file"] == "src/a.py"
+        assert result["line"] == "42"
+        assert result["cat"] == "Sec"
+        assert result["skill"] == "pr-review"
+
+    def test_missing_file_returns_none(self):
+        text = f"Question {METADATA_PREFIX}line=42,cat=Security,skill=pr-review"
+        assert self.mod._parse_metadata(text) is None
+
+    def test_missing_cat_returns_none(self):
+        text = f"Question {METADATA_PREFIX}file=src/auth.py,line=42,skill=pr-review"
+        assert self.mod._parse_metadata(text) is None
+
+    def test_no_prefix_returns_none(self):
+        text = "A normal question without any metadata suffix"
+        assert self.mod._parse_metadata(text) is None
+
+    def test_file_with_comma_causes_parse_failure(self):
+        """File path with comma breaks the parser (known limitation)."""
+        pfx = METADATA_PREFIX
+        text = f"Q {pfx}file=src/file,name.py,line=42,cat=Sec,skill=pr-review"
+        result = self.mod._parse_metadata(text)
+        if result is not None:
+            assert result.get("file") != "src/file,name.py"
+
+    def test_file_with_path_traversal_returns_none(self):
+        pfx = METADATA_PREFIX
+        text = f"Question {pfx}file=../../etc/passwd,line=1,cat=Sec,skill=pr"
+        assert self.mod._parse_metadata(text) is None
+
+    def test_whitespace_around_values_stripped(self):
+        pfx = METADATA_PREFIX
+        text = f"Q {pfx}file= src/auth.py ,line= 42 ,cat= Security ,skill= pr "
+        result = self.mod._parse_metadata(text)
+        assert result is not None
+        assert result["file"] == "src/auth.py"
+        assert result["cat"] == "Security"
+
+    def test_optional_line_field_absent(self):
+        text = f"Question {METADATA_PREFIX}file=src/auth.py,cat=Security,skill=pr-review"
+        result = self.mod._parse_metadata(text)
+        assert result is not None
+        assert result["file"] == "src/auth.py"
+        assert result["cat"] == "Security"
+
+    def test_rpartition_handles_double_prefix(self):
+        """If ▸dp: appears in description body, rpartition finds the last (real) suffix."""
+        pfx = METADATA_PREFIX
+        text = f"Describes {pfx} injection {pfx}file=src/a.py,line=1,cat=Sec,skill=pr"
+        result = self.mod._parse_metadata(text)
+        assert result is not None
+        assert result["file"] == "src/a.py"
+        assert result["cat"] == "Sec"
+
+
+class TestExtractDescriptionSnippet:
+    """Unit tests for _extract_description_snippet."""
+
+    def setup_method(self):
+        self.mod = _load_module()
+
+    def test_double_prefix_preserves_full_description(self):
+        """rsplit on last ▸dp: preserves description containing the prefix."""
+        pfx = METADATA_PREFIX
+        text = f"Describes {pfx} injection {pfx}file=src/a.py,line=1,cat=Sec,skill=pr"
+        snippet = self.mod._extract_description_snippet(text)
+        assert "injection" in snippet
+
+
+# ── pr-test-5: PreToolUse partial-batch passthrough ──────────────────────────
+
+
+class TestPreToolUsePartialBatch:
+    """Integration tests for partial-batch passthrough in PreToolUse."""
+
+    def test_mixed_type_batch_passthroughs(self, tmp_path):
+        """Batch with Fix/Defer + non-Fix/Defer questions → passthrough."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+
+        record = make_decision_record()
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q_fixdefer = make_dp_question("SQL injection")
+        q_other = {
+            "question": "Which approach?",
+            "options": [{"label": "Option A"}, {"label": "Option B"}],
+        }
+
+        payload = make_pre_payload([q_fixdefer, q_other])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "", (
+            "expected passthrough for mixed-type batch (Fix/Defer + non-Fix/Defer)"
+        )
+
+    def test_one_matched_one_unmatched_passthroughs(self, tmp_path):
+        """2-question batch where only 1 has a stored decision → passthrough."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+
+        record = make_decision_record(file="src/auth.py", line="42", cat="Security")
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q1 = make_dp_question("SQL injection", file="src/auth.py", line="42", cat="Security")
+        q2 = make_dp_question("XSS in template", file="src/templates.py", line="88", cat="Quality")
+
+        payload = make_pre_payload([q1, q2])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "", (
+            f"expected passthrough for partial batch: got {result.stdout!r}"
+        )
+
+    def test_all_matched_produces_auto_answer(self, tmp_path):
+        """2-question batch where both have stored decisions → auto-answer."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+
+        record1 = make_decision_record(file="src/auth.py", line="42", cat="Security")
+        record2 = make_decision_record(
+            file="src/templates.py", line="88", cat="Quality", decision="Defer"
+        )
+        seed_decisions_file(hack / "review-decisions.json", [record1, record2])
+
+        q1 = make_dp_question("SQL injection", file="src/auth.py", line="42", cat="Security")
+        q2 = make_dp_question("XSS in template", file="src/templates.py", line="88", cat="Quality")
+
+        payload = make_pre_payload([q1, q2])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() != ""
+        output = json.loads(result.stdout)
+        hook_out = output["hookSpecificOutput"]
+        assert hook_out["permissionDecision"] == "allow"
+        assert len(hook_out["updatedInput"]["answers"]) == 2
+
+    def test_no_stored_decisions_passthroughs(self, tmp_path):
+        """No stored decisions at all → passthrough."""
+        project = setup_project_with_hack(tmp_path)
+        seed_decisions_file(project / "hack" / "review-decisions.json", [])
+
+        q = make_dp_question("Missing validation", file="src/api.py", line="10", cat="Security")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_expired_decision_not_auto_applied(self, tmp_path):
+        """PreToolUse ignores decisions older than 30 days."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        old_date = (datetime.now(UTC) - timedelta(days=60)).isoformat()
+        record = make_decision_record(decided_at=old_date)
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q = make_dp_question("SQL injection")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "", (
+            "expected passthrough — expired decision should not auto-apply"
+        )
+
+
+# ── pr-test-6: PostToolUse answer-source fallback ────────────────────────────
+
+
+class TestPostToolUseAnswerSource:
+    """Integration tests for answer-source fallback in PostToolUse."""
+
+    def test_answers_in_tool_input_captured(self, tmp_path):
+        """Answers in tool_input.answers (fallback) are captured when tool_response is empty."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q = make_dp_question("SQL injection", file="src/auth.py", line="42", cat="Security")
+        q_text = q["question"]
+
+        payload = make_post_payload([q], {q_text: "Fix"})
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["decision"] == "Fix"
+        assert stored["decisions"][0]["file"] == "src/auth.py"
+
+    def test_answers_in_tool_response_captured(self, tmp_path):
+        """Answers in tool_response.answers are captured and persisted."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q = make_dp_question("XSS vulnerability", file="src/views.py", line="15", cat="Security")
+        q_text = q["question"]
+
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "AskUserQuestion",
+            "tool_input": {"questions": [q]},
+            "tool_response": {"answers": {q_text: "Defer"}},
+        }
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["decision"] == "Defer"
+        assert stored["decisions"][0]["file"] == "src/views.py"
+
+    def test_answers_in_tool_response_takes_precedence(self, tmp_path):
+        """When answers in both tool_response and tool_input, tool_response wins."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q = make_dp_question("CSRF token missing", file="src/forms.py", line="30", cat="Security")
+        q_text = q["question"]
+
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "AskUserQuestion",
+            "tool_input": {"questions": [q], "answers": {q_text: "Fix"}},
+            "tool_response": {"answers": {q_text: "Defer"}},
+        }
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        # tool_response wins over tool_input
+        assert stored["decisions"][0]["decision"] == "Defer"
+
+    def test_upsert_overwrites_existing_decision(self, tmp_path):
+        """Changing from Defer to Fix updates the stored decision."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        # Seed with an existing "Defer" decision
+        record = make_decision_record(decision="Defer")
+        seed_decisions_file(decisions_file, [record])
+
+        q = make_dp_question("SQL injection")
+        q_text = q["question"]
+
+        # User now picks Fix
+        payload = make_post_payload([q], {q_text: "Fix"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["decision"] == "Fix"
+
+    def test_invalid_answer_not_captured(self, tmp_path):
+        """Answer values not in VALID_DECISIONS are discarded."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q = make_dp_question("Unrelated finding", file="src/misc.py", line="5", cat="Quality")
+        q_text = q["question"]
+
+        payload = make_post_payload([q], {q_text: "Skip"})
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert stored["decisions"] == []
+
+    def test_expired_decisions_pruned_on_write(self, tmp_path):
+        """Decisions older than 30 days are pruned when PostToolUse writes."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        old_date = (datetime.now(UTC) - timedelta(days=60)).isoformat()
+        old_record = make_decision_record(
+            file="src/old.py", line="10", cat="QA", decided_at=old_date
+        )
+        seed_decisions_file(decisions_file, [old_record])
+
+        # New decision triggers a write, which prunes the old one
+        q = make_dp_question("New finding", file="src/new.py", line="5", cat="Security")
+        q_text = q["question"]
+        payload = make_post_payload([q], {q_text: "Fix"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["file"] == "src/new.py"
+
+    def test_recapture_skip_preserves_timestamp(self, tmp_path):
+        """Auto-applied answers via tool_input fallback skip re-capture."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        original_time = datetime.now(UTC).isoformat()
+        record = make_decision_record(decision="Fix", decided_at=original_time)
+        seed_decisions_file(decisions_file, [record])
+
+        # Send same decision via tool_input (fallback — simulates auto-applied)
+        q = make_dp_question("SQL injection")
+        q_text = q["question"]
+        payload = make_post_payload([q], {q_text: "Fix"})  # tool_input default
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        # Timestamp should NOT be refreshed — re-capture was skipped
+        assert stored["decisions"][0]["decided_at"] == original_time
+
+
+# ── pr-test-1: General hook passthrough cases ────────────────────────────────
+
+
+class TestHookPassthrough:
+    """Integration tests for basic hook passthrough behavior."""
+
+    def test_non_ask_user_question_tool_passthroughs(self, tmp_path):
+        payload = {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/some/file.py"},
+        }
+        result = run_hook(payload, cwd=tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_invalid_json_stdin_passthroughs(self, tmp_path):
+        result = run_hook(cwd=tmp_path, raw_input="not json at all")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_empty_stdin_passthroughs(self, tmp_path):
+        result = run_hook(cwd=tmp_path, raw_input="")
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_non_fix_defer_question_passthroughs(self, tmp_path):
+        payload = make_pre_payload(
+            [
+                {
+                    "question": "Which approach do you prefer?",
+                    "options": [{"label": "Option A"}, {"label": "Option B"}],
+                }
+            ]
+        )
+        result = run_hook(payload, cwd=tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_question_without_dp_metadata_passthroughs(self, tmp_path):
+        q = make_fix_defer_question("This question has no metadata suffix")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_pre_tool_use_auto_answer_format(self, tmp_path):
+        """PreToolUse auto-answer includes required hookSpecificOutput fields."""
+        project = setup_project_with_hack(tmp_path, with_git=True)
+        hack = project / "hack"
+        record = make_decision_record(
+            file="src/auth.py", line="20", cat="Security", decision="Defer"
+        )
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q = make_dp_question("Unvalidated input", file="src/auth.py", line="20", cat="Security")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        hook_out = output["hookSpecificOutput"]
+        assert hook_out["hookEventName"] == "PreToolUse"
+        assert hook_out["permissionDecision"] == "allow"
+        assert "updatedInput" in hook_out
+        assert "answers" in hook_out["updatedInput"]
+        assert "additionalContext" in hook_out
+
+    def test_post_tool_use_no_questions_passthroughs(self, tmp_path):
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "AskUserQuestion",
+            "tool_input": {"questions": [], "answers": {}},
+            "tool_response": {},
+        }
+        result = run_hook(payload, cwd=tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_unknown_hook_event_passthroughs(self, tmp_path):
+        payload = {
+            "hook_event_name": "SubagentStop",
+            "tool_name": "AskUserQuestion",
+            "tool_input": {},
+        }
+        result = run_hook(payload, cwd=tmp_path)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""

--- a/dev-guard/tests/test_decision_persistence.py
+++ b/dev-guard/tests/test_decision_persistence.py
@@ -21,8 +21,6 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 SCRIPT = Path(__file__).parent.parent / "hooks" / "decision-persistence.py"
 
 METADATA_PREFIX = "▸dp:"
@@ -287,35 +285,32 @@ class TestSaveDecisionsOSError:
 
 
 class TestFingerprint:
-    """Unit tests for _fingerprint windowing behavior."""
+    """Unit tests for _fingerprint exact-line behavior."""
 
-    @pytest.mark.parametrize(
-        "line_a,line_b,same_window",
-        [
-            ("42", "47", True),  # same window: 40
-            ("40", "49", True),  # boundary edges, same window: 40
-            ("39", "40", False),  # cross-window: 30 vs 40
-            ("49", "50", False),  # cross-window: 40 vs 50
-            ("0", "9", True),  # window 0
-            ("10", "19", True),  # window 10
-        ],
-    )
-    def test_line_windowing(self, line_a, line_b, same_window):
-        fp_a = _MOD._fingerprint("src/auth.py", "Security", line_a)
-        fp_b = _MOD._fingerprint("src/auth.py", "Security", line_b)
-        if same_window:
-            assert fp_a == fp_b, f"lines {line_a} and {line_b} should map to the same window"
-        else:
-            assert fp_a != fp_b, f"lines {line_a} and {line_b} should map to different windows"
+    def test_same_line_same_fingerprint(self):
+        fp_a = _MOD._fingerprint("src/auth.py", "Security", "42")
+        fp_b = _MOD._fingerprint("src/auth.py", "Security", "42")
+        assert fp_a == fp_b
 
-    def test_non_digit_line_uses_zero_window(self):
-        """Non-digit line string falls back to window 0."""
+    def test_different_lines_different_fingerprints(self):
+        """Exact line numbers — nearby lines produce different fingerprints."""
+        fp_a = _MOD._fingerprint("src/auth.py", "Security", "42")
+        fp_b = _MOD._fingerprint("src/auth.py", "Security", "45")
+        assert fp_a != fp_b, "lines 42 and 45 must produce different fingerprints"
+
+    def test_adjacent_lines_different_fingerprints(self):
+        fp_a = _MOD._fingerprint("src/auth.py", "Security", "42")
+        fp_b = _MOD._fingerprint("src/auth.py", "Security", "43")
+        assert fp_a != fp_b
+
+    def test_non_digit_line_uses_zero(self):
+        """Non-digit line string falls back to 0."""
         fp_non_digit = _MOD._fingerprint("src/auth.py", "Security", "N/A")
         fp_zero = _MOD._fingerprint("src/auth.py", "Security", "0")
         assert fp_non_digit == fp_zero
 
-    def test_empty_string_line_uses_zero_window(self):
-        """Empty string line is non-digit → window 0."""
+    def test_empty_string_line_uses_zero(self):
+        """Empty string line is non-digit → 0."""
         fp_empty = _MOD._fingerprint("src/auth.py", "Security", "")
         fp_zero = _MOD._fingerprint("src/auth.py", "Security", "0")
         assert fp_empty == fp_zero
@@ -330,7 +325,7 @@ class TestFingerprint:
         fp_b = _MOD._fingerprint("src/other.py", "Security", "42")
         assert fp_a != fp_b
 
-    def test_fingerprint_length_is_16(self):
+    def test_fingerprint_length_is_32(self):
         fp = _MOD._fingerprint("src/auth.py", "Security", "42")
         assert len(fp) == 32
         assert all(c in "0123456789abcdef" for c in fp)

--- a/dev-guard/tests/test_decision_persistence.py
+++ b/dev-guard/tests/test_decision_persistence.py
@@ -122,9 +122,6 @@ def seed_decisions_file(path: Path, decisions: list[dict]) -> None:
     path.write_text(json.dumps(data, indent=2) + "\n")
 
 
-_MOD = _load_module()
-
-
 def make_decision_record(
     *,
     file: str = "src/auth.py",
@@ -158,6 +155,10 @@ def setup_project_with_hack(tmp_path: Path, *, with_git: bool = True) -> Path:
     if with_git:
         (tmp_path / ".git").mkdir()
     return tmp_path
+
+
+# ── Module loaded after all helpers to clarify dependency order ────────────────
+_MOD = _load_module()
 
 
 # ── pr-test-8: _find_memory_dir git-root walking ──────────────────────────────
@@ -331,7 +332,7 @@ class TestFingerprint:
 
     def test_fingerprint_length_is_16(self):
         fp = _MOD._fingerprint("src/auth.py", "Security", "42")
-        assert len(fp) == 16
+        assert len(fp) == 32
         assert all(c in "0123456789abcdef" for c in fp)
 
     def test_default_line_argument(self):
@@ -413,20 +414,18 @@ class TestParseMetadata:
 
     def test_file_with_comma_causes_parse_failure(self):
         """File path with comma breaks the parser (known limitation)."""
-        pfx = METADATA_PREFIX
-        text = f"Q {pfx}file=src/file,name.py,line=42,cat=Sec,skill=pr-review"
+
+        text = f"Q {METADATA_PREFIX}file=src/file,name.py,line=42,cat=Sec,skill=pr-review"
         result = _MOD._parse_metadata(text)
         if result is not None:
             assert result.get("file") != "src/file,name.py"
 
     def test_file_with_path_traversal_returns_none(self):
-        pfx = METADATA_PREFIX
-        text = f"Question {pfx}file=../../etc/passwd,line=1,cat=Sec,skill=pr"
+        text = f"Question {METADATA_PREFIX}file=../../etc/passwd,line=1,cat=Sec,skill=pr"
         assert _MOD._parse_metadata(text) is None
 
     def test_whitespace_around_values_stripped(self):
-        pfx = METADATA_PREFIX
-        text = f"Q {pfx}file= src/auth.py ,line= 42 ,cat= Security ,skill= pr "
+        text = f"Q {METADATA_PREFIX}file= src/auth.py ,line= 42 ,cat= Security ,skill= pr "
         result = _MOD._parse_metadata(text)
         assert result is not None
         assert result["file"] == "src/auth.py"
@@ -441,8 +440,9 @@ class TestParseMetadata:
 
     def test_rpartition_handles_double_prefix(self):
         """If ▸dp: appears in description body, rpartition finds the last (real) suffix."""
-        pfx = METADATA_PREFIX
-        text = f"Describes {pfx} injection {pfx}file=src/a.py,line=1,cat=Sec,skill=pr"
+
+        dp = METADATA_PREFIX
+        text = f"Describes {dp} injection {dp}file=src/a.py,line=1,cat=Sec,skill=pr"
         result = _MOD._parse_metadata(text)
         assert result is not None
         assert result["file"] == "src/a.py"
@@ -454,8 +454,8 @@ class TestExtractDescriptionSnippet:
 
     def test_double_prefix_preserves_full_description(self):
         """rsplit on last ▸dp: preserves description containing the prefix."""
-        pfx = METADATA_PREFIX
-        text = f"Describes {pfx} injection {pfx}file=src/a.py,line=1,cat=Sec,skill=pr"
+        dp = METADATA_PREFIX
+        text = f"Describes {dp} injection {dp}file=src/a.py,line=1,cat=Sec,skill=pr"
         snippet = _MOD._extract_description_snippet(text)
         assert "injection" in snippet
 
@@ -594,12 +594,7 @@ class TestPostToolUseAnswerSource:
         q = make_dp_question("XSS vulnerability", file="src/views.py", line="15", cat="Security")
         q_text = q["question"]
 
-        payload = {
-            "hook_event_name": "PostToolUse",
-            "tool_name": "AskUserQuestion",
-            "tool_input": {"questions": [q]},
-            "tool_response": {"answers": {q_text: "Defer"}},
-        }
+        payload = make_post_payload([q], {q_text: "Defer"}, source="tool_response")
         result = run_hook(payload, cwd=project)
 
         assert result.returncode == 0
@@ -776,6 +771,9 @@ class TestHookPassthrough:
         assert "updatedInput" in hook_out
         assert "answers" in hook_out["updatedInput"]
         assert "additionalContext" in hook_out
+        ctx = hook_out["additionalContext"]
+        assert "auto-applying 1 prior" in ctx
+        assert "src/auth.py" in ctx
 
     def test_post_tool_use_no_questions_passthroughs(self, tmp_path):
         payload = {
@@ -813,7 +811,7 @@ class TestComputeCodeHash:
         with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
             h = _MOD._compute_code_hash("src/auth.py", "3")
         assert h is not None
-        assert len(h) == 16
+        assert len(h) == 32
         assert all(c in "0123456789abcdef" for c in h)
 
     def test_hash_changes_when_code_changes(self, tmp_path):
@@ -875,18 +873,6 @@ class TestCodeHashStaleness:
         lines[41] = line_42_content  # line 42 (0-indexed as 41)
         return "\n".join(lines) + "\n"
 
-    def _compute_hash_for_file(self, filepath: Path, line: str) -> str:
-        """Compute the code hash the same way the hook does."""
-        import hashlib as _hl
-
-        lines = filepath.read_text().splitlines()
-        target = int(line) if line.isdigit() else 0
-        center = max(0, target - 1)
-        start = max(0, center - 5)
-        end = min(len(lines), center + 5 + 1)
-        window = "\n".join(lines[start:end])
-        return _hl.sha256(window.encode()).hexdigest()[:16]
-
     def test_stale_decision_not_auto_applied(self, tmp_path):
         """Code changed since decision → decision is stale → passthrough."""
         project = setup_project_with_hack(tmp_path)
@@ -896,7 +882,8 @@ class TestCodeHashStaleness:
         f = src / "auth.py"
         f.write_text(self._make_source_file("original_code"))
 
-        code_hash = self._compute_hash_for_file(f, "42")
+        with patch.object(_MOD, "_find_git_root", return_value=project):
+            code_hash = _MOD._compute_code_hash("src/auth.py", "42")
         record = make_decision_record()
         record["code_hash"] = code_hash
         seed_decisions_file(hack / "review-decisions.json", [record])
@@ -920,7 +907,8 @@ class TestCodeHashStaleness:
         f = src / "auth.py"
         f.write_text(self._make_source_file("original_code"))
 
-        code_hash = self._compute_hash_for_file(f, "42")
+        with patch.object(_MOD, "_find_git_root", return_value=project):
+            code_hash = _MOD._compute_code_hash("src/auth.py", "42")
         record = make_decision_record()
         record["code_hash"] = code_hash
         seed_decisions_file(hack / "review-decisions.json", [record])
@@ -972,7 +960,7 @@ class TestCodeHashStaleness:
         stored = json.loads(decisions_file.read_text())
         assert len(stored["decisions"]) == 1
         assert "code_hash" in stored["decisions"][0]
-        assert len(stored["decisions"][0]["code_hash"]) == 16
+        assert len(stored["decisions"][0]["code_hash"]) == 32
 
     def test_post_tool_use_missing_file_omits_code_hash(self, tmp_path):
         """PostToolUse with non-existent file → code_hash omitted from record."""
@@ -1138,20 +1126,21 @@ class TestExtractDescriptionSnippetBrackets:
     """qa-7: Bracket-stripping coverage."""
 
     def test_single_bracket_prefix_stripped(self):
-        pfx = METADATA_PREFIX
-        text = f"[sec-1] SQL injection {pfx}file=a.py,line=1,cat=Sec,skill=pr"
+        text = f"[sec-1] SQL injection {METADATA_PREFIX}file=a.py,line=1,cat=Sec,skill=pr"
         snippet = _MOD._extract_description_snippet(text)
         assert snippet == "SQL injection"
 
     def test_double_bracket_prefix_stripped(self):
-        pfx = METADATA_PREFIX
-        text = f"[sec-1] [Security] SQL injection {pfx}file=a.py,line=1,cat=Sec,skill=pr"
+        text = (
+            f"[sec-1] [Security] SQL injection {METADATA_PREFIX}file=a.py,line=1,cat=Sec,skill=pr"
+        )
         snippet = _MOD._extract_description_snippet(text)
         assert snippet == "SQL injection"
 
     def test_unclosed_bracket_preserved(self):
-        pfx = METADATA_PREFIX
-        text = f"[broken description without close {pfx}file=a.py,line=1,cat=Sec,skill=pr"
+        text = (
+            f"[broken description without close {METADATA_PREFIX}file=a.py,line=1,cat=Sec,skill=pr"
+        )
         snippet = _MOD._extract_description_snippet(text)
         assert snippet.startswith("[broken")
 
@@ -1184,8 +1173,9 @@ class TestDescriptionSnippetSanitization:
         decisions_file = project / "hack" / "review-decisions.json"
         seed_decisions_file(decisions_file, [])
 
-        pfx = METADATA_PREFIX
-        q_text = f"Desc with\x00null and\ttab {pfx}file=src/a.py,line=1,cat=Sec,skill=pr"
+        q_text = (
+            f"Desc with\x00null and\ttab {METADATA_PREFIX}file=src/a.py,line=1,cat=Sec,skill=pr"
+        )
         q = make_fix_defer_question(q_text)
         payload = make_post_payload([q], {q_text: "Fix"}, source="tool_response")
         result = run_hook(payload, cwd=project)
@@ -1195,3 +1185,164 @@ class TestDescriptionSnippetSanitization:
         snippet = stored["decisions"][0]["description_snippet"]
         assert "\x00" not in snippet
         assert "\t" not in snippet
+
+
+# ── QA domain review coverage gaps ───────────────────────────────────────────
+
+
+class TestStaleHashFileUnreadable:
+    """QA-F1: PreToolUse staleness when current file is unreadable."""
+
+    def test_file_deleted_after_decision_passthroughs(self, tmp_path):
+        """Stored code_hash + current file missing → None != hash → stale → passthrough."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        src = project / "src"
+        src.mkdir()
+        f = src / "auth.py"
+        f.write_text("line\n" * 50)
+
+        with patch.object(_MOD, "_find_git_root", return_value=project):
+            code_hash = _MOD._compute_code_hash("src/auth.py", "42")
+        record = make_decision_record()
+        record["code_hash"] = code_hash
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        # Delete the file — _compute_code_hash will return None
+        f.unlink()
+
+        q = make_dp_question("SQL injection")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "", (
+            "expected passthrough — file deleted, hash mismatch (None != stored)"
+        )
+
+
+class TestPostToolUseMixedBatch:
+    """QA-F2: PostToolUse captures Fix/Defer subset from mixed-type batch."""
+
+    def test_mixed_batch_captures_fix_defer_only(self, tmp_path):
+        """Mixed batch: Fix/Defer captured, non-Fix/Defer skipped."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q_fixdefer = make_dp_question("SQL injection")
+        q_other = {
+            "question": "Which approach?",
+            "options": [{"label": "Option A"}, {"label": "Option B"}],
+        }
+        q_text = q_fixdefer["question"]
+
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "AskUserQuestion",
+            "tool_input": {"questions": [q_fixdefer, q_other]},
+            "tool_response": {"answers": {q_text: "Fix", "Which approach?": "Option A"}},
+        }
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["decision"] == "Fix"
+
+
+class TestMemoryDirCandidates:
+    """QA-F3: scratch/.dev candidates + priority ordering."""
+
+    def test_scratch_dir_found(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+        scratch = project / "scratch"
+        scratch.mkdir()
+        (scratch / "PROJECT.md").write_text("# Project\n")
+        (scratch / "TODO.md").write_text("# TODO\n")
+
+        q = make_dp_question("Finding")
+        record = make_decision_record()
+        seed_decisions_file(scratch / "review-decisions.json", [record])
+
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+        assert result.stdout.strip() != "", "expected auto-answer with scratch/ memory dir"
+
+    def test_dev_dir_found(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+        dev = project / ".dev"
+        dev.mkdir()
+        (dev / "PROJECT.md").write_text("# Project\n")
+        (dev / "TODO.md").write_text("# TODO\n")
+
+        q = make_dp_question("Finding")
+        record = make_decision_record()
+        seed_decisions_file(dev / "review-decisions.json", [record])
+
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+        assert result.stdout.strip() != "", "expected auto-answer with .dev/ memory dir"
+
+    def test_hack_takes_priority_over_local(self, tmp_path):
+        """When both hack/ and .local/ exist, hack/ wins (first in candidates)."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+
+        for d in ("hack", ".local"):
+            p = project / d
+            p.mkdir()
+            (p / "PROJECT.md").write_text("# Project\n")
+            (p / "TODO.md").write_text("# TODO\n")
+
+        q = make_dp_question("Finding")
+        record = make_decision_record()
+        # Seed only in hack/ — if .local/ were chosen, no match → passthrough
+        seed_decisions_file(project / "hack" / "review-decisions.json", [record])
+
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+        assert result.stdout.strip() != "", (
+            "expected auto-answer — hack/ should take priority over .local/"
+        )
+
+
+class TestIsFixDeferQuestion:
+    """QA-F5: _is_fix_defer_question contract tests."""
+
+    def test_standard_fix_defer(self):
+        q = {"options": [{"label": "Fix"}, {"label": "Defer"}]}
+        assert _MOD._is_fix_defer_question(q) is True
+
+    def test_three_options_with_fix_defer(self):
+        """3+ options including Fix and Defer → True (by design)."""
+        q = {"options": [{"label": "Fix"}, {"label": "Defer"}, {"label": "Skip"}]}
+        assert _MOD._is_fix_defer_question(q) is True
+
+    def test_non_fix_defer_options(self):
+        q = {"options": [{"label": "Option A"}, {"label": "Option B"}]}
+        assert _MOD._is_fix_defer_question(q) is False
+
+    def test_single_option(self):
+        q = {"options": [{"label": "Fix"}]}
+        assert _MOD._is_fix_defer_question(q) is False
+
+    def test_empty_options(self):
+        q = {"options": []}
+        assert _MOD._is_fix_defer_question(q) is False
+
+    def test_no_options_key(self):
+        q = {"question": "text only"}
+        assert _MOD._is_fix_defer_question(q) is False
+
+    def test_case_insensitive(self):
+        q = {"options": [{"label": "FIX"}, {"label": "defer"}]}
+        assert _MOD._is_fix_defer_question(q) is True

--- a/dev-guard/tests/test_decision_persistence.py
+++ b/dev-guard/tests/test_decision_persistence.py
@@ -16,6 +16,7 @@ Exit semantics for this hook:
 import importlib.util
 import json
 import subprocess
+import types
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
@@ -30,7 +31,7 @@ METADATA_PREFIX = "▸dp:"
 # ── Module loader ─────────────────────────────────────────────────────────────
 
 
-def _load_module():
+def _load_module() -> types.ModuleType:
     """Import decision-persistence.py as a module for unit testing internal functions."""
     spec = importlib.util.spec_from_file_location("decision_persistence", SCRIPT)
     mod = importlib.util.module_from_spec(spec)
@@ -245,16 +246,13 @@ class TestFindMemoryDir:
 class TestSaveDecisionsOSError:
     """Unit tests for _save_decisions OSError cleanup path."""
 
-    def setup_method(self):
-        self.mod = _load_module()
-
     def test_oserror_during_write_cleans_up_tmp(self, tmp_path):
         """If write_text raises OSError, the .tmp file is removed."""
         decisions_path = tmp_path / "review-decisions.json"
         data = {"version": 1, "decisions": []}
 
         with patch.object(Path, "write_text", side_effect=OSError("disk full")):
-            self.mod._save_decisions(decisions_path, data)
+            _MOD._save_decisions(decisions_path, data)
 
         tmp_files = list(tmp_path.glob("*.tmp"))
         assert tmp_files == [], f"unexpected .tmp files left: {tmp_files}"
@@ -266,7 +264,7 @@ class TestSaveDecisionsOSError:
         data = {"version": 1, "decisions": []}
 
         with patch("os.replace", side_effect=OSError("cross-device link")):
-            self.mod._save_decisions(decisions_path, data)
+            _MOD._save_decisions(decisions_path, data)
 
         tmp_files = list(tmp_path.glob("*.tmp"))
         assert tmp_files == [], f"orphaned .tmp files: {tmp_files}"
@@ -276,7 +274,7 @@ class TestSaveDecisionsOSError:
         """Happy path: _save_decisions writes valid JSON atomically."""
         decisions_path = tmp_path / "review-decisions.json"
         data = {"version": 1, "decisions": [{"fingerprint": "abc123", "decision": "Fix"}]}
-        self.mod._save_decisions(decisions_path, data)
+        _MOD._save_decisions(decisions_path, data)
 
         assert decisions_path.exists()
         loaded = json.loads(decisions_path.read_text())
@@ -290,9 +288,6 @@ class TestSaveDecisionsOSError:
 class TestFingerprint:
     """Unit tests for _fingerprint windowing behavior."""
 
-    def setup_method(self):
-        self.mod = _load_module()
-
     @pytest.mark.parametrize(
         "line_a,line_b,same_window",
         [
@@ -305,8 +300,8 @@ class TestFingerprint:
         ],
     )
     def test_line_windowing(self, line_a, line_b, same_window):
-        fp_a = self.mod._fingerprint("src/auth.py", "Security", line_a)
-        fp_b = self.mod._fingerprint("src/auth.py", "Security", line_b)
+        fp_a = _MOD._fingerprint("src/auth.py", "Security", line_a)
+        fp_b = _MOD._fingerprint("src/auth.py", "Security", line_b)
         if same_window:
             assert fp_a == fp_b, f"lines {line_a} and {line_b} should map to the same window"
         else:
@@ -314,40 +309,40 @@ class TestFingerprint:
 
     def test_non_digit_line_uses_zero_window(self):
         """Non-digit line string falls back to window 0."""
-        fp_non_digit = self.mod._fingerprint("src/auth.py", "Security", "N/A")
-        fp_zero = self.mod._fingerprint("src/auth.py", "Security", "0")
+        fp_non_digit = _MOD._fingerprint("src/auth.py", "Security", "N/A")
+        fp_zero = _MOD._fingerprint("src/auth.py", "Security", "0")
         assert fp_non_digit == fp_zero
 
     def test_empty_string_line_uses_zero_window(self):
         """Empty string line is non-digit → window 0."""
-        fp_empty = self.mod._fingerprint("src/auth.py", "Security", "")
-        fp_zero = self.mod._fingerprint("src/auth.py", "Security", "0")
+        fp_empty = _MOD._fingerprint("src/auth.py", "Security", "")
+        fp_zero = _MOD._fingerprint("src/auth.py", "Security", "0")
         assert fp_empty == fp_zero
 
     def test_different_categories_different_fingerprints(self):
-        fp_a = self.mod._fingerprint("src/auth.py", "Security", "42")
-        fp_b = self.mod._fingerprint("src/auth.py", "Performance", "42")
+        fp_a = _MOD._fingerprint("src/auth.py", "Security", "42")
+        fp_b = _MOD._fingerprint("src/auth.py", "Performance", "42")
         assert fp_a != fp_b
 
     def test_different_files_different_fingerprints(self):
-        fp_a = self.mod._fingerprint("src/auth.py", "Security", "42")
-        fp_b = self.mod._fingerprint("src/other.py", "Security", "42")
+        fp_a = _MOD._fingerprint("src/auth.py", "Security", "42")
+        fp_b = _MOD._fingerprint("src/other.py", "Security", "42")
         assert fp_a != fp_b
 
     def test_fingerprint_length_is_16(self):
-        fp = self.mod._fingerprint("src/auth.py", "Security", "42")
+        fp = _MOD._fingerprint("src/auth.py", "Security", "42")
         assert len(fp) == 16
         assert all(c in "0123456789abcdef" for c in fp)
 
     def test_default_line_argument(self):
-        fp_default = self.mod._fingerprint("src/auth.py", "Security")
-        fp_explicit = self.mod._fingerprint("src/auth.py", "Security", "0")
+        fp_default = _MOD._fingerprint("src/auth.py", "Security")
+        fp_explicit = _MOD._fingerprint("src/auth.py", "Security", "0")
         assert fp_default == fp_explicit
 
     def test_different_skills_different_fingerprints(self):
         """Same file/cat/line but different skill → different fingerprint."""
-        fp_a = self.mod._fingerprint("src/auth.py", "Security", "42", "pr-review")
-        fp_b = self.mod._fingerprint("src/auth.py", "Security", "42", "quality-gate")
+        fp_a = _MOD._fingerprint("src/auth.py", "Security", "42", "pr-review")
+        fp_b = _MOD._fingerprint("src/auth.py", "Security", "42", "quality-gate")
         assert fp_a != fp_b
 
 
@@ -357,39 +352,36 @@ class TestFingerprint:
 class TestSanitizePathField:
     """Unit tests for _sanitize_path_field path traversal and injection rejection."""
 
-    def setup_method(self):
-        self.mod = _load_module()
-
     def test_path_traversal_rejected(self):
-        assert self.mod._sanitize_path_field("../../etc/passwd") == "<invalid>"
+        assert _MOD._sanitize_path_field("../../etc/passwd") == "<invalid>"
 
     def test_path_traversal_in_middle_rejected(self):
-        assert self.mod._sanitize_path_field("src/../../../etc/shadow") == "<invalid>"
+        assert _MOD._sanitize_path_field("src/../../../etc/shadow") == "<invalid>"
 
     def test_absolute_path_rejected(self):
-        assert self.mod._sanitize_path_field("/absolute/path") == "<invalid>"
+        assert _MOD._sanitize_path_field("/absolute/path") == "<invalid>"
 
     def test_absolute_path_root_rejected(self):
-        assert self.mod._sanitize_path_field("/") == "<invalid>"
+        assert _MOD._sanitize_path_field("/") == "<invalid>"
 
     def test_valid_relative_path_accepted(self):
-        assert self.mod._sanitize_path_field("src/auth.py") == "src/auth.py"
+        assert _MOD._sanitize_path_field("src/auth.py") == "src/auth.py"
 
     def test_valid_nested_path_accepted(self):
-        result = self.mod._sanitize_path_field("deep/nested/path/file.py")
+        result = _MOD._sanitize_path_field("deep/nested/path/file.py")
         assert result == "deep/nested/path/file.py"
 
     def test_non_path_characters_normalized(self):
-        result = self.mod._sanitize_path_field("src/file with spaces.py")
+        result = _MOD._sanitize_path_field("src/file with spaces.py")
         assert result == "src/file_with_spaces.py"
 
     def test_long_string_truncated_at_512(self):
         long_path = "a/b/" + "x" * 600
-        result = self.mod._sanitize_path_field(long_path)
+        result = _MOD._sanitize_path_field(long_path)
         assert len(result) <= 512
 
     def test_empty_string_accepted(self):
-        assert self.mod._sanitize_path_field("") == ""
+        assert _MOD._sanitize_path_field("") == ""
 
 
 # ── pr-test-4: _parse_metadata edge cases ────────────────────────────────────
@@ -398,12 +390,9 @@ class TestSanitizePathField:
 class TestParseMetadata:
     """Unit tests for _parse_metadata format edge cases."""
 
-    def setup_method(self):
-        self.mod = _load_module()
-
     def test_valid_full_metadata(self):
         text = f"Question {METADATA_PREFIX}file=src/a.py,line=42,cat=Sec,skill=pr-review"
-        result = self.mod._parse_metadata(text)
+        result = _MOD._parse_metadata(text)
         assert result is not None
         assert result["file"] == "src/a.py"
         assert result["line"] == "42"
@@ -412,40 +401,40 @@ class TestParseMetadata:
 
     def test_missing_file_returns_none(self):
         text = f"Question {METADATA_PREFIX}line=42,cat=Security,skill=pr-review"
-        assert self.mod._parse_metadata(text) is None
+        assert _MOD._parse_metadata(text) is None
 
     def test_missing_cat_returns_none(self):
         text = f"Question {METADATA_PREFIX}file=src/auth.py,line=42,skill=pr-review"
-        assert self.mod._parse_metadata(text) is None
+        assert _MOD._parse_metadata(text) is None
 
     def test_no_prefix_returns_none(self):
         text = "A normal question without any metadata suffix"
-        assert self.mod._parse_metadata(text) is None
+        assert _MOD._parse_metadata(text) is None
 
     def test_file_with_comma_causes_parse_failure(self):
         """File path with comma breaks the parser (known limitation)."""
         pfx = METADATA_PREFIX
         text = f"Q {pfx}file=src/file,name.py,line=42,cat=Sec,skill=pr-review"
-        result = self.mod._parse_metadata(text)
+        result = _MOD._parse_metadata(text)
         if result is not None:
             assert result.get("file") != "src/file,name.py"
 
     def test_file_with_path_traversal_returns_none(self):
         pfx = METADATA_PREFIX
         text = f"Question {pfx}file=../../etc/passwd,line=1,cat=Sec,skill=pr"
-        assert self.mod._parse_metadata(text) is None
+        assert _MOD._parse_metadata(text) is None
 
     def test_whitespace_around_values_stripped(self):
         pfx = METADATA_PREFIX
         text = f"Q {pfx}file= src/auth.py ,line= 42 ,cat= Security ,skill= pr "
-        result = self.mod._parse_metadata(text)
+        result = _MOD._parse_metadata(text)
         assert result is not None
         assert result["file"] == "src/auth.py"
         assert result["cat"] == "Security"
 
     def test_optional_line_field_absent(self):
         text = f"Question {METADATA_PREFIX}file=src/auth.py,cat=Security,skill=pr-review"
-        result = self.mod._parse_metadata(text)
+        result = _MOD._parse_metadata(text)
         assert result is not None
         assert result["file"] == "src/auth.py"
         assert result["cat"] == "Security"
@@ -454,7 +443,7 @@ class TestParseMetadata:
         """If ▸dp: appears in description body, rpartition finds the last (real) suffix."""
         pfx = METADATA_PREFIX
         text = f"Describes {pfx} injection {pfx}file=src/a.py,line=1,cat=Sec,skill=pr"
-        result = self.mod._parse_metadata(text)
+        result = _MOD._parse_metadata(text)
         assert result is not None
         assert result["file"] == "src/a.py"
         assert result["cat"] == "Sec"
@@ -463,14 +452,11 @@ class TestParseMetadata:
 class TestExtractDescriptionSnippet:
     """Unit tests for _extract_description_snippet."""
 
-    def setup_method(self):
-        self.mod = _load_module()
-
     def test_double_prefix_preserves_full_description(self):
         """rsplit on last ▸dp: preserves description containing the prefix."""
         pfx = METADATA_PREFIX
         text = f"Describes {pfx} injection {pfx}file=src/a.py,line=1,cat=Sec,skill=pr"
-        snippet = self.mod._extract_description_snippet(text)
+        snippet = _MOD._extract_description_snippet(text)
         assert "injection" in snippet
 
 
@@ -811,3 +797,401 @@ class TestHookPassthrough:
         result = run_hook(payload, cwd=tmp_path)
         assert result.returncode == 0
         assert result.stdout.strip() == ""
+
+
+# ── Code-hash staleness detection ─────────────────────────────────────────────
+
+
+class TestComputeCodeHash:
+    """Unit tests for _compute_code_hash."""
+
+    def test_hash_returns_16_hex_chars(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "auth.py").write_text("line0\nline1\nline2\nline3\nline4\n")
+        with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
+            h = _MOD._compute_code_hash("src/auth.py", "3")
+        assert h is not None
+        assert len(h) == 16
+        assert all(c in "0123456789abcdef" for c in h)
+
+    def test_hash_changes_when_code_changes(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        f = src / "auth.py"
+        f.write_text("line0\nline1\noriginal\nline3\nline4\n")
+        with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
+            h1 = _MOD._compute_code_hash("src/auth.py", "3")
+        f.write_text("line0\nline1\nmodified\nline3\nline4\n")
+        with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
+            h2 = _MOD._compute_code_hash("src/auth.py", "3")
+        assert h1 != h2
+
+    def test_hash_stable_when_code_unchanged(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "auth.py").write_text("line0\nline1\nstable\nline3\nline4\n")
+        with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
+            h1 = _MOD._compute_code_hash("src/auth.py", "3")
+            h2 = _MOD._compute_code_hash("src/auth.py", "3")
+        assert h1 == h2
+
+    def test_missing_file_returns_none(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
+            h = _MOD._compute_code_hash("src/nonexistent.py", "1")
+        assert h is None
+
+    def test_empty_file_returns_none(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "empty.py").write_text("")
+        with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
+            h = _MOD._compute_code_hash("src/empty.py", "1")
+        assert h is None
+
+    def test_non_digit_line_uses_zero(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "f.py").write_text("a\nb\nc\n")
+        with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
+            h1 = _MOD._compute_code_hash("src/f.py", "N/A")
+            h2 = _MOD._compute_code_hash("src/f.py", "0")
+        assert h1 == h2
+
+
+class TestCodeHashStaleness:
+    """Integration tests for code-hash staleness in PreToolUse."""
+
+    @staticmethod
+    def _make_source_file(line_42_content: str = "original_code") -> str:
+        """Generate a 50-line source file with controllable content at line 42."""
+        lines = [f"line_{i}" for i in range(50)]
+        lines[41] = line_42_content  # line 42 (0-indexed as 41)
+        return "\n".join(lines) + "\n"
+
+    def _compute_hash_for_file(self, filepath: Path, line: str) -> str:
+        """Compute the code hash the same way the hook does."""
+        import hashlib as _hl
+
+        lines = filepath.read_text().splitlines()
+        target = int(line) if line.isdigit() else 0
+        center = max(0, target - 1)
+        start = max(0, center - 5)
+        end = min(len(lines), center + 5 + 1)
+        window = "\n".join(lines[start:end])
+        return _hl.sha256(window.encode()).hexdigest()[:16]
+
+    def test_stale_decision_not_auto_applied(self, tmp_path):
+        """Code changed since decision → decision is stale → passthrough."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        src = project / "src"
+        src.mkdir()
+        f = src / "auth.py"
+        f.write_text(self._make_source_file("original_code"))
+
+        code_hash = self._compute_hash_for_file(f, "42")
+        record = make_decision_record()
+        record["code_hash"] = code_hash
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        # Now change the code at line 42
+        f.write_text(self._make_source_file("MODIFIED_code"))
+
+        q = make_dp_question("SQL injection")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "", "expected passthrough — code changed, decision is stale"
+
+    def test_fresh_decision_auto_applied(self, tmp_path):
+        """Code unchanged since decision → decision is fresh → auto-answer."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        src = project / "src"
+        src.mkdir()
+        f = src / "auth.py"
+        f.write_text(self._make_source_file("original_code"))
+
+        code_hash = self._compute_hash_for_file(f, "42")
+        record = make_decision_record()
+        record["code_hash"] = code_hash
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q = make_dp_question("SQL injection")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() != "", (
+            "expected auto-answer — code unchanged, decision is fresh"
+        )
+        output = json.loads(result.stdout)
+        assert output["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+    def test_no_code_hash_skips_staleness_check(self, tmp_path):
+        """Decision without code_hash (legacy) → staleness check skipped → auto-answer."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+
+        record = make_decision_record()
+        assert "code_hash" not in record
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q = make_dp_question("SQL injection")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() != "", (
+            "expected auto-answer — no code_hash means skip staleness check"
+        )
+
+    def test_post_tool_use_stores_code_hash(self, tmp_path):
+        """PostToolUse stores code_hash in the decision record."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+        src = project / "src"
+        src.mkdir()
+        (src / "auth.py").write_text(self._make_source_file("vulnerable_code"))
+
+        q = make_dp_question("SQL injection")
+        q_text = q["question"]
+        payload = make_post_payload([q], {q_text: "Fix"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert "code_hash" in stored["decisions"][0]
+        assert len(stored["decisions"][0]["code_hash"]) == 16
+
+    def test_post_tool_use_missing_file_omits_code_hash(self, tmp_path):
+        """PostToolUse with non-existent file → code_hash omitted from record."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q = make_dp_question("SQL injection")
+        q_text = q["question"]
+        payload = make_post_payload([q], {q_text: "Fix"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert "code_hash" not in stored["decisions"][0]
+
+
+# ── PR review coverage gaps ───────────────────────────────────────────────────
+
+
+class TestPreToolUseAnswerValues:
+    """qa-1: Verify auto-answer values are correct, not just structure."""
+
+    def test_auto_answer_returns_correct_decision_value(self, tmp_path):
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        record = make_decision_record(
+            file="src/auth.py", line="20", cat="Security", decision="Defer"
+        )
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q = make_dp_question("Unvalidated input", file="src/auth.py", line="20", cat="Security")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        q_text = q["question"]
+        assert output["hookSpecificOutput"]["updatedInput"]["answers"][q_text] == "Defer"
+
+    def test_multi_question_answer_values_correct(self, tmp_path):
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        r1 = make_decision_record(file="src/auth.py", line="42", cat="Security", decision="Fix")
+        r2 = make_decision_record(
+            file="src/templates.py", line="88", cat="Quality", decision="Defer"
+        )
+        seed_decisions_file(hack / "review-decisions.json", [r1, r2])
+
+        q1 = make_dp_question("SQL injection", file="src/auth.py", line="42", cat="Security")
+        q2 = make_dp_question("XSS in template", file="src/templates.py", line="88", cat="Quality")
+        payload = make_pre_payload([q1, q2])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        answers = output["hookSpecificOutput"]["updatedInput"]["answers"]
+        assert answers[q1["question"]] == "Fix"
+        assert answers[q2["question"]] == "Defer"
+
+
+class TestPreToolUseCorruptedRecord:
+    """qa-2: Corrupted stored record passthrough."""
+
+    def test_invalid_decision_value_passthroughs(self, tmp_path):
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        record = make_decision_record()
+        record["decision"] = "INVALID"
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q = make_dp_question("SQL injection")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "", "expected passthrough for corrupted decision value"
+
+
+class TestPostToolUseCoverageGaps:
+    """qa-3, qa-6: PostToolUse coverage gaps."""
+
+    def test_fix_defer_without_metadata_not_captured(self, tmp_path):
+        """qa-3: Fix/Defer questions without ▸dp: metadata → nothing captured."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q = make_fix_defer_question("Bare question without metadata")
+        q_text = q["question"]
+        payload = make_post_payload([q], {q_text: "Fix"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert stored["decisions"] == []
+
+    def test_no_memory_dir_passthroughs(self, tmp_path):
+        """qa-6: PostToolUse with no memory dir → passthrough."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+
+        q = make_dp_question("Missing validation")
+        q_text = q["question"]
+        payload = make_post_payload([q], {q_text: "Fix"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+
+class TestLoadDecisionsRecovery:
+    """qa-4: _load_decisions corrupted JSON recovery."""
+
+    def test_invalid_json_returns_empty_structure(self):
+        data = _MOD._load_decisions(Path("/dev/null"))
+        assert data == {"version": 1, "decisions": []}
+
+    def test_corrupted_json_returns_empty_structure(self, tmp_path):
+        f = tmp_path / "review-decisions.json"
+        f.write_text("not valid json {{{")
+        data = _MOD._load_decisions(f)
+        assert data == {"version": 1, "decisions": []}
+
+    def test_valid_json_round_trips(self, tmp_path):
+        f = tmp_path / "review-decisions.json"
+        expected = {"version": 1, "decisions": [{"fingerprint": "abc", "decision": "Fix"}]}
+        f.write_text(json.dumps(expected))
+        data = _MOD._load_decisions(f)
+        assert data == expected
+
+    def test_missing_file_returns_empty_structure(self, tmp_path):
+        f = tmp_path / "nonexistent.json"
+        data = _MOD._load_decisions(f)
+        assert data == {"version": 1, "decisions": []}
+
+
+class TestNonHackMemoryDir:
+    """qa-5: Non-hack memory directory candidates."""
+
+    def test_local_dir_found(self, tmp_path):
+        """Memory dir using .local/ instead of hack/."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".git").mkdir()
+        local = project / ".local"
+        local.mkdir()
+        (local / "PROJECT.md").write_text("# Project\n")
+        (local / "TODO.md").write_text("# TODO\n")
+
+        q = make_dp_question("Finding in .local project")
+        record = make_decision_record()
+        seed_decisions_file(local / "review-decisions.json", [record])
+
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+        assert result.stdout.strip() != "", "expected auto-answer when .local/ is the memory dir"
+
+
+class TestExtractDescriptionSnippetBrackets:
+    """qa-7: Bracket-stripping coverage."""
+
+    def test_single_bracket_prefix_stripped(self):
+        pfx = METADATA_PREFIX
+        text = f"[sec-1] SQL injection {pfx}file=a.py,line=1,cat=Sec,skill=pr"
+        snippet = _MOD._extract_description_snippet(text)
+        assert snippet == "SQL injection"
+
+    def test_double_bracket_prefix_stripped(self):
+        pfx = METADATA_PREFIX
+        text = f"[sec-1] [Security] SQL injection {pfx}file=a.py,line=1,cat=Sec,skill=pr"
+        snippet = _MOD._extract_description_snippet(text)
+        assert snippet == "SQL injection"
+
+    def test_unclosed_bracket_preserved(self):
+        pfx = METADATA_PREFIX
+        text = f"[broken description without close {pfx}file=a.py,line=1,cat=Sec,skill=pr"
+        snippet = _MOD._extract_description_snippet(text)
+        assert snippet.startswith("[broken")
+
+
+class TestLineSanitization:
+    """sec-1: Line field sanitization."""
+
+    def test_non_digit_line_sanitized(self, tmp_path):
+        """Non-digit characters stripped from line field in stored record."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q = make_dp_question("Finding", file="src/a.py", line="42abc", cat="Sec")
+        q_text = q["question"]
+        payload = make_post_payload([q], {q_text: "Fix"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert stored["decisions"][0]["line"] == "42"
+
+
+class TestDescriptionSnippetSanitization:
+    """sec-2: Control character stripping in description_snippet."""
+
+    def test_control_chars_stripped(self, tmp_path):
+        """Control characters replaced with spaces in stored snippet."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        pfx = METADATA_PREFIX
+        q_text = f"Desc with\x00null and\ttab {pfx}file=src/a.py,line=1,cat=Sec,skill=pr"
+        q = make_fix_defer_question(q_text)
+        payload = make_post_payload([q], {q_text: "Fix"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        snippet = stored["decisions"][0]["description_snippet"]
+        assert "\x00" not in snippet
+        assert "\t" not in snippet

--- a/dev-guard/tests/test_decision_persistence.py
+++ b/dev-guard/tests/test_decision_persistence.py
@@ -706,6 +706,30 @@ class TestPostToolUseAnswerSource:
         # Timestamp should NOT be refreshed — re-capture was skipped
         assert stored["decisions"][0]["decided_at"] == original_time
 
+    def test_changed_decision_via_tool_input_still_captured(self, tmp_path):
+        """Different decision from stored via tool_input fallback IS captured (not skipped).
+
+        The guard skips re-capture only when the incoming answer matches the
+        stored decision (already_stored is True). A changed answer (Fix → Defer)
+        must not be silently dropped.
+        """
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        original_time = datetime.now(UTC).isoformat()
+        record = make_decision_record(decision="Fix", decided_at=original_time)
+        seed_decisions_file(decisions_file, [record])
+
+        # Send a DIFFERENT decision via tool_input (fallback path)
+        q = make_dp_question("SQL injection")
+        q_text = q["question"]
+        payload = make_post_payload([q], {q_text: "Defer"})  # tool_input, changed decision
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["decision"] == "Defer"
+
 
 # ── pr-test-1: General hook passthrough cases ────────────────────────────────
 
@@ -806,7 +830,7 @@ class TestHookPassthrough:
 class TestComputeCodeHash:
     """Unit tests for _compute_code_hash."""
 
-    def test_hash_returns_16_hex_chars(self, tmp_path):
+    def test_hash_returns_32_hex_chars(self, tmp_path):
         (tmp_path / ".git").mkdir()
         src = tmp_path / "src"
         src.mkdir()
@@ -864,6 +888,33 @@ class TestComputeCodeHash:
             h1 = _MOD._compute_code_hash("src/f.py", "N/A")
             h2 = _MOD._compute_code_hash("src/f.py", "0")
         assert h1 == h2
+
+    def test_symlink_outside_git_root_returns_none(self, tmp_path):
+        """Symlink that resolves outside git root → boundary check returns None."""
+        (tmp_path / ".git").mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        # Target outside the git root
+        outside = tmp_path.parent / "outside_secret.py"
+        outside.write_text("secret\n")
+        link = src / "escape.py"
+        link.symlink_to(outside)
+        try:
+            with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
+                h = _MOD._compute_code_hash("src/escape.py", "1")
+            assert h is None
+        finally:
+            outside.unlink(missing_ok=True)
+
+    def test_binary_file_returns_none(self, tmp_path):
+        """File with non-UTF-8 bytes raises UnicodeDecodeError → returns None."""
+        (tmp_path / ".git").mkdir()
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "binary.bin").write_bytes(bytes([0xFF, 0xFE, 0x00, 0x01]))
+        with patch.object(_MOD, "_find_git_root", return_value=tmp_path):
+            h = _MOD._compute_code_hash("src/binary.bin", "1")
+        assert h is None
 
 
 class TestCodeHashStaleness:
@@ -1043,6 +1094,21 @@ class TestPreToolUseCorruptedRecord:
         assert result.returncode == 0
         assert result.stdout.strip() == "", "expected passthrough for corrupted decision value"
 
+    def test_missing_decision_key_passthroughs(self, tmp_path):
+        """Record with fingerprint but no 'decision' key → passthrough (not crash)."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        record = make_decision_record()
+        del record["decision"]
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q = make_dp_question("SQL injection")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0, "hook must not crash on missing decision key"
+        assert result.stdout.strip() == "", "expected passthrough for record missing decision key"
+
 
 class TestPostToolUseCoverageGaps:
     """qa-3, qa-6: PostToolUse coverage gaps."""
@@ -1074,6 +1140,30 @@ class TestPostToolUseCoverageGaps:
         result = run_hook(payload, cwd=project)
         assert result.returncode == 0
         assert result.stdout.strip() == ""
+
+    def test_invalid_answer_preserves_existing_records(self, tmp_path):
+        """'no mutations' exit path preserves pre-existing records.
+
+        Sends an invalid answer (not in VALID_DECISIONS) when the decisions file
+        already contains a valid record. The hook must exit without writing,
+        preserving the original record exactly.
+        """
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        existing_record = make_decision_record(file="src/auth.py", decision="Fix")
+        seed_decisions_file(decisions_file, [existing_record])
+
+        q = make_dp_question("Some finding", file="src/other.py", line="10", cat="Quality")
+        q_text = q["question"]
+        payload = make_post_payload([q], {q_text: "Skip"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        # File must be unchanged: still exactly one record (the original)
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["file"] == "src/auth.py"
+        assert stored["decisions"][0]["decision"] == "Fix"
 
 
 class TestLoadDecisionsRecovery:


### PR DESCRIPTION
## Summary
- Adds PreToolUse/PostToolUse hooks for AskUserQuestion that persist Fix/Defer decisions to hack/review-decisions.json across sessions
- Skills embed structured ▸dp: metadata suffix in question text for reliable finding fingerprinting
- PreToolUse auto-answers via updatedInput when matching prior decisions exist (spike for v2.1.85 updatedInput capability)