### PR TITLE
fix(code-quality): classification gate verifier enrichment

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.60.0",
+      "version": "1.60.1",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback",
       "category": "quality",
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.22.0",
+      "version": "3.23.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning (with issue tracking), roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning (with issue tracking), roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/references/finding-classification.md
+++ b/code-quality/references/finding-classification.md
@@ -57,6 +57,37 @@ Two-tier taxonomy:
 - "This is stylistic" → `needs-fix`. Apply the project's conventions.
 - "The risk is low" → `needs-fix` if there's a fix, or don't report it. Risk assessment is not input.
 
+## Verifier De-escalation
+
+The Finding Verifier is the classification enforcement gate. When a reviewer classifies a
+finding as `needs-input`, the verifier MUST investigate and apply this decision tree:
+
+1. **Does the finding have exactly one correct resolution?** (e.g., missing dependency,
+   wrong task ordering, incorrect prerequisite) → Reclassify to `needs-fix`. Set
+   `investigation_summary` to explain why no decision exists.
+2. **Does the finding have multiple valid resolutions with meaningfully different
+   consequences?** (e.g., two architectures with different tradeoffs, API design choice
+   affecting consumers) → Keep `needs-input`. Generate 2-4 concrete options in the
+   `options` array.
+3. **Is the "decision" actually about effort, priority, or risk tolerance — not about
+   what to do?** (e.g., "should we add this test?", "is this dependency worth adding?")
+   → Reclassify to `needs-fix`. The answer is always "yes, do the work."
+
+**De-escalation test:** "If I gave this to two competent engineers independently, would
+they make different choices?" If no → `needs-fix`. If yes → `needs-input` with options.
+
+## Option Quality
+
+When the verifier generates options for `needs-input` findings:
+
+- Each option must be a concrete, actionable approach — not "fix it" or "investigate further"
+- Options must be mutually exclusive — selecting one rules out the others
+- Options must have meaningfully different consequences — if two options lead to the same
+  outcome, merge them
+- Labels should be short (3-7 words): "Extract shared module", "Use dependency injection"
+- Descriptions should include the key tradeoff: "Simpler but couples A to B"
+- 2 options minimum, 4 maximum (excluding Defer)
+
 **Post-triage states** (assigned after user interaction via AskUserQuestion, not by reviewers):
 
 - `user-confirmed`: User selected the finding as needing work. Promoted to `needs-fix` and placed
@@ -102,7 +133,8 @@ Canonical JSON schema for reviewer output:
       "evidence": "string",
       "suggested_fix": "string",
       "risk": "string — what could go wrong if not addressed",
-      "input_needed": "string | null — what decision the user must make (required when classification is needs-input)"
+      "input_needed": "string | null — what decision the user must make (required when classification is needs-input)",
+      "options": "array | null — concrete fix approaches when classification=needs-input. Each element: {label: string, description: string}. Required when classification=needs-input (verifier generates these). null when needs-fix. 2-4 options (excluding Defer, which is always appended by the orchestrator)."
     }
   ]
 }
@@ -122,7 +154,8 @@ Canonical JSON schema for Fixer output:
       "loe": "trivial | moderate | significant",
       "description": "string",
       "input_needed": "string — what decision the user must make",
