### PR TITLE
fix(dev-guard): blocks SKIP=, core.hooksPath, and env-prefix bypass

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.59.0",
+      "version": "1.60.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -1364,6 +1364,31 @@ GIT_DENY_RULES: list[GitRule] = [
         "--no-verify flag is FORBIDDEN. Git hooks must run for all commits and pushes.",
     ),
     GitRule(
+        "hookspath-c",
+        lambda cmd: bool(re.search(r"git\s+.*-c\s+['\"]?core\.hooksPath\b", cmd, re.IGNORECASE)),
+        "git -c core.hooksPath=... is FORBIDDEN. "
+        "Redirecting the hooks directory disables all git hooks.",
+    ),
+    GitRule(
+        "hookspath-config",
+        lambda cmd: (
+            bool(re.search(r"git\s+config\b", cmd))
+            and bool(re.search(r"\bcore\.hooksPath\b", cmd, re.IGNORECASE))
+            and not re.search(r"--(get|unset|list)\b", cmd)
+        ),
+        "git config core.hooksPath is FORBIDDEN. "
+        "Persistently redirecting the hooks directory disables all git hooks. "
+        "Use --unset to restore hooks.",
+    ),
+    GitRule(
+        "hookspath-env",
+        lambda cmd: bool(
+            re.search(r"\bGIT_CONFIG_KEY_\d+=['\"]?core\.hooksPath\b", cmd, re.IGNORECASE)
+        ),
+        "GIT_CONFIG_KEY_N=core.hooksPath is FORBIDDEN. "
+        "Setting hooksPath via GIT_CONFIG_* env vars bypasses git hook enforcement.",
+    ),
+    GitRule(
         "filter-branch",
         lambda cmd: bool(re.search(r"git\s+filter-branch", cmd)),
         "git filter-branch is FORBIDDEN. It is deprecated — use git-filter-repo instead.",
@@ -1449,6 +1474,15 @@ GIT_ASK_RULES: list[GitRule] = [
         "branch-from-non-upstream",
         _is_branch_from_non_upstream,
         "Branching from a non-upstream ref risks branch stacking. Use upstream/main instead.",
+    ),
+    GitRule(
+        "skip-env-bypass",
+        lambda cmd: (
+            bool(re.search(r"(^|\s)(SKIP|PREK_SKIP)=\S+\s+", cmd))
+            and bool(re.search(r"\bgit\s", cmd))
+        ),
+        "SKIP= / PREK_SKIP= selectively bypasses pre-commit/prek hooks. "
+        "Confirm this is intentional.",
     ),
 ]
 
@@ -1677,7 +1711,8 @@ def check_git_safety(cmd: str, fetch_seen: bool = False) -> None:
             _exit_with_decision(message, "block", rule_name=name, matched_segment=cmd)
 
     # Special case: commit to main/master (requires git rev-parse)
-    if re.search(r"^\s*git\s+commit", cmd):
+    # Strip env prefix so FOO=bar git commit still matches
+    if re.search(r"^\s*git\s+commit", strip_env_prefix(cmd)):
         try:
             # _GUARD_TEST_BRANCH is only honoured during test runs
             _test_branch = None

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -999,7 +999,7 @@ def strip_env_prefix(cmd: str) -> str:
     """
     stripped = cmd
     while True:
-        m = re.match(r"^\s*[A-Za-z_]\w*=\S*\s+", stripped)
+        m = re.match(r"""^\s*[A-Za-z_]\w*=(?:'[^']*'|"[^"]*"|\S*)\s+""", stripped)
         if m:
             stripped = stripped[m.end() :]
         else:
