### PR TITLE
fix(code-quality): corrects SendMessage parameter guidance across skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning (with issue tracking), roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
       "category": "quality",

--- a/.github/workflows/plugin-lint.yml
+++ b/.github/workflows/plugin-lint.yml
@@ -30,3 +30,12 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
       - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41  # v7
       - run: uvx claudelint --strict
+
+      - name: No README in skill directories
+        run: |
+          files=$(find . -path '*/skills/*/README.md' -not -path './.claude/*')
+          if [ -n "$files" ]; then
+            echo "::error::README.md found in skill directories (use SKILL.md instead):"
+            echo "$files"
+            exit 1
+          fi

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning (with issue tracking), roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/skills/map-reduce/references/agent-prompts.md
+++ b/code-quality/skills/map-reduce/references/agent-prompts.md
@@ -146,10 +146,11 @@ Format:
 
 ### Step 6: Notify the Lead
 
-After writing your ChunkResult, send a brief summary to the lead via SendMessage:
+After writing your ChunkResult, send a brief summary to the lead:
 ```
-Chunk {chunk_id} complete. Status: complete. Found {N} findings ({X} needs-fix, {Y} needs-input; {Z} verified, {W} chunk-local).
-Output written to {output_path}. turn_count: {N}
+SendMessage(to="team-lead",
+  message="Chunk {chunk_id} complete. Status: complete. Found {N} findings ({X} needs-fix, {Y} needs-input; {Z} verified, {W} chunk-local). Output written to {output_path}. turn_count: {N}",
+  summary="Mapper {chunk_id}: {N} findings")
 ```
 
 ## Key Rules
@@ -290,13 +291,11 @@ cross-chunk validation — there are no more `chunk-local` findings.
 
 ### Step 6: Notify the Lead
 
-After writing your ReductionResult, send a summary to the lead via SendMessage:
+After writing your ReductionResult, send a summary to the lead:
 ```
-Reduction complete. Status: complete.
-Raw findings: {total}, After dedup: {deduplicated}, Invalidated: {invalidated}.
-By classification: needs-fix={N}, needs-input={N}.
-Fidelity warnings: {count}. Cross-chunk issues: {count}.
-Output written to {output_path}.
+SendMessage(to="team-lead",
+  message="Reduction complete. Status: complete. Raw findings: {total}, After dedup: {deduplicated}, Invalidated: {invalidated}. By classification: needs-fix={N}, needs-input={N}. Fidelity warnings: {count}. Cross-chunk issues: {count}. Output written to {output_path}.",
+  summary="Reducer: {deduplicated} findings after dedup")
 ```
 
 ## Key Rules

--- a/code-quality/skills/speculative/references/agent-prompts.md
+++ b/code-quality/skills/speculative/references/agent-prompts.md
@@ -116,13 +116,13 @@ from the schema (see `references/communication-schema.md`).
 Then send a message to the lead:
 
 ```
-SendMessage(to="team-lead", content=JSON.stringify({
+SendMessage(to="team-lead", message=JSON.stringify({
   "schema": "ImplementationResult",
   "competitor_id": "{competitor_id}",
   "status": "complete",
   "approach": "...",
   ... (all fields)
-}))
+}), summary="Competitor {competitor_id}: implementation complete")
 ```
 
 Do NOT send a plain text message — the lead expects structured JSON.
@@ -237,7 +237,7 @@ fields (see `references/communication-schema.md`).
 Then send a message to the lead:
 
 ```
-SendMessage(to="team-lead", content=JSON.stringify({
+SendMessage(to="team-lead", message=JSON.stringify({
   "schema": "JudgmentResult",
   "winner": "competitor-N",
   "scoring_matrix": [...],
@@ -245,7 +245,7 @@ SendMessage(to="team-lead", content=JSON.stringify({
   "code_inspected": [...],
   "hybrid_recommended": false,
   "hybrid_elements": []
-}))
+}), summary="Judge: winner is competitor-N")
 ```
 
 ## Important Rules

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -644,7 +644,7 @@ If `{tracker}` matches `jira:PROJ-N`:
 
 Generate the final audit report at
 `{run_dir}/swarm-report.md`. Announce completion with a summary and report path.