-      "suggested_action": "string — what the Fixer recommends"
+      "suggested_action": "string — what the Fixer recommends",
+      "options": "array | null — verifier-generated options passed through from ReviewFindings. Fixer MUST preserve this field when collecting needs-input items. null if the upstream finding had no options."
     }
   ],
   "user_deferred": [
@@ -158,12 +191,19 @@ How the Fixer processes findings:
      question: "[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={reviewer},skill={skill_name}"
      header: "{id}"
      options: [
-       {"label": "Fix", "description": "{suggested_action}"},
-       {"label": "Defer", "description": "Skip for now"}
+       {options[0].label}: {options[0].description},
+       {options[1].label}: {options[1].description},
+       ... (all verifier-generated options),
+       {"label": "Defer", "description": "Skip for now — user-deferred"}
      ]
      multiSelect: false
      ```
-   - Fix: Lead sends back to Fixer (or fixes inline if trivial), adds to `findings_fixed`
+   The orchestrator (Lead) appends Defer as the final option. The verifier does NOT include
+   Defer in its `options` array — that's the orchestrator's responsibility.
+   When `options` is `null` (needs-fix findings, or findings from pipelines without a verifier
+   like the swarm Fixer), fall back to the original binary: `[{"label": "Fix"}, {"label": "Defer"}]`.
+   The `▸dp:` metadata suffix MUST be present — it's consumed by the decision-persistence hook.
+   - **Option selected (any non-Defer option):** Lead sends back to Fixer (or fixes inline if trivial), records selected option label in suggested_fix, adds to `findings_fixed`
    - Defer: recorded in `user_deferred` with reason "User declined via triage"
 5. After user triage complete: Lead updates the final FixSummary with `user_deferred` entries
 

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -353,10 +353,12 @@ AskUserQuestion(questions=[
     "question": "[{file}:{issue_type}] {action}\n\nDiagnostic: {diagnostic_level}\nDecision needed: {input_needed}\n▸dp:file={file},line=0,cat={issue_type},skill=file-audit",
     "header": "{file}",
     "options": [
-      {"label": "Fix", "description": "Confirm this needs work — promoted to needs-fix"},
-      {"label": "Defer", "description": "Skip for now — user-deferred"}
+      ...(verifier options if needs-input, OR {"label": "Fix", "description": "{suggested_action}"} if needs-fix),
+      {"label": "Defer", "description": "Skip for now"}
     ],
     "multiSelect": false
+    // Note: For needs-input findings with verifier-generated options, replace the Fix option
+    // with the verifier's options array. Defer is always the last option.
   },
   ... (one question per item, up to 4 per call)
 ])

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -353,21 +353,23 @@ AskUserQuestion(questions=[
     "question": "[{file}:{issue_type}] {action}\n\nDiagnostic: {diagnostic_level}\nDecision needed: {input_needed}\n▸dp:file={file},line=0,cat={issue_type},skill=file-audit",
     "header": "{file}",
     "options": [
-      ...(verifier options if needs-input, OR {"label": "Fix", "description": "{suggested_action}"} if needs-fix),
-      {"label": "Defer", "description": "Skip for now"}
+      ... (map each element from the finding's `options` array to {label, description}),
+      {"label": "Defer", "description": "Skip for now — user-deferred"}
     ],
     "multiSelect": false
-    // Note: For needs-input findings with verifier-generated options, replace the Fix option
-    // with the verifier's options array. Defer is always the last option.
   },
   ... (one question per item, up to 4 per call)
 ])
 ```
 
+When `options` is `null` (findings from pipelines without a verifier), fall back to the binary:
+`[{"label": "Fix"}, {"label": "Defer"}]`.
+
 If more than 4 `needs-input` items exist, make multiple AskUserQuestion calls.
 
 For each `needs-input` TODO:
-- **Fix selected:** Promote to `needs-fix` in inventory.json — the user confirmed this TODO needs work.
+- **Option selected (any non-Defer option):** Promote to `needs-fix` in inventory.json.
+  Record the selected option label in the finding's `suggested_fix` field.
 - **Defer selected:** Update classification to `user-deferred` in inventory.json.
 
 If zero `needs-input` TODOs exist, skip this step. If AskUserQuestion is unavailable, treat

--- a/code-quality/skills/file-audit/SKILL.md
+++ b/code-quality/skills/file-audit/SKILL.md
@@ -365,6 +365,10 @@ AskUserQuestion(questions=[
 When `options` is `null` (findings from pipelines without a verifier), fall back to the binary:
 `[{"label": "Fix"}, {"label": "Defer"}]`.
 
+File-audit has no Finding Verifier — the Lead applies the de-escalation test from
+`code-quality/references/finding-classification.md` inline before presenting to the user.
+If the finding has a single correct resolution, reclassify to `needs-fix` and fix it.
+
 If more than 4 `needs-input` items exist, make multiple AskUserQuestion calls.
 
 For each `needs-input` TODO:

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -153,7 +153,10 @@ LEAD (you)
    user. For `needs-input` findings: present each individually via AskUserQuestion (one question
    per finding, batch up to 4 per call). Each question includes full context:
    `"[{id}] [{category}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={category},skill=map-reduce"` with
-   options "Fix" (promoted to `needs-fix`) and "Defer" (`user-deferred`). `multiSelect: false`.
+   options from the verifier's `options` array (if present) plus "Defer" as the last option,
+   OR the binary `[{"label": "Fix"}, {"label": "Defer"}]` if `options` is null.
+   `multiSelect: false`. Note: For needs-input findings with verifier-generated options, use
+   the verifier's options array. Defer is always the last option.
    Do NOT exit with unresolved `needs-input` findings. If AskUserQuestion is unavailable, treat
    all `needs-input` findings as `needs_context` in the final report (surface them, don't hide
    them). Offer to write a detailed report or create actionable TODO items.
@@ -164,7 +167,10 @@ LEAD (you)
    - For `needs-input` findings: present each individually via AskUserQuestion (one question
      per finding, batch up to 4 per call). Each question includes full context:
      `"[{id}] [{category}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={category},skill=map-reduce"`
-     with options "Fix" (apply change) and "Defer" (`user-deferred`). `multiSelect: false`.
+     with options from the verifier's `options` array (if present) plus "Defer" as the last
+     option, OR the binary `[{"label": "Fix"}, {"label": "Defer"}]` if `options` is null.
+     `multiSelect: false`. Note: For needs-input findings with verifier-generated options, use
+     the verifier's options array. Defer is always the last option.
      Selected items are applied, then tests re-run. Do NOT apply `needs-input` changes without
      user approval. If AskUserQuestion is unavailable, treat all `needs-input` findings as
      `needs_context` in the final report (surface them, don't hide them).

--- a/code-quality/skills/map-reduce/SKILL.md
+++ b/code-quality/skills/map-reduce/SKILL.md
@@ -155,8 +155,10 @@ LEAD (you)
    `"[{id}] [{category}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={category},skill=map-reduce"` with
    options from the verifier's `options` array (if present) plus "Defer" as the last option,
    OR the binary `[{"label": "Fix"}, {"label": "Defer"}]` if `options` is null.
-   `multiSelect: false`. Note: For needs-input findings with verifier-generated options, use
-   the verifier's options array. Defer is always the last option.
+   `multiSelect: false`. Map-reduce has no Finding Verifier — the Lead applies the
+   de-escalation test from `code-quality/references/finding-classification.md` inline before
+   presenting to the user. If the finding has a single correct resolution, reclassify to
+   `needs-fix` and fix it.
    Do NOT exit with unresolved `needs-input` findings. If AskUserQuestion is unavailable, treat
    all `needs-input` findings as `needs_context` in the final report (surface them, don't hide
    them). Offer to write a detailed report or create actionable TODO items.
@@ -169,8 +171,10 @@ LEAD (you)
      `"[{id}] [{category}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={category},skill=map-reduce"`
      with options from the verifier's `options` array (if present) plus "Defer" as the last
      option, OR the binary `[{"label": "Fix"}, {"label": "Defer"}]` if `options` is null.
-     `multiSelect: false`. Note: For needs-input findings with verifier-generated options, use
-     the verifier's options array. Defer is always the last option.
+     `multiSelect: false`. Map-reduce has no Finding Verifier — the Lead applies the
+     de-escalation test from `code-quality/references/finding-classification.md` inline before
+     presenting to the user. If the finding has a single correct resolution, reclassify to
+     `needs-fix` and apply it.
      Selected items are applied, then tests re-run. Do NOT apply `needs-input` changes without
      user approval. If AskUserQuestion is unavailable, treat all `needs-input` findings as
      `needs_context` in the final report (surface them, don't hide them).

--- a/code-quality/skills/plan-review/SKILL.md
+++ b/code-quality/skills/plan-review/SKILL.md
@@ -253,7 +253,7 @@ Build the findings JSON array:
 ```
 Agent(
   description="Finding verification for plan: {plan_file_path}",
-  model="sonnet",
+  model="opus",
   prompt=<Finding Verifier template from references/reviewer-prompts.md, placeholders substituted>
 )
 ```
@@ -263,7 +263,7 @@ The verifier receives: `{findings_json}` (the array above), `{plan_content}`,
 
 The verifier **re-reads the plan** to check each finding against plan content. It returns a
 JSON array with a verdict for each finding:
-`[{finding_id, verdict, investigation_summary, category, classification}, ...]`
+`[{finding_id, verdict, investigation_summary, category, classification, options}, ...]`
 
 Verdicts: `verified` (finding accurately references plan content), `false_positive` (finding
 misread or misrepresents the plan), `needs_context` (cannot confirm or deny — requires human
@@ -325,7 +325,7 @@ AskUserQuestion(questions=[
     "question": "[{id}] [{Reviewer}] {description}\n\nLocation: {location}\nDecision needed: {input_needed}\n▸dp:file={plan_file},line=0,cat={Reviewer},skill=plan-review",
     "header": "{id}",
     "options": [
-      {"label": "Fix", "description": "Confirm this finding needs work — promoted to needs-fix"},
+      ... (map each element from the finding's `options` array to {label, description}),
       {"label": "Defer", "description": "Skip for now — user-deferred"}
     ],
     "multiSelect": false
@@ -339,11 +339,10 @@ If more than 4 `needs-input` findings exist, make multiple AskUserQuestion calls
 ### Record Decisions
 
 For each `needs-input` finding:
-- **Fix selected:** Promote to `needs-fix` with verdict `verified`. Place the finding in its
-  normal category section alongside other verified findings. The user has confirmed this
-  finding needs work — it is no longer ambiguous.
+- **Option selected (any non-Defer option):** Promote to `needs-fix` with verdict `verified`.
+  Record the selected option label in the finding's `suggested_fix` field (this tells the
+  Fixer which approach to implement). Place the finding in its normal category section.
 - **Defer selected:** Update the finding's classification to `user-deferred` in the output.
-  The user explicitly chose not to act on it now.
 
 Every `needs-input` item gets a recorded user decision, not silent deferral.
 

--- a/code-quality/skills/plan-review/references/reviewer-prompts.md
+++ b/code-quality/skills/plan-review/references/reviewer-prompts.md
@@ -490,20 +490,38 @@ Assign each finding to the category that best describes its nature:
 
 ## Classification Guidance
 
-Default classification to `needs-fix`. The reviewer already applied "default to needs-fix" —
-preserve the reviewer's classification unless your investigation reveals a NEW decision point
-the reviewer missed (e.g., you discovered two mutually exclusive approaches with different
-tradeoffs that the plan must choose between).
+You are the classification enforcement gate. Reviewers are fast but imprecise — they
+may misclassify obvious fixes as `needs-input`. Your job is to correct this.
 
-Do NOT reclassify a finding to `needs-input` because:
+**De-escalation (needs-input → needs-fix):** When a reviewer classified a finding as
+`needs-input`, apply the de-escalation test from
+`code-quality/references/finding-classification.md`: "If I gave this to two competent
+engineers independently, would they make different choices?" If no → reclassify to
+`needs-fix` and explain in `investigation_summary` why no genuine decision exists.
+
+Common false needs-input patterns to de-escalate:
+- "Missing prerequisite" (task depends on something not listed) → needs-fix. Add it.
+- "Wrong task ordering" (dependency sequencing error) → needs-fix. Fix the order.
+- "Plan doesn't list X as a dependency" → needs-fix. Add the dependency.
+- "Should the plan include Y?" (test step, validation, documentation) → needs-fix. Yes.
+
+**Escalation (needs-fix → needs-input):** Only if your investigation surfaced a NEW
+decision point the reviewer missed — two approaches with meaningfully different
+user-visible consequences (behavior, API contract, data model). Implementation choices
+(regex vs schema, loop vs map) are NOT decision points.
+
+**Option generation (when needs-input survives):** When a finding remains `needs-input`
+after de-escalation testing, you MUST generate 2-4 concrete fix approaches in the
+`options` array. Each option must be:
+- A specific, actionable approach (not "fix it" or "investigate")
+- Mutually exclusive with other options
+- Described with its key tradeoff
+Do NOT include "Defer" — the orchestrator appends that.
+
+Do NOT reclassify to `needs-input` because:
 - You are uncertain whether the finding is valid — use verdict `needs_context` instead
 - The finding seems hard to address — that is an LoE concern, not a classification concern
 - The category is "Research Gaps" — unvalidated assumptions are actionable (validate them)
-
-Only set `needs-input` when your investigation surfaced a specific, articulable decision the
-user must make — e.g., two approaches with meaningfully different user-visible consequences
-(behavior, API contract, data model). A choice between two plan approaches (validation step
-vs spike, inline vs separate task, etc.) is NOT a decision point — pick the more thorough one.
 
 ## Output
 
@@ -514,6 +532,7 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
     "verdict": "verified",
     "category": "Feasibility",
     "classification": "needs-fix",
+    "options": null,
     "investigation_summary": "Confirmed: Task 3 step 2 says 'implement the streaming parser' with no further detail. The plan provides no specification of the format, error handling, or backpressure strategy."
   },
   {
@@ -521,6 +540,7 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
     "verdict": "false_positive",
     "category": "Scope",
     "classification": "needs-fix",
+    "options": null,
     "investigation_summary": "The plan addresses this in the 'Error Handling' section under Task 4, which the reviewer did not reference."
   },
   {
@@ -528,7 +548,19 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
     "verdict": "needs_context",
     "category": "Research Gaps",
     "classification": "needs-fix",
+    "options": null,
     "investigation_summary": "The plan states it 'assumes API supports webhooks' but does not cite documentation. Whether this is a real gap depends on whether the team has already validated this externally. The fix (adding a validation step to the plan) is clear regardless."
+  },
+  {
+    "finding_id": "arch-2",
+    "verdict": "verified",
+    "category": "Architecture",
+    "classification": "needs-input",
+    "options": [
+      {"label": "Blue-green deployment", "description": "Zero-downtime but requires 2x infrastructure"},
+      {"label": "Rolling migration", "description": "Cheaper but has a mixed-state window"}
+    ],
+    "investigation_summary": "The plan must choose between two migration strategies with different rollback characteristics."
   }
 ]
 

--- a/code-quality/skills/pr-review/SKILL.md
+++ b/code-quality/skills/pr-review/SKILL.md
@@ -293,7 +293,7 @@ investigate each finding.
 ```
 Agent(
   description="Finding verification for PR #{number}",
-  model="sonnet",
+  model="opus",
   prompt=<Finding Verifier template from references/reviewer-prompts.md, placeholders substituted>
 )
 ```
@@ -304,7 +304,7 @@ The verifier receives: `{findings_json}` (the array above), `{claude_md_rules}`,
 The verifier **investigates each finding** — it reads the actual source files, traces call
 chains, and checks whether the finding is real. It returns a JSON array with a verdict for
 each finding:
-`[{finding_id, verdict, investigation_summary, category, classification}, ...]`
+`[{finding_id, verdict, investigation_summary, category, classification, options}, ...]`
 
 Verdicts: `verified` (confirmed real), `false_positive` (investigated and disproven),
 `needs_context` (cannot confirm or deny — requires human judgment).
@@ -364,7 +364,7 @@ AskUserQuestion(questions=[
     "question": "[{id}] [{Reviewer}] {description}\n\nLocation: {file}:{line}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={Reviewer},skill=pr-review",
     "header": "{id}",
     "options": [
-      {"label": "Fix", "description": "Confirm this finding needs work — promoted to needs-fix"},
+      ... (map each element from the finding's `options` array to {label, description}),
       {"label": "Defer", "description": "Skip for now — user-deferred"}
     ],
     "multiSelect": false
@@ -378,11 +378,10 @@ If more than 4 `needs-input` findings exist, make multiple AskUserQuestion calls
 ### Record Decisions
 
 For each `needs-input` finding:
-- **Fix selected:** Promote to `needs-fix` with verdict `verified`. Place the finding in its
-  normal category section alongside other verified findings. The user has confirmed this
-  finding needs work — it is no longer ambiguous.
+- **Option selected (any non-Defer option):** Promote to `needs-fix` with verdict `verified`.
+  Record the selected option label in the finding's `suggested_fix` field (this tells the
+  Fixer which approach to implement). Place the finding in its normal category section.
 - **Defer selected:** Update the finding's classification to `user-deferred` in the output.
-  The user explicitly chose not to act on it now.
 
 Every `needs-input` item gets a recorded user decision, not silent deferral.
 

--- a/code-quality/skills/pr-review/references/reviewer-prompts.md
+++ b/code-quality/skills/pr-review/references/reviewer-prompts.md
@@ -445,19 +445,38 @@ Assign each finding to the category that best describes its nature:
 
 ## Classification Guidance
 
-Default classification to `needs-fix`. The reviewer already applied "default to needs-fix" —
-preserve the reviewer's classification unless your investigation reveals a NEW decision point
-the reviewer missed (e.g., you discovered two mutually exclusive fixes with different tradeoffs).
+You are the classification enforcement gate. Reviewers are fast but imprecise — they
+may misclassify obvious fixes as `needs-input`. Your job is to correct this.
 
-Do NOT reclassify a finding to `needs-input` because:
+**De-escalation (needs-input → needs-fix):** When a reviewer classified a finding as
+`needs-input`, apply the de-escalation test from
+`code-quality/references/finding-classification.md`: "If I gave this to two competent
+engineers independently, would they make different choices?" If no → reclassify to
+`needs-fix` and explain in `investigation_summary` why no genuine decision exists.
+
+Common false needs-input patterns to de-escalate:
+- "Missing X" (dependency, test, import, error handling) → needs-fix. Add it.
+- "Wrong ordering" (task prerequisites, dependency sequence) → needs-fix. Fix the order.
+- "Should we add this?" (test, validation, documentation) → needs-fix. Yes, add it.
+- "This could be done two ways" (but one is clearly simpler/better) → needs-fix. Pick it.
+
+**Escalation (needs-fix → needs-input):** Only if your investigation surfaced a NEW
+decision point the reviewer missed — two approaches with meaningfully different
+user-visible consequences (behavior, API contract, data model). Implementation choices
+(regex vs schema, loop vs map) are NOT decision points.
+
+**Option generation (when needs-input survives):** When a finding remains `needs-input`
+after de-escalation testing, you MUST generate 2-4 concrete fix approaches in the
+`options` array. Each option must be:
+- A specific, actionable approach (not "fix it" or "investigate")
+- Mutually exclusive with other options
+- Described with its key tradeoff
+Do NOT include "Defer" — the orchestrator appends that.
+
+Do NOT reclassify to `needs-input` because:
 - You are uncertain whether the finding is valid — use verdict `needs_context` instead
 - The finding seems hard to fix — that is an LoE concern, not a classification concern
-- The category is "Decisions Needed" — category describes the finding's nature, not its classification
-
-Only set `needs-input` when your investigation surfaced a specific, articulable decision the
-user must make — e.g., two approaches with meaningfully different user-visible consequences
-(behavior, API contract, data model). A choice between two implementation approaches (regex
-vs schema, loop vs map, etc.) is NOT a decision point — pick the simpler one.
+- The category is "Decisions Needed" — category describes the nature, not the classification
 
 ## Output
 
@@ -468,6 +487,7 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
     "verdict": "verified",
     "category": "Security",
     "classification": "needs-fix",
+    "options": null,
     "investigation_summary": "Confirmed: user input at line 42 reaches SQL query at line 58 without parameterization. Traced through handle_request -> process_query."
   },
   {
@@ -475,6 +495,7 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
     "verdict": "false_positive",
     "category": "Testing Gaps",
     "classification": "needs-fix",
+    "options": null,
     "investigation_summary": "Tests exist in tests/unit/test_auth.py:test_login_edge_cases covering this exact path."
   },
   {
@@ -482,7 +503,19 @@ Return ONLY a valid JSON array — no prose, no explanation outside the JSON:
     "verdict": "needs_context",
     "category": "Performance",
     "classification": "needs-fix",
+    "options": null,
     "investigation_summary": "N+1 query exists but dataset size is unclear. Could be 10 rows or 10,000 — performance impact depends on production data volume. The fix (batching the query) is straightforward regardless of scale."
+  },
+  {
+    "finding_id": "cor-3",
+    "verdict": "verified",
+    "category": "Architecture",
+    "classification": "needs-input",
+    "options": [
+      {"label": "Extract shared module", "description": "Pull common code into a third module — simpler but adds a new file"},
+      {"label": "Use dependency injection", "description": "Invert the dependency — more complex but better testability"}
+    ],
+    "investigation_summary": "Two valid approaches exist for breaking the circular dependency, with different testability implications."
   }
 ]
 

--- a/code-quality/skills/quality-gate/SKILL.md
+++ b/code-quality/skills/quality-gate/SKILL.md
@@ -373,10 +373,23 @@ After all 4 reviewers complete, synthesize findings by classification
 3. For `needs-input` findings: present each individually via AskUserQuestion (one question
    per finding, batch up to 4 per call). Each question includes full context:
    `"[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={reviewer},skill=quality-gate"`
-   with options "Fix" and "Defer". `multiSelect: false`. User decides per-finding.
-   Fix approved items. Record deferred items with user's reason.
+   For each `needs-input` finding, the Lead first applies de-escalation (see Note below).
+   For findings that remain `needs-input` after de-escalation, present via AskUserQuestion
+   with the Lead-generated options + Defer appended as the final option. `multiSelect: false`.
+   User selects an approach or defers. Fix approved items using the selected approach —
+   record the selected option label in the finding's `suggested_fix` field per the Record
+   Decisions convention. Record deferred items with reason.
 4. Do NOT proceed to Layer 2 until all `needs-fix` items are fixed and all
    `needs-input` items are resolved via user decision.
+
+**Note:** Quality-gate domain reviewers do not go through a Finding Verifier. When a
+domain reviewer classifies a finding as `needs-input`, the Lead applies the de-escalation
+test from `code-quality/references/finding-classification.md` before presenting to the
+user. If the finding has a single correct resolution, reclassify to `needs-fix` and fix
+it. If genuine ambiguity exists, generate 2-4 concrete options per the Option Quality
+section in `code-quality/references/finding-classification.md` (labels 3-7 words, include
+tradeoff in description, mutually exclusive) and present via AskUserQuestion with Defer
+appended.
 
 **Finding completion verification:** After fixing all `needs-fix` items and resolving all
 `needs-input` items, verify completeness per `code-quality/references/finding-classification.md`

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -591,7 +591,9 @@ The Docs Reviewer checks:
 Findings are written to `{run_dir}/reviews/docs-review.json` using the standard ReviewFindings
 schema with `DOC-R` prefix. `needs-fix` findings are routed back to the Docs agent for fixes
 (max 1 iteration — the Docs Reviewer re-reviews after fixes). `needs-input` findings are
-presented to the user via AskUserQuestion. All findings are recorded in the audit trail.
+presented to the user via AskUserQuestion using the option-based format from
+`code-quality/references/finding-classification.md` Fixer Protocol. All findings are recorded
+in the audit trail.
 
 After the Docs Reviewer completes (or confirms clean), spawn a separate **Lessons Extractor** agent (sonnet model). This
 agent scans the swarm run's audit trail and extracts principle-level lessons to

--- a/code-quality/skills/swarm/references/orchestration-playbook.md
+++ b/code-quality/skills/swarm/references/orchestration-playbook.md
@@ -1640,8 +1640,9 @@ structural verification:
 2. If non-empty, present each item individually via AskUserQuestion (one question per finding,
    batch up to 4 per call). Each question includes full context:
    `"[{id}] {description}\n\nLoE: {loe}\nDecision needed: {input_needed}\n▸dp:file={file},line={line},cat={reviewer},skill=swarm"`
-   with options: "Fix" (`{suggested_action}`) and "Defer" ("Skip for now"). `multiSelect: false`.
-3. Fix selected: send back to Fixer for resolution (or fix inline if trivial), add to `findings_fixed`
+   with options from the finding's `options` array (if present) plus "Defer" as the last option,
+   OR the binary `[{"label": "Fix"}, {"label": "Defer"}]` if `options` is null. `multiSelect: false`.
+3. Option selected (any non-Defer): send back to Fixer with selected label in `suggested_fix`, add to `findings_fixed`
 4. Defer selected: recorded in `user_deferred` with reason "User declined via triage"
 5. Update the final FixSummary with `user_deferred` entries
 
@@ -1868,9 +1869,10 @@ The Docs Reviewer writes findings to `{run_dir}/reviews/docs-review.json`. If it
 3. Docs Reviewer re-reviews (max 1 iteration)
 
 If `needs-input` findings: present each individually via AskUserQuestion (one question per
-finding, batch up to 4 per call, `multiSelect: false`) with options "Fix" and "Defer". Each
-question includes `▸dp:file={file},line={line},cat=docs,skill=swarm` metadata suffix for
-decision persistence. Proceed after all resolved.
+finding, batch up to 4 per call, `multiSelect: false`) using the option-based format from
+`code-quality/references/finding-classification.md` Fixer Protocol. Each question includes
+`▸dp:file={file},line={line},cat=docs,skill=swarm` metadata suffix for decision persistence.
+Proceed after all resolved.
 If no `needs-fix` findings, proceed.
 
 ### Step 6.6: Shutdown Docs Agent

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback",
-  "version": "1.60.0",
+  "version": "1.60.1",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -351,7 +351,8 @@ def _handle_pre_tool_use(data: dict) -> None:
         if meta is not None:
             safe_line = re.sub(r"[^\w./_-]", "_", str(meta.get("line", "?")))
             safe_cat = re.sub(r"[^\w./_-]", "_", meta["cat"])
-            context_lines.append(f"  {meta['file']}:{safe_line} [{safe_cat}] → {decision}")
+            safe_decision = re.sub(r"[^\w./_\s-]", "_", decision[:_MAX_FIELD_LEN])
+            context_lines.append(f"  {meta['file']}:{safe_line} [{safe_cat}] → {safe_decision}")
 
     output = {
         "hookSpecificOutput": {
@@ -456,7 +457,7 @@ def _handle_post_tool_use(data: dict) -> None:
             "line": line_val,
             "category": re.sub(r"[^\w./_-]", "_", meta["cat"])[:_MAX_FIELD_LEN],
             "skill": re.sub(r"[^\w./_-]", "_", meta.get("skill", "unknown"))[:_MAX_FIELD_LEN],
-            "decision": answer,
+            "decision": answer[:_MAX_FIELD_LEN],
             "description_snippet": re.sub(r"[\x00-\x1f\x7f]", " ", snippet)[:80],
             "decided_at": datetime.now(UTC).isoformat(),
         }

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -258,7 +258,8 @@ def _is_dp_question(question: dict) -> bool:
     labels = {opt.get("label", "").lower() for opt in options}
     if DEFER_LABEL.lower() not in labels:
         return False
-    return METADATA_PREFIX in question.get("question", "")
+    q_text = question.get("question") or ""
+    return METADATA_PREFIX in q_text
 
 
 # ── PreToolUse handler ──

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -374,7 +374,7 @@ def _handle_pre_tool_use(data: dict) -> None:
 
 
 def _handle_post_tool_use(data: dict) -> None:
-    """Capture Fix/Defer decisions from AskUserQuestion responses."""
+    """Capture review finding decisions from AskUserQuestion responses."""
     tool_input = data.get("tool_input", {})
     tool_response = data.get("tool_response", {})
 

--- a/dev-guard/hooks/decision-persistence.py
+++ b/dev-guard/hooks/decision-persistence.py
@@ -2,14 +2,16 @@
 # /// script
 # requires-python = ">=3.13"
 # ///
-"""Decision Persistence Hook — remembers Fix/Defer decisions across sessions.
+"""Decision Persistence Hook — remembers fix/defer decisions across sessions.
 
 PreToolUse: checks stored decisions and auto-answers AskUserQuestion via updatedInput.
-PostToolUse: captures Fix/Defer decisions to {memory_dir}/review-decisions.json.
+PostToolUse: captures decisions to {memory_dir}/review-decisions.json.
 
 Decisions are persisted as fingerprinted records (file + category + line + skill) so
-that repeated reviews of the same finding auto-apply the prior Fix/Defer decision
-without re-prompting the user.
+that repeated reviews of the same finding auto-apply the prior decision without
+re-prompting the user. Supports both binary Fix/Defer questions and multi-option
+questions (verifier-generated options) — any non-Defer selection is treated as a
+fix-equivalent, with the actual label stored.
 """
 
 import hashlib
@@ -22,7 +24,7 @@ from pathlib import Path
 
 # ── Constants ──
 
-VALID_DECISIONS: frozenset[str] = frozenset({"Fix", "Defer"})
+DEFER_LABEL = "Defer"
 _MAX_FIELD_LEN = 512
 _MAX_DECISION_AGE_DAYS = 30
 
@@ -242,13 +244,21 @@ def _extract_description_snippet(question_text: str) -> str:
     return first_line
 
 
-def _is_fix_defer_question(question: dict) -> bool:
-    """Check if a question has Fix/Defer options (our target pattern)."""
+def _is_dp_question(question: dict) -> bool:
+    """Check if a question is a decision-persistence target.
+
+    Matches questions that have a Defer option and dp: metadata in the question
+    text. Supports both binary Fix/Defer questions and multi-option questions
+    where the verifier generated concrete options (any label other than Defer
+    is treated as a fix-equivalent).
+    """
     options = question.get("options", [])
     if len(options) < 2:
         return False
     labels = {opt.get("label", "").lower() for opt in options}
-    return "fix" in labels and "defer" in labels
+    if DEFER_LABEL.lower() not in labels:
+        return False
+    return METADATA_PREFIX in question.get("question", "")
 
 
 # ── PreToolUse handler ──
@@ -262,16 +272,16 @@ def _handle_pre_tool_use(data: dict) -> None:
     if not questions:
         sys.exit(0)  # passthrough
 
-    # Only process Fix/Defer questions — bail if batch is mixed-type
-    fix_defer_questions = [q for q in questions if _is_fix_defer_question(q)]
-    if not fix_defer_questions:
+    # Only process dp-tagged questions — bail if batch is mixed-type
+    dp_questions = [q for q in questions if _is_dp_question(q)]
+    if not dp_questions:
         sys.exit(0)  # passthrough — not our kind of question
-    if len(fix_defer_questions) != len(questions):
-        sys.exit(0)  # mixed-type batch: answers dict would only cover Fix/Defer subset
+    if len(dp_questions) != len(questions):
+        sys.exit(0)  # mixed-type batch: answers dict would only cover dp subset
 
-    # Parse metadata for all Fix/Defer questions (deduplicated per question text)
+    # Parse metadata for all dp questions (deduplicated per question text)
     parsed: dict[str, dict] = {}
-    for q in fix_defer_questions:
+    for q in dp_questions:
         q_text = q.get("question", "")
         meta = _parse_metadata(q_text)
         if meta is None:
@@ -294,12 +304,12 @@ def _handle_pre_tool_use(data: dict) -> None:
     if not stored:
         sys.exit(0)  # no prior decisions (or all expired) — passthrough
 
-    # Try to match each Fix/Defer question
+    # Try to match each dp question
     answers = {}
     all_matched = True
     code_hash_cache: dict[tuple[str, str], str | None] = {}
 
-    for q in fix_defer_questions:
+    for q in dp_questions:
         q_text = q.get("question", "")
         meta = parsed[q_text]
         skill = meta.get("skill", "unknown")
@@ -308,7 +318,7 @@ def _handle_pre_tool_use(data: dict) -> None:
         if fp in stored:
             prior = stored[fp]
             decision = prior.get("decision")
-            if decision not in VALID_DECISIONS:
+            if not decision or not isinstance(decision, str):
                 all_matched = False
                 break  # corrupted/unexpected stored value — re-ask
             # Staleness check: verify code hasn't changed since decision was made
@@ -388,10 +398,10 @@ def _handle_post_tool_use(data: dict) -> None:
     if not questions or not answers:
         sys.exit(0)
 
-    # Pre-scan: parse metadata for all Fix/Defer questions (deduplicated)
+    # Pre-scan: parse metadata for all dp questions (deduplicated)
     parsed: dict[str, dict | None] = {}
     for q in questions:
-        if _is_fix_defer_question(q):
+        if _is_dp_question(q):
             q_text = q.get("question", "")
             parsed[q_text] = _parse_metadata(q_text)
 
@@ -413,7 +423,7 @@ def _handle_post_tool_use(data: dict) -> None:
     mutated = False
     code_hash_cache: dict[tuple[str, str], str | None] = {}
     for q in questions:
-        if not _is_fix_defer_question(q):
+        if not _is_dp_question(q):
             continue
 
         q_text = q.get("question", "")
@@ -422,8 +432,8 @@ def _handle_post_tool_use(data: dict) -> None:
             continue
 
         answer = answers.get(q_text)
-        if answer is None or answer not in VALID_DECISIONS:
-            continue  # discard unexpected answers
+        if not answer or not isinstance(answer, str):
+            continue  # discard missing or malformed answers
 
         skill = meta.get("skill", "unknown")
         fp = _fingerprint(meta["file"], meta["cat"], meta.get("line", "0"), skill)

--- a/dev-guard/tests/test_decision_persistence.py
+++ b/dev-guard/tests/test_decision_persistence.py
@@ -649,8 +649,8 @@ class TestPostToolUseAnswerSource:
         assert len(stored["decisions"]) == 1
         assert stored["decisions"][0]["decision"] == "Fix"
 
-    def test_invalid_answer_not_captured(self, tmp_path):
-        """Answer values not in VALID_DECISIONS are discarded."""
+    def test_empty_answer_not_captured(self, tmp_path):
+        """Empty or missing answers are discarded."""
         project = setup_project_with_hack(tmp_path)
         decisions_file = project / "hack" / "review-decisions.json"
         seed_decisions_file(decisions_file, [])
@@ -658,12 +658,31 @@ class TestPostToolUseAnswerSource:
         q = make_dp_question("Unrelated finding", file="src/misc.py", line="5", cat="Quality")
         q_text = q["question"]
 
-        payload = make_post_payload([q], {q_text: "Skip"})
+        payload = make_post_payload([q], {q_text: ""})
         result = run_hook(payload, cwd=project)
         assert result.returncode == 0
 
         stored = json.loads(decisions_file.read_text())
         assert stored["decisions"] == []
+
+    def test_multi_option_answer_captured(self, tmp_path):
+        """Non-standard option labels (multi-option) are captured as valid decisions."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q = make_dp_question(
+            "Architecture choice", file="src/arch.py", line="10", cat="Architecture"
+        )
+        q_text = q["question"]
+
+        payload = make_post_payload([q], {q_text: "Extract shared module"})
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["decision"] == "Extract shared module"
 
     def test_expired_decisions_pruned_on_write(self, tmp_path):
         """Decisions older than 30 days are pruned when PostToolUse writes."""
@@ -1080,11 +1099,12 @@ class TestPreToolUseAnswerValues:
 class TestPreToolUseCorruptedRecord:
     """qa-2: Corrupted stored record passthrough."""
 
-    def test_invalid_decision_value_passthroughs(self, tmp_path):
+    def test_non_standard_decision_label_replayed(self, tmp_path):
+        """Stored multi-option label (e.g., 'Extract shared module') is replayed."""
         project = setup_project_with_hack(tmp_path)
         hack = project / "hack"
         record = make_decision_record()
-        record["decision"] = "INVALID"
+        record["decision"] = "Extract shared module"
         seed_decisions_file(hack / "review-decisions.json", [record])
 
         q = make_dp_question("SQL injection")
@@ -1092,7 +1112,26 @@ class TestPreToolUseCorruptedRecord:
         result = run_hook(payload, cwd=project)
 
         assert result.returncode == 0
-        assert result.stdout.strip() == "", "expected passthrough for corrupted decision value"
+        output = json.loads(result.stdout) if result.stdout.strip() else {}
+        answers = output.get("hookSpecificOutput", {}).get("updatedInput", {}).get("answers", {})
+        assert any("Extract shared module" in v for v in answers.values()), (
+            "stored multi-option label should be auto-applied"
+        )
+
+    def test_empty_decision_value_passthroughs(self, tmp_path):
+        """Empty string stored as decision → passthrough (corrupted record)."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        record = make_decision_record()
+        record["decision"] = ""
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q = make_dp_question("SQL injection")
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "", "expected passthrough for empty decision value"
 
     def test_missing_decision_key_passthroughs(self, tmp_path):
         """Record with fingerprint but no 'decision' key → passthrough (not crash)."""
@@ -1141,12 +1180,12 @@ class TestPostToolUseCoverageGaps:
         assert result.returncode == 0
         assert result.stdout.strip() == ""
 
-    def test_invalid_answer_preserves_existing_records(self, tmp_path):
+    def test_empty_answer_preserves_existing_records(self, tmp_path):
         """'no mutations' exit path preserves pre-existing records.
 
-        Sends an invalid answer (not in VALID_DECISIONS) when the decisions file
-        already contains a valid record. The hook must exit without writing,
-        preserving the original record exactly.
+        Sends an empty answer when the decisions file already contains a valid
+        record. The hook must exit without writing, preserving the original
+        record exactly.
         """
         project = setup_project_with_hack(tmp_path)
         decisions_file = project / "hack" / "review-decisions.json"
@@ -1155,7 +1194,7 @@ class TestPostToolUseCoverageGaps:
 
         q = make_dp_question("Some finding", file="src/other.py", line="10", cat="Quality")
         q_text = q["question"]
-        payload = make_post_payload([q], {q_text: "Skip"}, source="tool_response")
+        payload = make_post_payload([q], {q_text: ""}, source="tool_response")
         result = run_hook(payload, cwd=project)
         assert result.returncode == 0
 
@@ -1408,34 +1447,50 @@ class TestMemoryDirCandidates:
         )
 
 
-class TestIsFixDeferQuestion:
-    """QA-F5: _is_fix_defer_question contract tests."""
+class TestIsDpQuestion:
+    """QA-F5: _is_dp_question contract tests — metadata-based detection."""
 
-    def test_standard_fix_defer(self):
-        q = {"options": [{"label": "Fix"}, {"label": "Defer"}]}
-        assert _MOD._is_fix_defer_question(q) is True
+    def test_standard_fix_defer_with_metadata(self):
+        q = make_dp_question("Finding desc")
+        assert _MOD._is_dp_question(q) is True
 
-    def test_three_options_with_fix_defer(self):
-        """3+ options including Fix and Defer → True (by design)."""
-        q = {"options": [{"label": "Fix"}, {"label": "Defer"}, {"label": "Skip"}]}
-        assert _MOD._is_fix_defer_question(q) is True
+    def test_multi_option_with_defer_and_metadata(self):
+        """Multi-option question with Defer + dp: metadata → True."""
+        q_text = f"Finding desc {METADATA_PREFIX}file=src/a.py,line=1,cat=QA,skill=pr-review"
+        q = {
+            "question": q_text,
+            "options": [
+                {"label": "Extract shared module"},
+                {"label": "Use dependency injection"},
+                {"label": "Defer"},
+            ],
+        }
+        assert _MOD._is_dp_question(q) is True
 
-    def test_non_fix_defer_options(self):
-        q = {"options": [{"label": "Option A"}, {"label": "Option B"}]}
-        assert _MOD._is_fix_defer_question(q) is False
+    def test_fix_defer_without_metadata(self):
+        """Fix/Defer options but no dp: metadata → False."""
+        q = {"question": "plain question", "options": [{"label": "Fix"}, {"label": "Defer"}]}
+        assert _MOD._is_dp_question(q) is False
+
+    def test_options_without_defer(self):
+        """Options without Defer label → False (even with metadata)."""
+        q_text = f"Finding {METADATA_PREFIX}file=src/a.py,line=1,cat=QA,skill=pr-review"
+        q = {"question": q_text, "options": [{"label": "Option A"}, {"label": "Option B"}]}
+        assert _MOD._is_dp_question(q) is False
 
     def test_single_option(self):
-        q = {"options": [{"label": "Fix"}]}
-        assert _MOD._is_fix_defer_question(q) is False
+        q = {"options": [{"label": "Defer"}]}
+        assert _MOD._is_dp_question(q) is False
 
     def test_empty_options(self):
         q = {"options": []}
-        assert _MOD._is_fix_defer_question(q) is False
+        assert _MOD._is_dp_question(q) is False
 
     def test_no_options_key(self):
         q = {"question": "text only"}
-        assert _MOD._is_fix_defer_question(q) is False
+        assert _MOD._is_dp_question(q) is False
 
-    def test_case_insensitive(self):
-        q = {"options": [{"label": "FIX"}, {"label": "defer"}]}
-        assert _MOD._is_fix_defer_question(q) is True
+    def test_defer_case_insensitive(self):
+        q_text = f"Finding {METADATA_PREFIX}file=src/a.py,line=1,cat=QA,skill=pr-review"
+        q = {"question": q_text, "options": [{"label": "Fix"}, {"label": "DEFER"}]}
+        assert _MOD._is_dp_question(q) is True

--- a/dev-guard/tests/test_decision_persistence.py
+++ b/dev-guard/tests/test_decision_persistence.py
@@ -706,6 +706,66 @@ class TestPostToolUseAnswerSource:
         assert len(stored["decisions"]) == 1
         assert stored["decisions"][0]["decision"] == "Use dependency injection"
 
+    def test_multi_option_question_structure_captured(self, tmp_path):
+        """Realistic multi-option question with verifier options is captured."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q_text = (
+            f"Circular dep finding "
+            f"{METADATA_PREFIX}file=src/arch.py,line=10,cat=Architecture,skill=pr-review"
+        )
+        q = {
+            "question": q_text,
+            "options": [
+                {"label": "Extract shared module", "description": "Simpler"},
+                {"label": "Use dependency injection", "description": "Better testability"},
+                {"label": "Defer", "description": "Skip for now"},
+            ],
+        }
+
+        payload = make_post_payload([q], {q_text: "Extract shared module"}, source="tool_response")
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["decision"] == "Extract shared module"
+
+    def test_multi_option_question_replayed(self, tmp_path):
+        """Stored multi-option decision is replayed against matching question."""
+        project = setup_project_with_hack(tmp_path)
+        hack = project / "hack"
+        record = make_decision_record(
+            file="src/arch.py",
+            line="10",
+            cat="Architecture",
+            decision="Extract shared module",
+        )
+        seed_decisions_file(hack / "review-decisions.json", [record])
+
+        q_text = (
+            f"Circular dep "
+            f"{METADATA_PREFIX}file=src/arch.py,line=10,cat=Architecture,skill=pr-review"
+        )
+        q = {
+            "question": q_text,
+            "options": [
+                {"label": "Extract shared module", "description": "Simpler"},
+                {"label": "Use dependency injection", "description": "Better"},
+                {"label": "Defer", "description": "Skip"},
+            ],
+        }
+
+        payload = make_pre_payload([q])
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        output = json.loads(result.stdout)
+        answers = output["hookSpecificOutput"]["updatedInput"]["answers"]
+        assert answers[q_text] == "Extract shared module"
+
     def test_expired_decisions_pruned_on_write(self, tmp_path):
         """Decisions older than 30 days are pruned when PostToolUse writes."""
         project = setup_project_with_hack(tmp_path)

--- a/dev-guard/tests/test_decision_persistence.py
+++ b/dev-guard/tests/test_decision_persistence.py
@@ -109,7 +109,10 @@ def make_dp_question(
     cat: str = "Security",
     skill: str = "pr-review",
 ) -> dict:
-    """Return a Fix/Defer question with a valid ▸dp: metadata suffix."""
+    """Return a question with Fix/Defer options and ▸dp: metadata.
+
+    For multi-option questions, construct the dict manually with custom options.
+    """
     q_text = f"{description} {METADATA_PREFIX}file={file},line={line},cat={cat},skill={skill}"
     return make_fix_defer_question(q_text)
 
@@ -683,6 +686,25 @@ class TestPostToolUseAnswerSource:
         stored = json.loads(decisions_file.read_text())
         assert len(stored["decisions"]) == 1
         assert stored["decisions"][0]["decision"] == "Extract shared module"
+
+    def test_multi_option_answer_captured_tool_response(self, tmp_path):
+        """Multi-option label captured via tool_response path (primary path)."""
+        project = setup_project_with_hack(tmp_path)
+        decisions_file = project / "hack" / "review-decisions.json"
+        seed_decisions_file(decisions_file, [])
+
+        q = make_dp_question("Arch choice", file="src/arch.py", line="10", cat="Architecture")
+        q_text = q["question"]
+
+        payload = make_post_payload(
+            [q], {q_text: "Use dependency injection"}, source="tool_response"
+        )
+        result = run_hook(payload, cwd=project)
+        assert result.returncode == 0
+
+        stored = json.loads(decisions_file.read_text())
+        assert len(stored["decisions"]) == 1
+        assert stored["decisions"][0]["decision"] == "Use dependency injection"
 
     def test_expired_decisions_pruned_on_write(self, tmp_path):
         """Decisions older than 30 days are pruned when PostToolUse writes."""
@@ -1480,6 +1502,12 @@ class TestIsDpQuestion:
 
     def test_single_option(self):
         q = {"options": [{"label": "Defer"}]}
+        assert _MOD._is_dp_question(q) is False
+
+    def test_single_option_with_metadata(self):
+        """Metadata present but only 1 option → False (len < 2 guard)."""
+        q_text = f"Finding {METADATA_PREFIX}file=src/a.py,line=1,cat=QA,skill=pr-review"
+        q = {"question": q_text, "options": [{"label": "Defer"}]}
         assert _MOD._is_dp_question(q) is False
 
     def test_empty_options(self):


### PR DESCRIPTION
## Summary
- Adds verifier de-escalation gate and options schema to finding-classification pipeline
- Upgrades verifier model from Sonnet to Opus for classification judgment
- Updates decision-persistence hook for multi-option support (replaces binary Fix/Defer)

Closes #127