@@ -1374,7 +1374,7 @@ GIT_DENY_RULES: list[GitRule] = [
         lambda cmd: (
             bool(re.search(r"git\s+config\b", cmd))
             and bool(re.search(r"\bcore\.hooksPath\b", cmd, re.IGNORECASE))
-            and not re.search(r"--(get|unset|list)\b", cmd)
+            and not re.search(r"--(get(?:-regexp)?|unset(?:-all)?|list)\b", cmd)
         ),
         "git config core.hooksPath is FORBIDDEN. "
         "Persistently redirecting the hooks directory disables all git hooks. "
@@ -1387,6 +1387,22 @@ GIT_DENY_RULES: list[GitRule] = [
         ),
         "GIT_CONFIG_KEY_N=core.hooksPath is FORBIDDEN. "
         "Setting hooksPath via GIT_CONFIG_* env vars bypasses git hook enforcement.",
+    ),
+    GitRule(
+        "hookspath-config-env",
+        lambda cmd: bool(
+            re.search(r"git\s+.*--config-env=?['\"]?core\.hooksPath\b", cmd, re.IGNORECASE)
+        ),
+        "git --config-env=core.hooksPath=... is FORBIDDEN. "
+        "Redirecting the hooks directory via env var disables all git hooks.",
+    ),
+    GitRule(
+        "hookspath-params-env",
+        lambda cmd: bool(
+            re.search(r"\bGIT_CONFIG_PARAMETERS=.*core\.hooksPath\b", cmd, re.IGNORECASE)
+        ),
+        "GIT_CONFIG_PARAMETERS containing core.hooksPath is FORBIDDEN. "
+        "Setting hooksPath via GIT_CONFIG_PARAMETERS bypasses git hook enforcement.",
     ),
     GitRule(
         "filter-branch",
@@ -3547,8 +3563,8 @@ def _handle_bash_command(command: str) -> NoReturn:
         for subcmd in subcmds:
             stripped = strip_env_prefix(strip_shell_keyword(subcmd))
             for name, check_fn, message in GIT_DENY_RULES:
-                if check_fn(stripped):
-                    _exit_with_decision(message, "block", rule_name=name, matched_segment=stripped)
+                if check_fn(stripped) or check_fn(subcmd):
+                    _exit_with_decision(message, "block", rule_name=name, matched_segment=subcmd)
         # Explicit allow for multiline bypass commands (same rationale as below)
         if "\n" in real_cmd:
             _exit_with_decision(

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1338,6 +1338,132 @@ class TestGitSafetyCommitToMain:
         result = run_guard("Bash", {"command": "git commit -m 'test'"}, env=env)
         assert result.returncode == 0
 
+    def test_commit_to_main_with_env_prefix(self):
+        """Gap 2 regression: env prefix before git bypasses ^-anchored check."""
+        env = os.environ.copy()
+        env["_GUARD_TEST_BRANCH"] = "main"
+        result = run_guard("Bash", {"command": "FOO=bar git commit -m 'test'"}, env=env)
+        assert_guard(result, 2, "FORBIDDEN", "commit-to-main-env-prefix")
+
+    def test_commit_to_main_with_skip_env_prefix(self):
+        """SKIP= on main should hit commit-to-main block (deny runs before ask)."""
+        env = os.environ.copy()
+        env["_GUARD_TEST_BRANCH"] = "main"
+        result = run_guard("Bash", {"command": "SKIP=hookid git commit -m 'test'"}, env=env)
+        assert_guard(result, 2, "FORBIDDEN", "commit-to-main-skip-prefix")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Git safety: SKIP / PREK_SKIP env var bypass (ASK)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSkipEnvBypass:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "SKIP=hookid git commit -m 'msg'",
+            "SKIP=hook1,hook2 git commit -m 'msg'",
+            "PREK_SKIP=hookid git commit -m 'msg'",
+            "PREK_SKIP=hook1,hook2 git push origin feature",
+            "SKIP=hookid git push origin feature",
+        ],
+        ids=[
+            "skip-single",
+            "skip-multiple",
+            "prek-skip-single",
+            "prek-skip-push",
+            "skip-push",
+        ],
+    )
+    def test_skip_env_triggers_ask(self, command):
+        result = run_bash(command)
+        assert_ask_decision(result, "SKIP")
+
+    def test_plain_git_commit_no_skip_ask(self):
+        """Plain git commit should NOT trigger the SKIP ask rule."""
+        result = run_bash("git commit -m 'msg'")
+        assert "SKIP" not in (result.stderr + result.stdout)
+
+    def test_skip_non_git_command_no_ask(self):
+        """SKIP= before a non-git command should NOT trigger the rule."""
+        result = run_bash("SKIP=hookid make test")
+        assert "SKIP" not in (result.stderr + result.stdout)
+
+    def test_skip_empty_value_no_ask(self):
+        """Empty SKIP= is a no-op in pre-commit — should NOT trigger ask."""
+        result = run_bash("SKIP= git commit -m 'msg'")
+        assert "SKIP" not in (result.stderr + result.stdout)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Git safety: core.hooksPath bypass (DENY)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestCoreHooksPathBypass:
+    @pytest.mark.parametrize(
+        "command, expected_exit, expected_msg",
+        [
+            # Gap 3: -c core.hooksPath (deny)
+            ("git -c core.hooksPath=/dev/null commit -m 'msg'", 2, "FORBIDDEN"),
+            ('git -c core.hooksPath="" commit -m "msg"', 2, "FORBIDDEN"),
+            ("git -c core.hooksPath=/tmp/empty commit -m 'msg'", 2, "FORBIDDEN"),
+            # Gap 4: git config core.hooksPath write (deny)
+            ("git config core.hooksPath /dev/null", 2, "FORBIDDEN"),
+            ("git config --local core.hooksPath /dev/null", 2, "FORBIDDEN"),
+            # Gap 4: git config --unset (allow — restores hooks)
+            ("git config --unset core.hooksPath", 0, None),
+            # Gap 4: git config --get (allow — read-only)
+            ("git config --get core.hooksPath", 0, None),
+            # Case-insensitive: git config keys are case-insensitive
+            ("git -c core.hookspath=/dev/null commit -m 'msg'", 2, "FORBIDDEN"),
+            ("git config core.hookspath /dev/null", 2, "FORBIDDEN"),
+            ("git config --get core.hookspath", 0, None),
+            # --global variant: deny fires before config-global-write ask
+            ("git config --global core.hooksPath /dev/null", 2, "FORBIDDEN"),
+            # --get-regexp is read-only (allow)
+            ("git config --get-regexp core.hooksPath", 0, None),
+            # GIT_CONFIG_KEY_N env var bypass
+            (
+                "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath "
+                "GIT_CONFIG_VALUE_0=/dev/null git commit -m 'msg'",
+                2,
+                "FORBIDDEN",
+            ),
+            # Quoted bypass attempts
+            ("git -c 'core.hooksPath=/dev/null' commit -m 'msg'", 2, "FORBIDDEN"),
+            ('git -c "core.hooksPath=/dev/null" commit -m "msg"', 2, "FORBIDDEN"),
+            (
+                "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0='core.hooksPath' "
+                "GIT_CONFIG_VALUE_0=/dev/null git commit -m 'msg'",
+                2,
+                "FORBIDDEN",
+            ),
+        ],
+        ids=[
+            "c-hookspath-devnull",
+            "c-hookspath-empty",
+            "c-hookspath-tmpdir",
+            "config-hookspath-write",
+            "config-hookspath-local-write",
+            "config-hookspath-unset-allow",
+            "config-hookspath-get-allow",
+            "c-hookspath-lowercase",
+            "config-hookspath-lowercase-write",
+            "config-hookspath-lowercase-get-allow",
+            "config-hookspath-global-write",
+            "config-hookspath-get-regexp-allow",
+            "hookspath-env-bypass",
+            "c-hookspath-single-quoted",
+            "c-hookspath-double-quoted",
+            "hookspath-env-quoted-key",
+        ],
+    )
+    def test_core_hookspath(self, command, expected_exit, expected_msg):
+        result = run_bash(command)
+        assert_guard(result, expected_exit, expected_msg)
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Git safety: branch creation enforcement

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -997,6 +997,8 @@ class TestEnvVarPrefix:
             ("A=1 B=2 python script.py", 2, "uv run"),
             ("FOO=bar make build", 0, None),
             ("FOO=bar uv run script.py", 0, None),
