### PR TITLE
fix(jira): presents issue keys as URLs in all contexts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -110,7 +110,7 @@
     },
     {
       "name": "jira",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "source": "./jira",
       "description": "Jira integration for issue tracking, querying, and management — OSAC defaults with full redhat.atlassian.net support",
       "category": "productivity",

--- a/dev-guard/tests/test_plugin_integrity.py
+++ b/dev-guard/tests/test_plugin_integrity.py
@@ -1,0 +1,109 @@
+"""Structural tests for Jira plugin integrity.
+
+Verifies that:
+1. jira/skills/jira/SKILL.md contains the URL presentation directive.
+2. jira/agents/jira-agent.md contains the URL presentation directive.
+3. Both files stay in sync — drift is detected immediately.
+4. Version numbers in each plugin's plugin.json match the entry in marketplace.json.
+
+These are grep-based and JSON-parse lint tests — no LLM calls, no subprocess execution.
+They guard against accidental deletion of the URL rule and against
+version drift between plugin manifests.
+"""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+JIRA_SKILL = REPO_ROOT / "jira" / "skills" / "jira" / "SKILL.md"
+JIRA_AGENT = REPO_ROOT / "jira" / "agents" / "jira-agent.md"
+MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+
+URL_DIRECTIVE = "redhat.atlassian.net/browse"
+OLD_PHRASE = "After every create or update operation"
+
+
+class TestJiraPluginIntegrity:
+    """Structural tests that the Jira URL presentation directive is present and consistent."""
+
+    def test_skill_contains_url_directive(self):
+        """jira/skills/jira/SKILL.md must contain the URL presentation directive."""
+        content = JIRA_SKILL.read_text()
+        assert URL_DIRECTIVE in content, (
+            f"{JIRA_SKILL} does not contain '{URL_DIRECTIVE}'. "
+            "The URL presentation rule was deleted or altered."
+        )
+
+    def test_agent_contains_url_directive(self):
+        """jira/agents/jira-agent.md must contain the URL presentation directive."""
+        content = JIRA_AGENT.read_text()
+        assert URL_DIRECTIVE in content, (
+            f"{JIRA_AGENT} does not contain '{URL_DIRECTIVE}'. "
+            "The URL presentation rule was deleted or altered."
+        )
+
+    def test_skill_does_not_contain_old_phrase(self):
+        """jira/skills/jira/SKILL.md must not use the old pre-URL-directive phrasing."""
+        content = JIRA_SKILL.read_text()
+        assert OLD_PHRASE not in content, (
+            f"{JIRA_SKILL} still contains the old phrase '{OLD_PHRASE}'. "
+            "The URL presentation rule may have been reverted."
+        )
+
+    def test_agent_does_not_contain_old_phrase(self):
+        """jira/agents/jira-agent.md must not use the old pre-URL-directive phrasing."""
+        content = JIRA_AGENT.read_text()
+        assert OLD_PHRASE not in content, (
+            f"{JIRA_AGENT} still contains the old phrase '{OLD_PHRASE}'. "
+            "The URL presentation rule may have been reverted."
+        )
+
+
+class TestPluginVersionParity:
+    """Structural tests that plugin.json and marketplace.json versions agree for all plugins."""
+
+    def _load_marketplace_versions(self):
+        """Return a dict mapping plugin name -> version from marketplace.json."""
+        marketplace = json.loads(MARKETPLACE_JSON.read_text())
+        return {entry["name"]: entry["version"] for entry in marketplace["plugins"]}
+
+    def test_all_plugin_versions_match_marketplace(self):
+        """Every plugin's plugin.json version must match its marketplace.json entry."""
+        marketplace_versions = self._load_marketplace_versions()
+        mismatches = []
+
+        for plugin_json_path in sorted(REPO_ROOT.glob("*/.claude-plugin/plugin.json")):
+            plugin_data = json.loads(plugin_json_path.read_text())
+            plugin_name = plugin_data["name"]
+            plugin_version = plugin_data["version"]
+
+            if plugin_name not in marketplace_versions:
+                mismatches.append(f"{plugin_name}: plugin.json name not found in marketplace.json")
+                continue
+
+            marketplace_version = marketplace_versions[plugin_name]
+            if plugin_version != marketplace_version:
+                mismatches.append(
+                    f"{plugin_name}: plugin.json={plugin_version!r} "
+                    f"vs marketplace.json={marketplace_version!r}"
+                )
+
+        assert not mismatches, (
+            "Plugin version mismatch between plugin.json and marketplace.json.\n"
+            "CLAUDE.md rule: 'Always bump plugin versions in both files.'\n"
+            + "\n".join(f"  - {m}" for m in mismatches)
+        )
+
+    def test_marketplace_entries_have_plugin_on_disk(self):
+        """Every plugin in marketplace.json must have a plugin.json on disk."""
+        marketplace_versions = self._load_marketplace_versions()
+        missing = []
+
+        for name in sorted(marketplace_versions):
+            plugin_json = REPO_ROOT / name / ".claude-plugin" / "plugin.json"
+            if not plugin_json.exists():
+                missing.append(f"{name}: listed in marketplace.json but {plugin_json} not found")
+
+        assert not missing, "Phantom marketplace entries (no plugin.json on disk):\n" + "\n".join(
+            f"  - {m}" for m in missing
+        )

--- a/dev-guard/tests/test_plugin_integrity.py
+++ b/dev-guard/tests/test_plugin_integrity.py
@@ -1,10 +1,11 @@
-"""Structural tests for Jira plugin integrity.
+"""Structural tests for plugin integrity.
 
 Verifies that:
 1. jira/skills/jira/SKILL.md contains the URL presentation directive.
 2. jira/agents/jira-agent.md contains the URL presentation directive.
 3. Both files stay in sync — drift is detected immediately.
 4. Version numbers in each plugin's plugin.json match the entry in marketplace.json.
+5. Every marketplace.json entry has a corresponding plugin.json on disk.
 
 These are grep-based and JSON-parse lint tests — no LLM calls, no subprocess execution.
 They guard against accidental deletion of the URL rule and against

--- a/jira/.claude-plugin/plugin.json
+++ b/jira/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jira",
   "description": "Jira integration for issue tracking, querying, and management — OSAC defaults with full redhat.atlassian.net support",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": { "name": "wgordon17" }
 }

