### PR TITLE
fix(code-quality): uses run-ID in TeamCreate team names

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.16.0",
+      "version": "3.17.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning, roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
-  "version": "3.16.0",
+  "version": "3.17.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/references/project-memory-reference.md
+++ b/code-quality/references/project-memory-reference.md
@@ -152,10 +152,10 @@ collisions. Team files persist at `~/.claude/teams/{team-name}/` and are home-di
 
 | Skill | Team Name Pattern |
 |-------|------------------|
-| `/swarm` | `swarm-{run_id}` |
-| `/unfuck` | `cleanup-{run_id}` |
+| `/swarm` | `swarm-{run-id}` |
+| `/unfuck` | `cleanup-{run-id}` |
 
-New skills using TeamCreate must follow the same `{prefix}-{run_id}` pattern.
+New skills using TeamCreate must follow the same `{prefix}-{run-id}` pattern.
 
 ---
 

--- a/code-quality/references/project-memory-reference.md
+++ b/code-quality/references/project-memory-reference.md
@@ -100,6 +100,7 @@ RUN_ID="${BRANCH_SLUG}-${TIMESTAMP}"
 | Audit trail directories | `{memory_dir}/{skill}/{run-id}/` | `hack/swarm/feat-auth-1711388400/` |
 | Report/plan filenames | `{memory_dir}/{type}/{run-id}-<topic>.md` | `hack/plans/feat-auth-1711388400-scope.md` |
 | Git branch names | `{skill}/{run-id}-<task-slug>` or `{skill}/{run-id}` | `swarm/feat-auth-1711388400-api` |
+| TeamCreate team names | `{prefix}-{run-id}` | `swarm-feat-auth-1711388400` |
 | Test plan documents | `{memory_dir}/test-plans/{run-id}.md` | `hack/test-plans/feat-auth-1711388400.md` |
 | Staged feature files | `{memory_dir}/test-plans/{run-id}-features/` | `hack/test-plans/feat-auth-1711388400-features/` |
 
@@ -110,6 +111,51 @@ Date stamps in content (lesson dates, report headers) remain `YYYY-MM-DD`. Run I
 ### Backward Compatibility
 
 Existing directories using old naming formats are left as-is. Run IDs apply to new skill invocations only.
+
+---
+
+## Agent Orchestration Pattern Selection
+
+Skills that spawn agents must choose the right orchestration pattern. The deciding criterion is
+**inter-agent communication**: do agents need to talk to each other, or do they only report results?
+
+### Decision Tree
+
+```
+Do agents need to send structured messages to EACH OTHER (not just the lead)?
+├── YES → TeamCreate with run-ID team name
+└── NO
+    ├── Do agents edit files that would conflict in parallel?
+    │   └── YES → Agent(isolation="worktree")
+    ├── Should the lead continue working while agents run?
+    │   └── YES → Agent(run_in_background=true) with file-based output
+    ├── Are there 3+ independent agents to run in parallel?
+    │   └── YES → Multiple Agent() calls in a single message
+    └── Otherwise → Single Agent() call (foreground, blocking)
+```
+
+### Pattern Reference
+
+| Pattern | When to Use | Communication | Context Isolation |
+|---------|------------|---------------|-------------------|
+| **TeamCreate** | Persistent agents with bidirectional handoffs, rejection/retry loops | SendMessage between teammates | Yes (separate context per teammate) |
+| **Parallel foreground** | Independent workers that report findings back | Result returns inline | Yes (separate context per agent) |
+| **Background** | Fire-and-forget; lead continues other work | Agent writes to files, lead reads later | Yes |
+| **Worktree isolation** | Competing implementations that edit the same files | Result returns inline + worktree path | Yes + file isolation |
+| **Plain foreground** | Simple one-off tasks (1-2 agents) | Result returns inline | Yes |
+
+### Team Naming Convention
+
+Skills using `TeamCreate` MUST include the run ID in the team name to prevent cross-session
+collisions. Team files persist at `~/.claude/teams/{team-name}/` and are home-directory-scoped
+(not project-scoped), so hardcoded names collide across projects and sessions.
+
+| Skill | Team Name Pattern |
+|-------|------------------|
+| `/swarm` | `swarm-{run_id}` |
+| `/unfuck` | `cleanup-{run_id}` |
+
+New skills using TeamCreate must follow the same `{prefix}-{run_id}` pattern.
 
 ---
 

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -86,7 +86,7 @@ whether a feature branch is needed. If not already on a feature branch, create o
 `upstream/main` or `origin/main`. Verify that auto-compaction is enabled — the /swarm skill
 depends on it for reliable agent operation (warn the user if disabled). Generate a run ID using the convention in `code-quality/references/project-memory-reference.md`
 (Run-ID Naming Convention section) and create the audit trail directory at `{memory_dir}/swarm/{run-id}/`.