+            ("FOO='bar baz' python script.py", 2, "uv run"),
+            ('FOO="bar baz" python script.py', 2, "uv run"),
         ],
         ids=[
             "python",
@@ -1006,6 +1008,8 @@ class TestEnvVarPrefix:
             "multi-prefix",
             "make-allow",
             "uv-run-allow",
+            "single-quoted-value",
+            "double-quoted-value",
         ],
     )
     def test_env_prefix(self, command, expected_exit, expected_msg):
@@ -1054,6 +1058,18 @@ class TestAndonCord:
             ("GUARD_BYPASS=1 bash setup.sh", 0, None),
             ("GUARD_BYPASS=1 uv run /tmp/t.py", 0, None),
             ("GUARD_BYPASS=1 cat f.py && grep p", 0, None),
+            (
+                "GUARD_BYPASS=1 GIT_CONFIG_KEY_0=core.hooksPath "
+                "GIT_CONFIG_VALUE_0=/dev/null git commit -m msg",
+                2,
+                "FORBIDDEN",
+            ),
+            (
+                "GUARD_BYPASS=1 GIT_CONFIG_PARAMETERS=\"'core.hooksPath=/dev/null'\" "
+                "git commit -m msg",
+                2,
+                "FORBIDDEN",
+            ),
             ("cat file.py", 2, "Read tool"),
         ],
         ids=[
@@ -1061,6 +1077,8 @@ class TestAndonCord:
             "bypass-bash-script",
             "bypass-tmp",
             "bypass-full-chain",
+            "bypass-hookspath-env-blocked",
+            "bypass-hookspath-params-blocked",
             "no-bypass-blocked",
         ],
     )
