### PR TITLE
fix(guard-stats): isolates test DB and adds explicit PR create syntax

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -88,7 +88,7 @@
     },
     {
       "name": "git-tools",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "source": "./git-tools",
       "description": "Git workflow tools: dynamic SessionStart git instructions, history manipulation, commit review, and CONTRIBUTING.md generation",
       "category": "productivity",

--- a/dev-guard/tests/conftest.py
+++ b/dev-guard/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared test fixtures for dev-guard tests."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_guard_db(tmp_path):
+    """Redirect GUARD_DB_PATH so tests never write to the production database."""
+    db_path = str(tmp_path / "test-guard.db")
+    old = os.environ.get("GUARD_DB_PATH")
+    os.environ["GUARD_DB_PATH"] = db_path
+    yield
+    if old is None:
+        os.environ.pop("GUARD_DB_PATH", None)
+    else:
+        os.environ["GUARD_DB_PATH"] = old

--- a/dev-guard/tests/conftest.py
+++ b/dev-guard/tests/conftest.py
@@ -1,18 +1,9 @@
 """Shared test fixtures for dev-guard tests."""
 
-import os
-
 import pytest
 
 
 @pytest.fixture(autouse=True)
-def _isolate_guard_db(tmp_path):
+def _isolate_guard_db(tmp_path, monkeypatch):
     """Redirect GUARD_DB_PATH so tests never write to the production database."""
-    db_path = str(tmp_path / "test-guard.db")
-    old = os.environ.get("GUARD_DB_PATH")
-    os.environ["GUARD_DB_PATH"] = db_path
-    yield
-    if old is None:
-        os.environ.pop("GUARD_DB_PATH", None)
-    else:
-        os.environ["GUARD_DB_PATH"] = old
+    monkeypatch.setenv("GUARD_DB_PATH", str(tmp_path / "test-guard.db"))

--- a/dev-guard/tests/conftest.py
+++ b/dev-guard/tests/conftest.py
@@ -5,5 +5,5 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _isolate_guard_db(tmp_path, monkeypatch):
-    """Redirect GUARD_DB_PATH so tests never write to the production database."""
-    monkeypatch.setenv("GUARD_DB_PATH", str(tmp_path / "test-guard.db"))
+    """Redirect GUARD_DB_PATH for tests that inherit os.environ."""
+    monkeypatch.setenv("GUARD_DB_PATH", str(tmp_path / "test.db"))

--- a/dev-guard/tests/test_git_instructions_allowlist.py
+++ b/dev-guard/tests/test_git_instructions_allowlist.py
@@ -1,0 +1,193 @@
+"""Tests for git-instructions.sh allowlist validation and URL parsing.
+
+Exercises the UPSTREAM_REPO and ORIGIN_OWNER allowlist patterns, and
+the parse_url_owner / parse_url_owner_repo extraction functions.
+"""
+
+import re
+import subprocess
+from pathlib import Path
+
+UPSTREAM_REPO_PATTERN = r"^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$"
+ORIGIN_OWNER_PATTERN = r"^[a-zA-Z0-9_.-]+$"
+
+GIT_INSTRUCTIONS_SH = (
+    Path(__file__).resolve().parents[2] / "git-tools" / "scripts" / "git-instructions.sh"
+)
+
+
+def _matches(pattern: str, value: str) -> bool:
+    return bool(re.search(pattern, value))
+
+
+class TestUpstreamRepoAllowlist:
+    def test_accepts_simple_owner_repo(self):
+        assert _matches(UPSTREAM_REPO_PATTERN, "owner/repo")
+
+    def test_accepts_dotted_names(self):
+        assert _matches(UPSTREAM_REPO_PATTERN, "my.org/my.repo")
+
+    def test_accepts_hyphens_underscores(self):
+        assert _matches(UPSTREAM_REPO_PATTERN, "my-org/my_repo")
+
+    def test_rejects_empty(self):
+        assert not _matches(UPSTREAM_REPO_PATTERN, "")
+
+    def test_rejects_no_slash(self):
+        assert not _matches(UPSTREAM_REPO_PATTERN, "ownerrepo")
+
+    def test_rejects_triple_segment(self):
+        assert not _matches(UPSTREAM_REPO_PATTERN, "a/b/c")
+
+    def test_rejects_backtick(self):
+        assert not _matches(UPSTREAM_REPO_PATTERN, "owner/repo`id`")
+
+    def test_rejects_backslash(self):
+        assert not _matches(UPSTREAM_REPO_PATTERN, r"owner/repo\ninjected")
+
+    def test_rejects_semicolon(self):
+        assert not _matches(UPSTREAM_REPO_PATTERN, "owner/repo;echo pwned")
+
+    def test_rejects_space(self):
+        assert not _matches(UPSTREAM_REPO_PATTERN, "owner/ repo")
+
+    def test_rejects_hash(self):
+        assert not _matches(UPSTREAM_REPO_PATTERN, "owner/repo#comment")
+
+    def test_rejects_dollar(self):
+        assert not _matches(UPSTREAM_REPO_PATTERN, "owner$HOME/repo")
+
+
+class TestOriginOwnerAllowlist:
+    def test_accepts_simple_owner(self):
+        assert _matches(ORIGIN_OWNER_PATTERN, "myuser")
+
+    def test_accepts_dotted(self):
+        assert _matches(ORIGIN_OWNER_PATTERN, "my.user")
+
+    def test_accepts_hyphens_underscores(self):
+        assert _matches(ORIGIN_OWNER_PATTERN, "my-user_name")
+
+    def test_rejects_empty(self):
+        assert not _matches(ORIGIN_OWNER_PATTERN, "")
+
+    def test_rejects_slash(self):
+        assert not _matches(ORIGIN_OWNER_PATTERN, "owner/repo")
+
+    def test_rejects_backtick(self):
+        assert not _matches(ORIGIN_OWNER_PATTERN, "user`id`")
+
+    def test_rejects_backslash(self):
+        assert not _matches(ORIGIN_OWNER_PATTERN, r"user\ninjected")
+
+    def test_rejects_semicolon(self):
+        assert not _matches(ORIGIN_OWNER_PATTERN, "user;echo pwned")
+
+    def test_rejects_space(self):
+        assert not _matches(ORIGIN_OWNER_PATTERN, "my user")
+
+    def test_rejects_dollar(self):
+        assert not _matches(ORIGIN_OWNER_PATTERN, "user$HOME")
+
+
+class TestPatternSync:
+    """Verify test constants match the patterns in git-instructions.sh."""
+
+    def test_upstream_repo_pattern_in_script(self):
+        script = GIT_INSTRUCTIONS_SH.read_text()
+        assert f"'{UPSTREAM_REPO_PATTERN}'" in script, (
+            f"UPSTREAM_REPO_PATTERN {UPSTREAM_REPO_PATTERN!r} not found in script"
+        )
+
+    def test_origin_owner_pattern_in_script(self):
+        script = GIT_INSTRUCTIONS_SH.read_text()
+        assert f"'{ORIGIN_OWNER_PATTERN}'" in script, (
+            f"ORIGIN_OWNER_PATTERN {ORIGIN_OWNER_PATTERN!r} not found in script"
+        )
+
+
+def _extract_bash_functions() -> str:
+    """Extract parse_url_owner and parse_url_owner_repo from git-instructions.sh."""
+    lines = GIT_INSTRUCTIONS_SH.read_text().splitlines()
+    funcs: list[str] = []
+    in_func = False
+    for line in lines:
+        if line.startswith(("parse_url_owner()", "parse_url_owner_repo()")):
+            in_func = True
+        if in_func:
+            funcs.append(line)
+            if line == "}":
+                in_func = False
+    return "\n".join(funcs)
+
+
+def _call_bash_func(func_name: str, url: str) -> str:
+    """Call an extracted bash function with the given URL argument."""
+    funcs = _extract_bash_functions()
+    result = subprocess.run(
+        ["bash", "-c", f'{funcs}\n{func_name} "$1"', "_", url],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+class TestParseUrlOwner:
+    def test_scp_style_ssh(self):
+        assert _call_bash_func("parse_url_owner", "git@github.com:owner/repo.git") == "owner"
+
+    def test_scp_style_ssh_no_dotgit(self):
+        assert _call_bash_func("parse_url_owner", "git@github.com:owner/repo") == "owner"
+
+    def test_https(self):
+        assert _call_bash_func("parse_url_owner", "https://github.com/owner/repo.git") == "owner"
+
+    def test_https_no_dotgit(self):
+        assert _call_bash_func("parse_url_owner", "https://github.com/owner/repo") == "owner"
+
+    def test_ssh_protocol(self):
+        assert _call_bash_func("parse_url_owner", "ssh://git@github.com/owner/repo.git") == "owner"
+
+    def test_ssh_with_port(self):
+        assert (
+            _call_bash_func("parse_url_owner", "ssh://git@github.com:22/owner/repo.git") == "owner"
+        )
+
+    def test_empty_url(self):
+        assert _call_bash_func("parse_url_owner", "") == ""
+
+
+class TestParseUrlOwnerRepo:
+    def test_scp_style_ssh(self):
+        assert (
+            _call_bash_func("parse_url_owner_repo", "git@github.com:owner/repo.git") == "owner/repo"
+        )
+
+    def test_scp_style_ssh_no_dotgit(self):
+        assert _call_bash_func("parse_url_owner_repo", "git@github.com:owner/repo") == "owner/repo"
+
+    def test_https(self):
+        assert (
+            _call_bash_func("parse_url_owner_repo", "https://github.com/owner/repo.git")
+            == "owner/repo"
+        )
+
+    def test_https_no_dotgit(self):
+        assert (
+            _call_bash_func("parse_url_owner_repo", "https://github.com/owner/repo") == "owner/repo"
+        )
+
+    def test_ssh_protocol(self):
+        assert (
+            _call_bash_func("parse_url_owner_repo", "ssh://git@github.com/owner/repo.git")
+            == "owner/repo"
+        )
+
+    def test_ssh_with_port(self):
+        assert (
+            _call_bash_func("parse_url_owner_repo", "ssh://git@github.com:22/owner/repo.git")
+            == "owner/repo"
+        )
+
+    def test_empty_url(self):
+        assert _call_bash_func("parse_url_owner_repo", "") == ""

--- a/git-tools/.claude-plugin/plugin.json
+++ b/git-tools/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "git-tools",
   "description": "Git workflow tools: dynamic SessionStart git instructions, history manipulation, commit review, and CONTRIBUTING.md generation",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": { "name": "wgordon17" }
 }

--- a/git-tools/scripts/git-instructions.sh
+++ b/git-tools/scripts/git-instructions.sh
@@ -313,34 +313,48 @@ cat <<PR_WORKFLOW
 
 2. **Push to origin**:
    \`\`\`bash
-   git push -u origin <branch-name>
+   git push -u origin HEAD
    \`\`\`
 
-3. **Create PR** via \`gh\` CLI:
+3. **Create PR** via \`gh\` CLI — always pass \`--title\`, \`--body\`, and \`--head\` (no interactive prompts):
 
 PR_WORKFLOW
 
 if [ "$IS_FORK" -eq 1 ]; then
+    # Resolve OWNER/REPO from upstream, and fork owner from origin
+    UPSTREAM_REPO=$(git remote get-url upstream 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
+    ORIGIN_OWNER=$(git remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+)/[^/]+?$|\1|')
     cat <<FORK_PR
-   **Fork repo — PR targets upstream:**
-   \`gh pr create --repo ${UPSTREAM_OWNER}/<repo-name>\`
+   **Fork repo — \`upstream\` = PR target, \`origin\` = PR head (your fork).**
+   Use a multiline double-quoted string for \`--body\`. Never use HEREDOC, \`--body-file\`, or pipes.
+   \`\`\`bash
+   BRANCH=\$(git branch --show-current)
+   git push -u origin HEAD
+   gh pr create --repo ${UPSTREAM_REPO} --head "${ORIGIN_OWNER}:\$BRANCH" \\
+     --title "type(scope): description" \\
+     --body "## Summary
+   - What changed and why"
+   \`\`\`
 
 FORK_PR
 else
     cat <<'NONFORK_PR'
-   `gh pr create`
+   **Push first, then create with explicit `--head`.**
+   Use a multiline double-quoted string for `--body`. Never use HEREDOC, `--body-file`, or pipes.
+   ```bash
+   BRANCH=$(git branch --show-current)
+   git push -u origin HEAD
+   gh pr create --head "$BRANCH" \
+     --title "type(scope): description" \
+     --body "## Summary
+   - What changed and why"
+   ```
 
 NONFORK_PR
 fi
 
 cat <<'PR_FORMAT'
-**PR body format — strictly follow this structure:**
-```
-## Summary
-- What changed and why (1-3 bullets)
-- Second bullet if needed
-- Third bullet if needed
-```
+**PR body rules:** Max 3 bullets under `## Summary`.
 
 **NEVER include in PR descriptions:**
 - "Test plan" sections

--- a/git-tools/scripts/git-instructions.sh
+++ b/git-tools/scripts/git-instructions.sh
@@ -324,12 +324,19 @@ if [ "$IS_FORK" -eq 1 ]; then
     # Resolve OWNER/REPO from upstream, and fork owner from origin
     UPSTREAM_REPO=$(git remote get-url upstream 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
     ORIGIN_OWNER=$(git remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+)/[^/]+?$|\1|')
+    # Validate before interpolation into session instructions (same allowlist as detect_fork)
+    if ! echo "$UPSTREAM_REPO" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$'; then
+        UPSTREAM_REPO="<upstream-owner>/<upstream-repo>"
+    fi
+    if ! echo "$ORIGIN_OWNER" | grep -qE '^[a-zA-Z0-9_.-]+$'; then
+        ORIGIN_OWNER="<fork-owner>"
+    fi
+    # Unquoted heredoc: UPSTREAM_REPO and ORIGIN_OWNER expand at script runtime
     cat <<FORK_PR
    **Fork repo — \`upstream\` = PR target, \`origin\` = PR head (your fork).**
    Use a multiline double-quoted string for \`--body\`. Never use HEREDOC, \`--body-file\`, or pipes.
    \`\`\`bash
    BRANCH=\$(git branch --show-current)
-   git push -u origin HEAD
    gh pr create --repo ${UPSTREAM_REPO} --head "${ORIGIN_OWNER}:\$BRANCH" \\
      --title "type(scope): description" \\
      --body "## Summary
@@ -338,12 +345,11 @@ if [ "$IS_FORK" -eq 1 ]; then
 
 FORK_PR
 else
+    # Quoted heredoc: no expansion — literal shell code for the reader
     cat <<'NONFORK_PR'
-   **Push first, then create with explicit `--head`.**
    Use a multiline double-quoted string for `--body`. Never use HEREDOC, `--body-file`, or pipes.
    ```bash
    BRANCH=$(git branch --show-current)
-   git push -u origin HEAD
    gh pr create --head "$BRANCH" \
      --title "type(scope): description" \
      --body "## Summary

--- a/git-tools/scripts/git-instructions.sh
+++ b/git-tools/scripts/git-instructions.sh
@@ -62,6 +62,16 @@ detect_mainline() {
     echo "$mainline"
 }
 
+parse_url_owner() {
+    # Extract owner from a git remote URL (SSH SCP-style, ssh://, or HTTPS)
+    echo "$1" | sed -E 's|\.git$||; s|.*[:/]([^/]+)/[^/]+$|\1|'
+}
+
+parse_url_owner_repo() {
+    # Extract owner/repo from a git remote URL (SSH SCP-style, ssh://, or HTTPS)
+    echo "$1" | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|'
+}
+
 detect_fork() {
     # Returns owner of upstream remote if fork, empty string otherwise
     local upstream_url
@@ -71,16 +81,8 @@ detect_fork() {
         return
     fi
 
-    # Extract owner from SSH (SCP-style or ssh://), HTTPS URL
-    local owner=""
-    if echo "$upstream_url" | grep -q "git@.*:"; then
-        # SCP-style SSH: git@github.com:owner/repo.git
-        owner=$(echo "$upstream_url" | sed 's|.*:\([^/]*\)/.*|\1|')
-    else
-        # HTTPS or ssh:// style: https://github.com/owner/repo.git
-        # Also handles ssh://git@github.com/owner/repo.git
-        owner=$(echo "$upstream_url" | sed 's|.*/\([^/]*\)/[^/]*$|\1|')
-    fi
+    local owner
+    owner=$(parse_url_owner "$upstream_url")
     # Validate owner contains only safe characters
     if echo "$owner" | grep -qE '^[a-zA-Z0-9_.-]+$'; then
         echo "$owner"
@@ -321,17 +323,15 @@ cat <<PR_WORKFLOW
 PR_WORKFLOW
 
 if [ "$IS_FORK" -eq 1 ]; then
-    # Resolve OWNER/REPO from upstream, and fork owner from origin
-    UPSTREAM_REPO=$(git remote get-url upstream 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|')
-    ORIGIN_OWNER=$(git remote get-url origin 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+)/[^/]+$|\1|')
-    # Validate before interpolation into session instructions (same allowlist as detect_fork)
+    UPSTREAM_REPO=$(parse_url_owner_repo "$(git remote get-url upstream 2>/dev/null)")
+    ORIGIN_OWNER=$(parse_url_owner "$(git remote get-url origin 2>/dev/null)")
+    # Validate before interpolation into session instructions
     if ! echo "$UPSTREAM_REPO" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$'; then
         UPSTREAM_REPO="<upstream-owner>/<upstream-repo>"
     fi
     if ! echo "$ORIGIN_OWNER" | grep -qE '^[a-zA-Z0-9_.-]+$'; then
         ORIGIN_OWNER="<fork-owner>"
     fi
-    # Unquoted heredoc: UPSTREAM_REPO and ORIGIN_OWNER expand at script runtime
     cat <<FORK_PR
    **Fork repo — \`upstream\` = PR target, \`origin\` = PR head (your fork).**
    Use a multiline double-quoted string for \`--body\`. Never use HEREDOC, \`--body-file\`, or pipes.
@@ -340,12 +340,11 @@ if [ "$IS_FORK" -eq 1 ]; then
    gh pr create --repo ${UPSTREAM_REPO} --head "${ORIGIN_OWNER}:\$BRANCH" \\
      --title "type(scope): description" \\
      --body "## Summary
-   - What changed and why"
+- What changed and why"
    \`\`\`
 
 FORK_PR
 else
-    # Quoted heredoc: no expansion — literal shell code for the reader
     cat <<'NONFORK_PR'
    Use a multiline double-quoted string for `--body`. Never use HEREDOC, `--body-file`, or pipes.
    ```bash
@@ -353,7 +352,7 @@ else
    gh pr create --head "$BRANCH" \
      --title "type(scope): description" \
      --body "## Summary
-   - What changed and why"
+- What changed and why"
    ```
 
 NONFORK_PR

--- a/git-tools/scripts/git-instructions.sh
+++ b/git-tools/scripts/git-instructions.sh
@@ -322,8 +322,8 @@ PR_WORKFLOW
 
 if [ "$IS_FORK" -eq 1 ]; then
     # Resolve OWNER/REPO from upstream, and fork owner from origin
-    UPSTREAM_REPO=$(git remote get-url upstream 2>/dev/null | sed -E 's|.*[:/]([^/]+/[^/]+?)(\.git)?$|\1|')
-    ORIGIN_OWNER=$(git remote get-url origin 2>/dev/null | sed -E 's|.*[:/]([^/]+)/[^/]+?$|\1|')
+    UPSTREAM_REPO=$(git remote get-url upstream 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+/[^/]+)$|\1|')
+    ORIGIN_OWNER=$(git remote get-url origin 2>/dev/null | sed -E 's|\.git$||; s|.*[:/]([^/]+)/[^/]+$|\1|')
     # Validate before interpolation into session instructions (same allowlist as detect_fork)
     if ! echo "$UPSTREAM_REPO" | grep -qE '^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$'; then
         UPSTREAM_REPO="<upstream-owner>/<upstream-repo>"


### PR DESCRIPTION
## Summary
- Adds conftest.py autouse fixture (monkeypatch) to isolate GUARD_DB_PATH in tool-selection-guard tests, preventing test runs from polluting production guard stats
- Rewrites git-instructions.sh PR workflow with exact gh pr create syntax: mandatory --head, --title, multiline --body, push-before-create, fork detection via origin/upstream remotes with allowlist validation and .git suffix stripping
- Bumps git-tools 2.1.0 to 2.2.0