--- a/jira/agents/jira-agent.md
+++ b/jira/agents/jira-agent.md
@@ -120,7 +120,6 @@ create/update confirmations, and any context where an issue is referenced. URLs 
 2. Read `jira/reference/jira-formatting.md` for markdown guidance
 3. Build the fields payload (project, components, summary, issuetype, labels, epicLink if applicable)
 4. Call `createJiraIssue` with `contentFormat: "markdown"` and `responseContentFormat: "markdown"`
-5. Return the full URL: `https://redhat.atlassian.net/browse/<KEY>` (clickable for the user)
 
 ### Update Issue
 

--- a/jira/agents/jira-agent.md
+++ b/jira/agents/jira-agent.md
@@ -108,8 +108,9 @@ Before creating any OSAC issue, read:
 - `jira/reference/osac-conventions.md` — description templates, field conventions, label usage
 - `jira/reference/jira-formatting.md` — markdown style guide for descriptions/comments
 
-**After every create or update operation**, return the fully-qualified URL
-`https://redhat.atlassian.net/browse/<KEY>` — not just the bare key. URLs are clickable.
+**Always present issue keys as fully-qualified URLs:**
+`https://redhat.atlassian.net/browse/<KEY>` — never bare keys. This applies to query results,
+create/update confirmations, and any context where an issue is referenced. URLs are clickable.
 
 ## Core Operations
 

--- a/jira/skills/jira/SKILL.md
+++ b/jira/skills/jira/SKILL.md
@@ -126,11 +126,11 @@ Jira-specific pagination. Use `searchAtlassian` only when the user explicitly re
 cross-product search across Jira and Confluence simultaneously. Filter or ignore Confluence
 results if they appear unexpectedly in `searchAtlassian` output.
 
-## CRUD Operations
-
 **Always present issue keys as fully-qualified URLs:**
 `https://redhat.atlassian.net/browse/<KEY>` — never bare keys. This applies to query results,
 create/update confirmations, and any context where an issue is referenced. URLs are clickable.
+
+## CRUD Operations
 
 ### Creating Issues
 

--- a/jira/skills/jira/SKILL.md
+++ b/jira/skills/jira/SKILL.md
@@ -128,8 +128,9 @@ results if they appear unexpectedly in `searchAtlassian` output.
 
 ## CRUD Operations
 
-**After every create or update operation**, return the fully-qualified URL
-`https://redhat.atlassian.net/browse/<KEY>` — not just the bare key. URLs are clickable.
+**Always present issue keys as fully-qualified URLs:**
+`https://redhat.atlassian.net/browse/<KEY>` — never bare keys. This applies to query results,
+create/update confirmations, and any context where an issue is referenced. URLs are clickable.
 
 ### Creating Issues
 


### PR DESCRIPTION
## Summary
- Updates skill and agent to always present issue keys as fully-qualified URLs, not just after create/update
- Query results, references, and confirmations all use `https://redhat.atlassian.net/browse/<KEY>` format