@@ -1339,7 +1357,7 @@ class TestGitSafetyCommitToMain:
         assert result.returncode == 0
 
     def test_commit_to_main_with_env_prefix(self):
-        """Gap 2 regression: env prefix before git bypasses ^-anchored check."""
+        """Regression: env prefix before git bypasses ^-anchored commit-to-main check."""
         env = os.environ.copy()
         env["_GUARD_TEST_BRANCH"] = "main"
         result = run_guard("Bash", {"command": "FOO=bar git commit -m 'test'"}, env=env)
@@ -1377,12 +1395,16 @@ class TestSkipEnvBypass:
         ],
     )
     def test_skip_env_triggers_ask(self, command):
-        result = run_bash(command)
+        env = os.environ.copy()
+        env["_GUARD_TEST_BRANCH"] = "feature/test"
+        result = run_guard("Bash", {"command": command}, env=env)
         assert_ask_decision(result, "SKIP")
 
     def test_plain_git_commit_no_skip_ask(self):
         """Plain git commit should NOT trigger the SKIP ask rule."""
-        result = run_bash("git commit -m 'msg'")
+        env = os.environ.copy()
+        env["_GUARD_TEST_BRANCH"] = "feature/test"
+        result = run_guard("Bash", {"command": "git commit -m 'msg'"}, env=env)
         assert "SKIP" not in (result.stderr + result.stdout)
 
     def test_skip_non_git_command_no_ask(self):
@@ -1392,7 +1414,9 @@ class TestSkipEnvBypass:
 
     def test_skip_empty_value_no_ask(self):
         """Empty SKIP= is a no-op in pre-commit — should NOT trigger ask."""
-        result = run_bash("SKIP= git commit -m 'msg'")
+        env = os.environ.copy()
+        env["_GUARD_TEST_BRANCH"] = "feature/test"
+        result = run_guard("Bash", {"command": "SKIP= git commit -m 'msg'"}, env=env)
         assert "SKIP" not in (result.stderr + result.stdout)
 
 