-Call `TeamCreate("swarm-impl")`, then create all tasks upfront with `addBlockedBy` dependencies
+Call `TeamCreate("swarm-{run_id}")` (using the run ID generated above), then create all tasks upfront with `addBlockedBy` dependencies
 so the full task graph is visible from the start.
 
 **Test Plan Discovery:** After branch creation and run-ID generation, discover the plan file

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -268,7 +268,7 @@ Initialize `design_escalation_count = 0` as tracked Lead state (used in Phase 4 
 ### Step 0.7: TeamCreate
 
 ```
-TeamCreate(team_name="swarm-impl", description="Full swarm: <task summary>")
+TeamCreate(team_name="swarm-{run_id}", description="Full swarm: <task summary>")
 ```
 
 Call this BEFORE creating any tasks — tasks require an active team.
@@ -430,7 +430,7 @@ Agent(
   name="architect",
   subagent_type="code-quality:architect",
   model="opus",
-  team_name="swarm-impl",
+  team_name="swarm-{run_id}",
   prompt="[context bundle from communication-schema.md]\n\n[architect prompt from agent-prompts.md]"
 )
 ```
@@ -536,7 +536,7 @@ Agent(
   name="security-design",
   subagent_type="code-quality:security",
   model="opus",
-  team_name="swarm-impl",
+  team_name="swarm-{run_id}",
   prompt="[context bundle from communication-schema.md]\n\n[security design prompt from agent-prompts.md]"
 )
 ```
@@ -703,12 +703,12 @@ For each contested component, spawn competitor agents simultaneously:
 
 ```
 Agent(name="competitor-1", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl", mode="bypassPermissions",
+     team_name="swarm-{run_id}", mode="bypassPermissions",
      isolation="worktree",
      prompt="[speculative context bundle]\n\n[competitor prompt — see below]")
 
 Agent(name="competitor-2", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl", mode="bypassPermissions",
+     team_name="swarm-{run_id}", mode="bypassPermissions",
      isolation="worktree",
      prompt="[speculative context bundle]\n\n[competitor prompt — see below]")
 ```
@@ -753,7 +753,7 @@ Spawn a single judge agent after all competitors have submitted:
 
 ```
 Agent(name="speculative-judge", subagent_type="general-purpose", model="opus",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[speculative context bundle]\n\n[judge prompt from speculative skill agent-prompts.md]")
 ```
 
@@ -913,19 +913,19 @@ components — do NOT shut them down between components. Also spawn the Architec
 
 ```
 Agent(name="implementer", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl", mode="bypassPermissions",
+     team_name="swarm-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[implementer prompt from agent-prompts.md]")
 
 Agent(name="reviewer", subagent_type="general-purpose", model="opus",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[reviewer prompt from agent-prompts.md]")
 
 Agent(name="test-writer", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl", mode="bypassPermissions",
+     team_name="swarm-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[test-writer prompt from agent-prompts.md]")
 
 Agent(name="test-runner", subagent_type="code-quality:test-runner", model="haiku",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[test-runner prompt from agent-prompts.md]")
 ```
 
@@ -1103,7 +1103,7 @@ When an agent's `turn_count` exceeds its threshold AND it is between components 
 4. **Spawn replacement** with the same name, type, model, and mode:
    ```
    Agent(name="implementer", subagent_type="general-purpose", model="sonnet",
-        team_name="swarm-impl", mode="bypassPermissions",
+        team_name="swarm-{run_id}", mode="bypassPermissions",
         prompt="[context bundle]\n\n[implementer prompt from agent-prompts.md]\n\n"
                "=== CONTINUATION FROM PREVIOUS AGENT ===\n"
                "<HandoffSummary JSON>\n"
@@ -1257,7 +1257,7 @@ Agent(
   name="bdd-step-writer",
   subagent_type="general-purpose",
   model="sonnet",
-  team_name="swarm-impl",
+  team_name="swarm-{run_id}",
   mode="bypassPermissions",
   prompt="[context bundle]\n\n"
          "TEST PLAN CONTEXT:\n{TEST_PLAN}\n\n"
@@ -1320,49 +1320,49 @@ Spawn ALL reviewers simultaneously in a SINGLE message. Do not spawn them sequen
 **Core reviewers (always spawn):**
 ```
 Agent(name="security-reviewer", subagent_type="code-quality:security", model="opus",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[security-reviewer prompt from agent-prompts.md]")
 
 Agent(name="qa-reviewer", subagent_type="code-quality:qa", model="opus",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[qa-reviewer prompt from agent-prompts.md]")
 
 Agent(name="code-reviewer", subagent_type="code-quality:code-reviewer", model="sonnet",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[code-reviewer prompt from agent-prompts.md]")
 
 Agent(name="performance-reviewer", subagent_type="code-quality:performance", model="sonnet",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[performance-reviewer prompt from agent-prompts.md]")
 ```
 
 **Optional reviewers (spawn if auto-detected or user-requested in Phase 1):**
 ```
 Agent(name="ui-reviewer", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[ui-reviewer prompt from agent-prompts.md]")
 
 Agent(name="api-reviewer", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[api-reviewer prompt from agent-prompts.md]")
 
 Agent(name="db-reviewer", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[db-reviewer prompt from agent-prompts.md]")
 
 Agent(name="plugin-validator", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[plugin-validator prompt — include plugin validation checklist]")
 
 Agent(name="skill-reviewer", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[skill-reviewer prompt — include skill validation checklist]")
 
 # Conditional: only if incremental plan file found
 # If Phase 0 Step 0.4.5 already set {plan_file_path}, reuse it — do not re-discover.
 # Otherwise discover via Branch-header matching (search {memory_dir}/plans/ for **Branch:** match).
 Agent(name="plan-adherence", subagent_type="code-quality:plan-adherence", model="opus",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[plan-adherence prompt from agent-prompts.md]")
 ```
 
@@ -1458,7 +1458,7 @@ If any finding is classified as **design-level** AND `design_escalation_count < 
 4. Respawn Architect with the findings:
    ```
    Agent(name="architect", subagent_type="code-quality:architect", model="opus",
-        team_name="swarm-impl",
+        team_name="swarm-{run_id}",
         prompt="[context bundle]\n\n[architect prompt from agent-prompts.md]\n\n"
                "=== DESIGN ESCALATION FROM PHASE 4 ===\n"
                "The following findings from Phase 4 review indicate a design-level issue "
@@ -1554,11 +1554,11 @@ Spawn both analysts simultaneously after Phase 4 escalation routing completes:
 
 ```
 Agent(name="structural-concurrency", subagent_type="general-purpose", model="opus",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[structural-concurrency analyst prompt from agent-prompts.md]")
 
 Agent(name="structural-integration", subagent_type="general-purpose", model="opus",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[structural-integration analyst prompt from agent-prompts.md]")
 ```
 
@@ -1622,7 +1622,7 @@ Proceed to Phase 6.
 
 ```
 Agent(name="fixer", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl", mode="bypassPermissions",
+     team_name="swarm-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[fixer prompt from agent-prompts.md]\n\n"
             "CONSOLIDATED FINDINGS:\n<JSON findings from synthesis>")
 ```
@@ -1664,7 +1664,7 @@ code paths, spawn the Test Coverage Agent:
 
 ```
 Agent(name="test-coverage-agent", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl", mode="bypassPermissions",
+     team_name="swarm-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[test coverage agent prompt from agent-prompts.md]\n\n"
             "TEST COVERAGE FINDINGS:\n<JSON test findings from Phase 4/4.5>\n\n"
             "PHASE 3 TEST SUMMARIES:\n<TestHandoff summaries from Phase 3 Test-Writer>")
@@ -1681,7 +1681,7 @@ After fixer and test coverage agent complete (and deferrals are handled), spawn 
 
 ```
 Agent(name="code-simplifier", subagent_type="code-quality:code-simplifier", model="sonnet",
-     team_name="swarm-impl", mode="bypassPermissions",
+     team_name="swarm-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[code-simplifier prompt from agent-prompts.md]")
 ```
 
@@ -1796,7 +1796,7 @@ the agent prompt. Then spawn the Docs agent:
 
 ```
 Agent(name="docs", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl", mode="bypassPermissions",
+     team_name="swarm-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[docs prompt from agent-prompts.md]\n\n"
             "FILES MODIFIED THIS SWARM:\n<git diff --name-only from branch start>\n\n"
             "DOCUMENTATION IMPACT (from architect):\n<documentation_impact JSON>")
@@ -1855,7 +1855,7 @@ After the Docs agent commits, spawn the Docs Reviewer to verify the work:
 
 ```
 Agent(name="docs-reviewer", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl", mode="default",
+     team_name="swarm-{run_id}", mode="default",
      prompt="[context bundle]\n\n[docs-reviewer prompt from agent-prompts.md]\n\n"
             "DOCUMENTATION IMPACT (from architect):\n<documentation_impact JSON>\n\n"
             "DOCS AGENT REPORT:\n<docs agent completion summary>")
@@ -1884,7 +1884,7 @@ After Docs agent is shut down, spawn the Lessons Extractor:
 
 ```
 Agent(name="lessons-extractor", subagent_type="general-purpose", model="sonnet",
-     team_name="swarm-impl", mode="bypassPermissions",
+     team_name="swarm-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[lessons-extractor prompt from agent-prompts.md]\n\n"
             "Run directory: {run_dir}\n"
             "Swarm date: {YYYY-MM-DD}\n"
@@ -1910,7 +1910,7 @@ SendMessage(type="shutdown_request", recipient="lessons-extractor",
 
 ```
 Agent(name="verifier", subagent_type="code-quality:test-runner", model="haiku",
-     team_name="swarm-impl",
+     team_name="swarm-{run_id}",
      prompt="[context bundle]\n\n[verifier prompt from agent-prompts.md]\n\n"
             "BASELINE: {baseline from Phase 0.1}\n\n"
             "{if bdd_framework_info is set:}"
@@ -2172,7 +2172,7 @@ If a plan file was detected in Phase 0.4, adopt its commit strategy exactly. The
 
 ```
 TeamCreate:
-  team_name: "swarm-impl"
+  team_name: "swarm-{run_id}"
   description: "Full swarm: <task summary>"
 ```
 

--- a/code-quality/skills/unfuck/SKILL.md
+++ b/code-quality/skills/unfuck/SKILL.md
@@ -39,12 +39,13 @@ Phase 4 verifies everything passes and generates a report.
 ## Workflow Phases
 
 ### Phase 0: Index & Setup
-1. Create TeamCreate swarm: `cleanup-swarm`
-2. Spawn parallel setup teammates for: repo indexing (`code-quality:index-repo`), language detection, tool detection
-3. Generate a run-ID using the convention in `code-quality/references/project-memory-reference.md`
-   (Run-ID Naming Convention section) and create feature branch: `cleanup/comprehensive-{run-id}` (from `origin/main`)
-4. Create `{memory_dir}/unfuck/{run-id}/discovery/` directory for agent output
-5. Collect setup results and build context bundle for discovery agents
+1. Generate a run-ID using the convention in `code-quality/references/project-memory-reference.md`
+   (Run-ID Naming Convention section)
+2. Create TeamCreate swarm: `cleanup-{run_id}` (using the run ID from step 1)
+3. Spawn parallel setup teammates for: repo indexing (`code-quality:index-repo`), language detection, tool detection
+4. Create feature branch: `cleanup/comprehensive-{run-id}` (from `origin/main`)
+5. Create `{memory_dir}/unfuck/{run-id}/discovery/` directory for agent output
+6. Collect setup results and build context bundle for discovery agents
 
 ### Phase 1: Discovery (7 parallel agents)
 

--- a/code-quality/skills/unfuck/SKILL.md
+++ b/code-quality/skills/unfuck/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   (file-audit, code-quality:index-repo, code-quality:code-simplifier,
   code-quality:architect, code-quality:security, code-quality:qa, code-quality:code-reviewer,
   code-quality:test-runner) into a unified cleanup workflow.
-allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, TeamCreate, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, LSP, Skill]
+allowed-tools: [Read, Write, Edit, Glob, Grep, Bash, Agent, AskUserQuestion, TeamCreate, TeamDelete, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, LSP, Skill]
 ---
 
 # /unfuck — Comprehensive Repo Cleanup

--- a/code-quality/skills/unfuck/references/orchestration-playbook.md
+++ b/code-quality/skills/unfuck/references/orchestration-playbook.md
@@ -44,7 +44,7 @@ All paths in this playbook use `{run_dir}` to refer to this directory. The orche
 
 Phase 0 has several independent tasks that SHOULD run in parallel using TeamCreate:
 
-1. **Create team immediately:** `TeamCreate(team_name="cleanup-swarm")` — needed before spawning any teammates
+1. **Create team immediately:** `TeamCreate(team_name="cleanup-{run_id}")` — needed before spawning any teammates
 2. **Launch parallel setup teammates** — spawn these as background teammates in a single message:
    - `setup-indexer`: Runs `code-quality:index-repo` to create PROJECT_INDEX.md
    - `setup-tools`: Detects available external tools (version checks)
@@ -130,7 +130,7 @@ This creates:
 ### Step 0.6: Create team
 
 ```
-TeamCreate(team_name="cleanup-swarm", description="Comprehensive repo cleanup swarm")
+TeamCreate(team_name="cleanup-{run_id}", description="Comprehensive repo cleanup swarm")
 ```
 
 ### Step 0.7: Prepare agent context bundle
@@ -192,31 +192,31 @@ In a single message, issue 7 parallel Agent calls with `team_name` to spawn as t
 
 ```
 Agent(name="dead-code-hunter", subagent_type="general-purpose", model="sonnet",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 1 prompt from discovery-agents.md]")
 
 Agent(name="duplicate-detector", subagent_type="general-purpose", model="sonnet",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 2 prompt from discovery-agents.md]")
 
 Agent(name="security-auditor", subagent_type="general-purpose", model="sonnet",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 3 prompt from discovery-agents.md]")
 
 Agent(name="architecture-reviewer", subagent_type="general-purpose", model="sonnet",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 4 prompt from discovery-agents.md]")
 
 Agent(name="ai-slop-detector", subagent_type="general-purpose", model="opus",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 5 prompt from discovery-agents.md]")
 
 Agent(name="complexity-auditor", subagent_type="general-purpose", model="sonnet",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 6 prompt from discovery-agents.md]")
 
 Agent(name="documentation-auditor", subagent_type="general-purpose", model="sonnet",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Agent 7 prompt from discovery-agents.md]")
 ```
 
@@ -272,7 +272,7 @@ Spawn a single `synthesis-planner` teammate using opus:
 
 ```
 Agent(name="synthesis-planner", subagent_type="general-purpose", model="opus",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\n[Full synthesis instructions below]\n\nRun directory: {run_dir}")
 ```
 
@@ -457,19 +457,19 @@ Spawn 4 persistent teammates in a single message. They collaborate on each categ
 
 ```
 Agent(name="impl-writer", subagent_type="general-purpose", model="sonnet",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\nYou are the WRITER on the implementation team. You implement fixes from the cleanup plan.\nYour teammates are: impl-qa (reviews your changes), impl-tester (runs tests), impl-docs (updates docs).\n\nWait for the team lead to assign you a category. For each category:\n1. Read the category's findings from {run_dir}/cleanup-plan.md\n2. Apply fixes using the strategies from references/implementation-agents.md\n3. When done with a category, message impl-qa to review your changes\n4. After QA approval and tests pass, commit the category\n5. Message the team lead that the category is complete\n\n[Full implementation agent shared rules from references/implementation-agents.md]")
 
 Agent(name="impl-qa", subagent_type="general-purpose", model="opus",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\nYou are QA on the implementation team. You review changes made by impl-writer.\n\nWhen impl-writer messages you that a category is ready for review:\n1. Read the modified files (git diff)\n2. Verify changes match the cleanup plan findings\n3. Check for regressions, broken imports, missing error handling\n4. Use LSP findReferences to verify no callers are broken\n5. If issues found, message impl-writer with specific feedback\n6. If clean, message impl-tester to run the test suite\n\nApply code-review rigor: no assumptions, verify everything.")
 
 Agent(name="impl-tester", subagent_type="general-purpose", model="sonnet",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\nYou are the TESTER on the implementation team. You run tests and formatters.\n\nWhen impl-qa messages you that changes are reviewed:\n1. Run the project's test suite (auto-detect: make test / uv run pytest / npm test / etc.)\n2. Run the formatter (make format / uvx ruff format / etc.)\n3. If tests pass: message impl-writer to commit\n4. If tests fail: message impl-writer with the failure details for rollback\n\nAuto-detect test commands from Makefile, pyproject.toml, or package.json.")
 
 Agent(name="impl-docs", subagent_type="general-purpose", model="sonnet",
-     team_name="cleanup-swarm", mode="bypassPermissions",
+     team_name="cleanup-{run_id}", mode="bypassPermissions",
      prompt="[context bundle]\n\nYou are the DOCUMENTER on the implementation team. You update docs after code changes.\n\nFor each completed category:\n1. Check if the changes affect any documentation (README, docstrings, config docs)\n2. If so, update documentation to reflect the changes\n3. Match existing documentation style, verify commands work\n4. Message impl-writer when doc updates are ready to include in the commit\n\nDo NOT create new documentation files. Only update existing ones.")
 ```
 
@@ -828,7 +828,7 @@ See `code-quality/references/finding-classification.md` for the canonical classi
 
 ```
 TeamCreate:
-  team_name: "cleanup-swarm"
+  team_name: "cleanup-{run_id}"
   description: "Comprehensive repo cleanup -- setup, discovery, synthesis, and implementation swarm"
 ```
 

--- a/code-quality/skills/unfuck/references/orchestration-playbook.md
+++ b/code-quality/skills/unfuck/references/orchestration-playbook.md
@@ -722,6 +722,18 @@ This performs a final cross-check against the original cleanup plan, verifying:
 
 If reflection identifies gaps, address them before announcing completion.
 
+### Step 4.6b: Team cleanup
+
+Shut down any remaining teammates and delete the team:
+
+```
+SendMessage(type="shutdown_request", recipient="*", content="Cleanup complete.")
+TeamDelete()
+```
+
+This removes `~/.claude/teams/cleanup-{run_id}/` and associated task files. Without this step,
+each `/unfuck` run leaves an orphaned team directory that is never cleaned up.
+
 ### Step 4.7: Announce completion
 
 Report to the user:


### PR DESCRIPTION
## Summary
- Replaces hardcoded TeamCreate team names (`swarm-impl`, `cleanup-swarm`) with run-ID-based names (`swarm-{run_id}`, `cleanup-{run_id}`) across 50 occurrences in 4 skill files to prevent cross-session crosstalk
- Adds an orchestration pattern selection guide to `project-memory-reference.md` documenting when to use TeamCreate vs Agent (foreground/background/worktree) patterns
- Bumps code-quality 3.16.0 -> 3.17.0