-Shut down all teammates via `SendMessage(type="shutdown_request")` and call `TeamDelete`.
+Shut down all teammates via `SendMessage(to="*", message={"type": "shutdown_request", "reason": "Swarm complete"})` and call `TeamDelete`.
 
 ---
 

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -1758,7 +1758,7 @@ SendMessage(to="team-lead",
     "total_new_tests": 5,
     "turn_count": 12
   }',
-  summary="Test Coverage Agent: 5 new tests across 2 files, 1 finding already covered")
+  summary="Test Coverage: 5 new tests, 1 already covered")
 ```
 ```
 

--- a/code-quality/skills/swarm/references/agent-prompts.md
+++ b/code-quality/skills/swarm/references/agent-prompts.md
@@ -218,8 +218,8 @@ the specified components before proceeding to Phase 3.
 When your plan is written, send a summary to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content="Architect complete.\n\nPlan: {run_dir}/architect-plan.json\n\n"
+SendMessage(to="team-lead",
+  message="Architect complete.\n\nPlan: {run_dir}/architect-plan.json\n\n"
           "Cynefin domain: {domain} — {one-sentence justification}\n"
           "Components: N\n"
           "Pipeline feasible: yes/no\n\n"
@@ -240,7 +240,7 @@ You can message these teammates directly during Phase 3:
 - Implementer (clarification on component specs or design intent)
 - Reviewer (clarification on design decisions during review)
 
-Use `SendMessage(type='message', recipient='implementer', ...)` or `recipient='reviewer'` for quick
+Use `SendMessage(to="implementer", message="<question>", summary="Architect: clarification")` for quick
 clarifications. Route everything else through the team lead.
 
 Do NOT begin implementing. Your job is to plan and clarify. The pipeline team implements.
@@ -294,8 +294,8 @@ You do NOT review implementation code (none exists yet at this phase).
 to the lead confirming you have received your assignment:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "schema": "ContextAcknowledgment",
     "component_id": "security-design-review",
     "agent_role": "security-design-reviewer",
@@ -380,8 +380,8 @@ Use the classification taxonomy and LoE scale from `code-quality/references/find
 When your review is written, send a summary to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content="Security design review complete (iteration {N}).\n\n"
+SendMessage(to="team-lead",
+  message="Security design review complete (iteration {N}).\n\n"
           "Results: {run_dir}/security-design-review.json\n\n"
           "Verdict: {proceed | revise | escalate}\n\n"
           "STRIDE findings: {N total — N needs-fix, N needs-input}\n"
@@ -434,8 +434,8 @@ outcomes. Do not implement features that technically work but would fail the use
 `ContextAcknowledgment` to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "schema": "ContextAcknowledgment",
     "component_id": "<component_id from assignment>",
     "agent_role": "implementer",
@@ -523,8 +523,8 @@ a `rationale` and `applies_to` component list — check whether your assigned co
 Send a ComponentHandoff to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "ComponentHandoff",
     "component_id": "component-1",
     "name": "OAuth service",
@@ -548,7 +548,7 @@ You can message these teammates directly:
 - Architect (clarification questions about component specs or design intent)
 - Reviewer (quick follow-ups on rejection feedback, if the feedback is unclear)
 
-Use `SendMessage(type='message', recipient='architect', ...)` or `recipient='reviewer'` for quick
+Use `SendMessage(to="architect", message="<question>", summary="Implementer: clarification")` for quick
 clarifications. Route all handoffs and assignments through the team lead.
 
 ## Boundaries
@@ -614,8 +614,8 @@ For each component, check:
 `ContextAcknowledgment` to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "schema": "ContextAcknowledgment",
     "component_id": "<component_id from handoff>",
     "agent_role": "reviewer",
@@ -636,8 +636,8 @@ You receive a ComponentHandoff from the lead. Review the implementation, then se
 ### Approve
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "ReviewResult",
     "component_id": "component-1",
     "verdict": "approved",
@@ -651,8 +651,8 @@ SendMessage(type="message", recipient="team-lead",
 ### Reject
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "ReviewResult",
     "component_id": "component-1",
     "verdict": "rejected",
@@ -688,7 +688,7 @@ You can message these teammates directly:
 - Architect (clarify design intent when evaluating a component)
 - Test-Writer (clarify what needs testing after approval)
 
-Use `SendMessage(type='message', recipient='<name>', ...)` for quick clarifications.
+Use `SendMessage(to="<name>", message="<question>", summary="Reviewer: clarification")` for quick clarifications.
 Route all ReviewResult handoffs through the team lead.
 ```
 
@@ -718,8 +718,8 @@ You do NOT run the test suite — test-runner handles that.
 `ContextAcknowledgment` to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "schema": "ContextAcknowledgment",
     "component_id": "<component_id from TestRequest>",
     "agent_role": "test-writer",
@@ -782,8 +782,8 @@ Match the project's test file naming pattern:
 ## When Done
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "TestHandoff",
     "component_id": "component-1",
     "test_files": ["tests/unit/test_oauth.py"],
@@ -802,7 +802,7 @@ Do NOT run the tests. Do NOT modify implementation files.
 You can message these teammates directly:
 - Reviewer (clarify what needs testing based on review notes)
 
-Use `SendMessage(type='message', recipient='reviewer', ...)` for quick clarifications.
+Use `SendMessage(to="reviewer", message="<question>", summary="Test-Writer: clarification")` for quick clarifications.
 Route all TestHandoff messages through the team lead.
 ```
 
@@ -851,8 +851,8 @@ Run the specified command. Parse the output. Report results.
 ## When Done
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "TestResult",
     "component_id": "component-1",
     "status": "passed",
@@ -868,8 +868,8 @@ SendMessage(type="message", recipient="team-lead",
 On failure:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "TestResult",
     "component_id": "component-1",
     "status": "failed",
@@ -1018,8 +1018,8 @@ Write to `{run_dir}/reviews/security.json`:
 Then send a summary:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content="Security review complete. Results: {run_dir}/reviews/security.json\n\n"
+SendMessage(to="team-lead",
+  message="Security review complete. Results: {run_dir}/reviews/security.json\n\n"
           "Findings: 3 (2 needs-fix, 1 needs-input)\n"
           "needs-fix: SQL injection in src/auth/oauth.py:43\n"
           "No hardcoded secrets. Auth flow looks correct.",
@@ -1316,8 +1316,8 @@ outcomes. Flag scenarios not addressed as `needs-fix` findings with category `mi
 **IMMEDIATELY upon being spawned**, send a ContextAcknowledgment to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "schema": "ContextAcknowledgment",
     "component_id": "plan-adherence-review",
     "agent_role": "plan-adherence-reviewer",
@@ -1385,8 +1385,8 @@ Use the classification taxonomy and LoE scale from `code-quality/references/find
 When your review is complete, send a summary to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content="Plan adherence review complete.\n\n"
+SendMessage(to="team-lead",
+  message="Plan adherence review complete.\n\n"
           "Results: {run_dir}/reviews/plan-adherence.json\n\n"
           "Plan tasks reviewed: N unchecked\n"
           "Fully addressed: N\n"
@@ -1481,8 +1481,8 @@ Category values: `race-condition`, `state-gap`, `error-propagation`, `dependency
 Then send a summary to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content="Structural review (Concurrency & State) complete. "
+SendMessage(to="team-lead",
+  message="Structural review (Concurrency & State) complete. "
           "Results: {run_dir}/reviews/structural-concurrency.json\n\n"
           "Findings: N (N needs-fix, N needs-input)\n"
           "[Brief summary of most significant structural issue found, if any]",
@@ -1573,8 +1573,8 @@ Category values: `contract-violation`, `cross-component-assumption`, `data-flow`
 Then send a summary to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content="Structural review (Integration & Contract) complete. "
+SendMessage(to="team-lead",
+  message="Structural review (Integration & Contract) complete. "
           "Results: {run_dir}/reviews/structural-integration.json\n\n"
           "Findings: N (N needs-fix, N needs-input)\n"
           "[Brief summary of most significant structural issue found, if any]",
@@ -1655,8 +1655,8 @@ Send a FixSummary to the lead when done (use the FixSummary schema from
 `references/communication-schema.md`):
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "schema": "FixSummary",
     "findings_fixed": ["SEC-001", "QA-001"],
     "needs_input_items": [
@@ -1743,8 +1743,8 @@ when no appropriate existing file exists. Match the project's naming conventions
 Send a TestCoverageResult to the lead when done:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "TestCoverageResult",
     "tests_written": [
       {"finding_id": "QA-003", "test_file": "tests/unit/test_oauth.py", "test_count": 3,
@@ -2232,8 +2232,8 @@ If a new lesson contradicts an existing one, mark the old lesson:
 Send summary to lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content="Lessons extraction complete.\n\n"
+SendMessage(to="team-lead",
+  message="Lessons extraction complete.\n\n"
           "Lessons written: N\n"
           "File: {lessons_file}\n\n"
           "[One-sentence summary of each lesson written, or 'No lessons — routine run']",
@@ -2318,8 +2318,8 @@ If no BDD files were promoted, skip this step.
 Send a VerificationResult to the lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "VerificationResult",
     "status": "passed",
     "test_results": {
@@ -2338,8 +2338,8 @@ SendMessage(type="message", recipient="team-lead",
 On failure:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "VerificationResult",
     "status": "failed",
     "test_results": {
@@ -2720,8 +2720,8 @@ The lead populates `{bdd_framework_info}` with the following structure:
 Send a BDDStepHandoff to the lead when done:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content='{
+SendMessage(to="team-lead",
+  message='{
     "type": "BDDStepHandoff",
     "feature_files": ["features/login_flow.feature"],
     "step_files": ["tests/acceptance/steps/test_login_steps.py"],

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1899,8 +1899,7 @@ or TODO.md — those are the Docs agent's responsibility.
 ### Step 6.8: Shutdown Lessons Extractor
 
 ```
-SendMessage(to="lessons-extractor",
-  message={"type": "shutdown_request", "reason": "Lessons extraction complete"})
+SendMessage(to="lessons-extractor", message={"type": "shutdown_request", "reason": "Lessons extraction complete"})
 ```
 
 ---

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -463,8 +463,8 @@ No user interruption needed — proceed autonomously.
 Send feedback to architect and request one revision:
 
 ```
-SendMessage(type="message", recipient="architect",
-  content="Plan needs revision. Issues:\n1. <specific issue>\n2. <specific issue>\n"
+SendMessage(to="architect",
+  message="Plan needs revision. Issues:\n1. <specific issue>\n2. <specific issue>\n"
           "Please revise {run_dir}/architect-plan.json and send updated summary.",
   summary="Plan revision requested")
 ```
@@ -502,8 +502,8 @@ for clarification questions from the Implementer and Reviewer.
 Notify the Architect that implementation is starting:
 
 ```
-SendMessage(type="message", recipient="architect",
-  content="Architecture review complete. Proceeding to Phase 3 implementation. "
+SendMessage(to="architect",
+  message="Architecture review complete. Proceeding to Phase 3 implementation. "
           "Please remain available — the Implementer and Reviewer may contact you "
           "directly with clarification questions.",
   summary="Phase 3 starting, architect on standby")
@@ -558,8 +558,8 @@ Check the `verdict` field:
 **`revise`** (`needs-fix` findings require architect plan revision):
 - Send findings to the Architect:
   ```
-  SendMessage(type="message", recipient="architect",
-    content="Security design review found findings requiring plan revision.\n\n"
+  SendMessage(to="architect",
+    message="Security design review found findings requiring plan revision.\n\n"
             "Findings: {run_dir}/security-design-review.json\n\n"
             "Please revise {run_dir}/architect-plan.json to address these findings and "
             "send an updated summary when done.",
@@ -791,9 +791,9 @@ After receiving the judge's result, read `{speculative_run_dir}/judgment.json`.
 
 **Shutdown judge and all competitor agents:**
 ```
-SendMessage(type="shutdown_request", recipient="speculative-judge", content="Judgment complete.")
-SendMessage(type="shutdown_request", recipient="competitor-1", content="Phase 2.7 complete.")
-SendMessage(type="shutdown_request", recipient="competitor-2", content="Phase 2.7 complete.")
+SendMessage(to="speculative-judge", message={"type": "shutdown_request", "reason": "Judgment complete"})
+SendMessage(to="competitor-1", message={"type": "shutdown_request", "reason": "Phase 2.7 complete"})
+SendMessage(to="competitor-2", message={"type": "shutdown_request", "reason": "Phase 2.7 complete"})
 ```
 
 ### Step 2.7.8: Audit Trail
@@ -1086,8 +1086,8 @@ When an agent's `turn_count` exceeds its threshold AND it is between components 
 
 1. **Send HandoffRequest:**
    ```
-   SendMessage(type="message", recipient="implementer",
-     content='{"schema": "HandoffRequest", "reason": "context_rotation",
+   SendMessage(to="implementer",
+     message='{"schema": "HandoffRequest", "reason": "context_rotation",
        "message": "You are approaching context limits. Please send a HandoffSummary with your current state so a replacement agent can continue your work."}',
      summary="Requesting handoff for context rotation")
    ```
@@ -1096,8 +1096,8 @@ When an agent's `turn_count` exceeds its threshold AND it is between components 
 
 3. **Shutdown the agent:**
    ```
-   SendMessage(type="shutdown_request", recipient="implementer",
-     content="Context rotation complete. Thank you.")
+   SendMessage(to="implementer",
+     message={"type": "shutdown_request", "reason": "Context rotation complete"})
    ```
 
 4. **Spawn replacement** with the same name, type, model, and mode:
@@ -1123,8 +1123,8 @@ TestHandoff, or TestResult) AND their task is not marked complete:
 
 1. **Send a status check** (the agent may just be processing a large file read):
    ```
-   SendMessage(type="message", recipient="implementer",
-     content="Status check — are you still working? If blocked, send current state.",
+   SendMessage(to="implementer",
+     message="Status check — are you still working? If blocked, send current state.",
      summary="Status check for silent agent")
    ```
 2. **If no response after the status check (agent remains idle):**
@@ -1282,7 +1282,7 @@ Wait for the `BDDStepHandoff` message from bdd-step-writer. Record:
 Store `{bdd_framework_info}` in Lead state — it is passed to the Verifier in Phase 7.
 
 ```
-SendMessage(type="shutdown_request", recipient="bdd-step-writer", content="Phase 3.5 complete.")
+SendMessage(to="bdd-step-writer", message={"type": "shutdown_request", "reason": "Phase 3.5 complete"})
 ```
 
 Log Phase 3.5 completion to `{run_dir}/.swarm-run` (append):
@@ -1306,11 +1306,11 @@ Send shutdown requests to all 4 pipeline agents AND the Architect before spawnin
 The Architect's clarification role ends when Phase 3 is complete. Wait for confirmations.
 
 ```
-SendMessage(type="shutdown_request", recipient="implementer", content="Pipeline complete.")
-SendMessage(type="shutdown_request", recipient="reviewer", content="Pipeline complete.")
-SendMessage(type="shutdown_request", recipient="test-writer", content="Pipeline complete.")
-SendMessage(type="shutdown_request", recipient="test-runner", content="Pipeline complete.")
-SendMessage(type="shutdown_request", recipient="architect", content="Implementation complete. Thank you.")
+SendMessage(to="implementer", message={"type": "shutdown_request", "reason": "Pipeline complete"})
+SendMessage(to="reviewer", message={"type": "shutdown_request", "reason": "Pipeline complete"})
+SendMessage(to="test-writer", message={"type": "shutdown_request", "reason": "Pipeline complete"})
+SendMessage(to="test-runner", message={"type": "shutdown_request", "reason": "Pipeline complete"})
+SendMessage(to="architect", message={"type": "shutdown_request", "reason": "Implementation complete"})
 ```
 
 ### Step 4.2: Spawn All Reviewers
@@ -1536,7 +1536,7 @@ Append entries rather than overwriting — multiple escalation events accumulate
 ### Step 4.6: Shutdown Reviewers
 
 ```
-SendMessage(type="shutdown_request", recipient="security-reviewer", content="Review synthesis complete.")
+SendMessage(to="security-reviewer", message={"type": "shutdown_request", "reason": "Review synthesis complete"})
 # ... repeat for each spawned reviewer ...
 ```
 
@@ -1604,8 +1604,8 @@ trail and skip_phase5 remains unchanged from Phase 4's determination.
 ### Step 4.5.5: Shutdown Structural Analysts
 
 ```
-SendMessage(type="shutdown_request", recipient="structural-concurrency", content="Structural review complete.")
-SendMessage(type="shutdown_request", recipient="structural-integration", content="Structural review complete.")
+SendMessage(to="structural-concurrency", message={"type": "shutdown_request", "reason": "Structural review complete"})
+SendMessage(to="structural-integration", message={"type": "shutdown_request", "reason": "Structural review complete"})
 ```
 
 ---
@@ -1721,9 +1721,9 @@ git commit -m "refactor: simplify implementation after review"
 ### Step 5.6: Shutdown
 
 ```
-SendMessage(type="shutdown_request", recipient="fixer", content="Fix phase complete.")
-SendMessage(type="shutdown_request", recipient="test-coverage-agent", content="Test coverage phase complete.")
-SendMessage(type="shutdown_request", recipient="code-simplifier", content="Simplify phase complete.")
+SendMessage(to="fixer", message={"type": "shutdown_request", "reason": "Fix phase complete"})
+SendMessage(to="test-coverage-agent", message={"type": "shutdown_request", "reason": "Test coverage phase complete"})
+SendMessage(to="code-simplifier", message={"type": "shutdown_request", "reason": "Simplify phase complete"})
 ```
 
 ---
@@ -1782,7 +1782,7 @@ The Lead does NOT write to the plan file directly (Can Edit: No).
 ### Step 5.5.5: Clean Up
 
 ```
-SendMessage(type="shutdown_request", recipient="plan-file-updater", content="Plan update complete.")
+SendMessage(to="plan-file-updater", message={"type": "shutdown_request", "reason": "Plan update complete"})
 ```
 
 ---
@@ -1876,7 +1876,7 @@ If no `needs-fix` findings, proceed.
 ### Step 6.6: Shutdown Docs Agent
 
 ```
-SendMessage(type="shutdown_request", recipient="docs", content="Documentation phase complete.")
+SendMessage(to="docs", message={"type": "shutdown_request", "reason": "Documentation phase complete"})
 ```
 
 ### Step 6.7: Spawn Lessons Extractor
@@ -1899,8 +1899,8 @@ or TODO.md — those are the Docs agent's responsibility.
 ### Step 6.8: Shutdown Lessons Extractor
 
 ```
-SendMessage(type="shutdown_request", recipient="lessons-extractor",
-  content="Lessons extraction complete.")
+SendMessage(to="lessons-extractor",
+  message={"type": "shutdown_request", "reason": "Lessons extraction complete"})
 ```
 
 ---
@@ -2084,7 +2084,7 @@ directory is not discoverable by future agents — project memory files are.
 ### Step 7.6: Shutdown and Cleanup
 
 ```
-SendMessage(type="shutdown_request", recipient="verifier", content="Swarm complete.")
+SendMessage(to="verifier", message={"type": "shutdown_request", "reason": "Swarm complete"})
 # ... any remaining agents ...
 TeamDelete()
 ```

--- a/code-quality/skills/unfuck/references/implementation-agents.md
+++ b/code-quality/skills/unfuck/references/implementation-agents.md
@@ -145,7 +145,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}', summary="FixSummary: N fixed, N needs-input")
 ```
 
 ## Commit Message Format
@@ -274,7 +274,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}', summary="FixSummary: N fixed, N needs-input")
 ```
 
 ## Commit Message Format
@@ -425,7 +425,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}', summary="FixSummary: N fixed, N needs-input")
 ```
 
 ## Commit Message Format
@@ -618,7 +618,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}', summary="FixSummary: N fixed, N needs-input")
 ```
 
 ## Commit Message Format
@@ -759,7 +759,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}', summary="FixSummary: N fixed, N needs-input")
 ```
 
 ## Commit Message Format
@@ -914,7 +914,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}', summary="FixSummary: N fixed, N needs-input")
 ```
 
 ## Commit Message Format
@@ -1183,7 +1183,7 @@ Then send a JSON FixSummary to the Lead via SendMessage (see `code-quality/refer
 for the full schema). Every agent MUST emit this — the SubagentStop hook validates it:
 
 ```
-SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}')
+SendMessage(to="team-lead", message='{"schema": "FixSummary", "findings_fixed": ["<id>", ...], "needs_input_items": [{"id": "<id>", "loe": "<trivial|moderate|significant>", "description": "...", "input_needed": "...", "suggested_action": "..."}], "user_deferred": [], "fixes": [{"finding_id": "<id>", "description": "...", "file": "...", "line_range": "..."}], "files_modified": ["..."]}', summary="FixSummary: N fixed, N needs-input")
 ```
 
 ## Commit Message Format

--- a/code-quality/skills/unfuck/references/orchestration-playbook.md
+++ b/code-quality/skills/unfuck/references/orchestration-playbook.md
@@ -225,8 +225,8 @@ Agent(name="documentation-auditor", subagent_type="general-purpose", model="sonn
 Each teammate, after writing its JSON output file, sends a summary to the team lead:
 
 ```
-SendMessage(type="message", recipient="team-lead",
-  content="[Agent name] complete. Results: {run_dir}/discovery/[file].json\n\n
+SendMessage(to="team-lead",
+  message="[Agent name] complete. Results: {run_dir}/discovery/[file].json\n\n
     Summary: N findings (X needs-fix, Y needs-input)\n
     Key findings: [1-3 sentence highlights]\n
     External tools used: [list]\n
@@ -253,8 +253,8 @@ Teammates send messages automatically when complete and go idle. The orchestrato
 After Phase 2 synthesis is complete and all discovery JSON files have been read, shut down the discovery teammates:
 
 ```
-SendMessage(type="shutdown_request", recipient="dead-code-hunter",
-  content="Discovery phase complete, shutting down")
+SendMessage(to="dead-code-hunter",
+  message={"type": "shutdown_request", "reason": "Discovery phase complete"})
 # ... repeat for each teammate
 ```
 
@@ -480,8 +480,8 @@ Agent(name="impl-docs", subagent_type="general-purpose", model="sonnet",
 The orchestrator assigns categories to the team in priority order by messaging `impl-writer`:
 
 ```
-SendMessage(type="message", recipient="impl-writer",
-  content="Begin Category 1: Security. Findings:\n[filtered findings from cleanup-plan.md]\n\nUse the security fixer strategy from implementation-agents.md.",
+SendMessage(to="impl-writer",
+  message="Begin Category 1: Security. Findings:\n[filtered findings from cleanup-plan.md]\n\nUse the security fixer strategy from implementation-agents.md.",
   summary="Assign security category")
 ```
 
@@ -727,7 +727,7 @@ If reflection identifies gaps, address them before announcing completion.
 Shut down any remaining teammates and delete the team:
 
 ```
-SendMessage(type="shutdown_request", recipient="*", content="Cleanup complete.")
+SendMessage(to="*", message={"type": "shutdown_request", "reason": "Cleanup complete"})
 TeamDelete()
 ```
 


### PR DESCRIPTION
## Summary
- Fixes wrong parameter names (type/recipient/content to to/message), adds missing summary fields, and restructures shutdown_request calls to use structured message objects across 7 reference files
- Bumps code-quality 3.21.0 to 3.22.0