@@ -1405,16 +1429,21 @@ class TestCoreHooksPathBypass:
     @pytest.mark.parametrize(
         "command, expected_exit, expected_msg",
         [
-            # Gap 3: -c core.hooksPath (deny)
+            # -c flag bypass (deny)
             ("git -c core.hooksPath=/dev/null commit -m 'msg'", 2, "FORBIDDEN"),
             ('git -c core.hooksPath="" commit -m "msg"', 2, "FORBIDDEN"),
             ("git -c core.hooksPath=/tmp/empty commit -m 'msg'", 2, "FORBIDDEN"),
-            # Gap 4: git config core.hooksPath write (deny)
+            # git config write variants (deny)
             ("git config core.hooksPath /dev/null", 2, "FORBIDDEN"),
             ("git config --local core.hooksPath /dev/null", 2, "FORBIDDEN"),
-            # Gap 4: git config --unset (allow — restores hooks)
+            ("git config --file /tmp/foo core.hooksPath /dev/null", 2, "FORBIDDEN"),
+            ("git config --worktree core.hooksPath /dev/null", 2, "FORBIDDEN"),
+            # --config-env flag bypass (deny)
+            ("git --config-env=core.hooksPath=MY_VAR commit -m 'msg'", 2, "FORBIDDEN"),
+            # git config --unset (allow — restores hooks)
             ("git config --unset core.hooksPath", 0, None),
-            # Gap 4: git config --get (allow — read-only)
+            ("git config --unset-all core.hooksPath", 0, None),
+            # git config --get (allow — read-only)
             ("git config --get core.hooksPath", 0, None),
             # Case-insensitive: git config keys are case-insensitive
             ("git -c core.hookspath=/dev/null commit -m 'msg'", 2, "FORBIDDEN"),
@@ -1428,6 +1457,12 @@ class TestCoreHooksPathBypass:
             (
                 "GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.hooksPath "
                 "GIT_CONFIG_VALUE_0=/dev/null git commit -m 'msg'",
+                2,
+                "FORBIDDEN",
+            ),
+            # GIT_CONFIG_PARAMETERS env var bypass
+            (
+                "GIT_CONFIG_PARAMETERS=\"'core.hooksPath=/dev/null'\" git commit -m 'msg'",
                 2,
                 "FORBIDDEN",
             ),
@@ -1447,7 +1482,11 @@ class TestCoreHooksPathBypass:
             "c-hookspath-tmpdir",
             "config-hookspath-write",
             "config-hookspath-local-write",
+            "config-hookspath-file-write",
+            "config-hookspath-worktree-write",
+            "config-env-hookspath",
             "config-hookspath-unset-allow",
+            "config-hookspath-unset-all-allow",
             "config-hookspath-get-allow",
             "c-hookspath-lowercase",
             "config-hookspath-lowercase-write",
@@ -1455,6 +1494,7 @@ class TestCoreHooksPathBypass:
             "config-hookspath-global-write",
             "config-hookspath-get-regexp-allow",
             "hookspath-env-bypass",
+            "hookspath-params-env-bypass",
             "c-hookspath-single-quoted",
             "c-hookspath-double-quoted",
             "hookspath-env-quoted-key",
@@ -1463,6 +1503,10 @@ class TestCoreHooksPathBypass:
     def test_core_hookspath(self, command, expected_exit, expected_msg):
         result = run_bash(command)
         assert_guard(result, expected_exit, expected_msg)
+        if expected_exit == 0:
+            output = result.stderr + result.stdout
+            assert "FORBIDDEN" not in output, f"Unexpected FORBIDDEN in allow case: {output!r}"
+            assert '"ask"' not in result.stdout, f"Unexpected ASK in allow case: {result.stdout!r}"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Adds SKIP=/PREK_SKIP= ASK rule, core.hooksPath DENY rules (via -c flag, git config, and GIT_CONFIG_KEY_N env var), with case-insensitive and quote-aware matching
- Fixes commit-to-main check bypassed by env var prefix (e.g. FOO=bar git commit on main)
- 26 new test cases covering all bypass vectors and negative/allow cases