### PR TITLE
feat(drawio): adds vendored draw.io diagramming plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "personal-claude-marketplace",
   "metadata": {
     "description": "Personal Claude Code plugins: LSP servers (uvx/npx) and custom agents",
-    "version": "3.2.0"
+    "version": "3.3.0"
   },
   "owner": {
     "name": "wgordon17"
@@ -115,6 +115,17 @@
       "description": "Jira integration via jira CLI — OSAC defaults with full redhat.atlassian.net support (MCP temporarily disabled)",
       "category": "productivity",
       "tags": ["jira", "cli", "issue-tracking", "osac"],
+      "author": {
+        "name": "wgordon17"
+      }
+    },
+    {
+      "name": "drawio",
+      "version": "1.0.0",
+      "source": "./drawio",
+      "description": "Draw.io diagram generation skill — creates native .drawio files with optional PNG/SVG/PDF export via draw.io Desktop CLI. Vendored from jgraph/drawio-mcp (Apache 2.0).",
+      "category": "productivity",
+      "tags": ["drawio", "diagrams", "diagramming", "mxgraph"],
       "author": {
         "name": "wgordon17"
       }

--- a/.github/workflows/sync-drawio-skill.yml
+++ b/.github/workflows/sync-drawio-skill.yml
@@ -1,0 +1,92 @@
+name: Sync draw.io Skill
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'  # Weekly, Monday 08:00 UTC
+  workflow_dispatch:  # Manual trigger for testing
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync upstream SKILL.md
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
+
+      - name: Fetch upstream SKILL.md
+        run: |
+          curl -sfL \
+            https://raw.githubusercontent.com/jgraph/drawio-mcp/main/skill-cli/drawio/SKILL.md \
+            -o "$RUNNER_TEMP/upstream-skill.md"
+          test -s "$RUNNER_TEMP/upstream-skill.md" || { echo "::error::Fetch failed or empty"; exit 1; }
+
+      - name: Check for changes
+        id: diff
+        run: |
+          if diff -q "$RUNNER_TEMP/upstream-skill.md" drawio/skills/drawio/SKILL.md > /dev/null 2>&1; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update vendored files
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          cp "$RUNNER_TEMP/upstream-skill.md" drawio/skills/drawio/SKILL.md
+
+          UPSTREAM_SHA=$(curl -sf \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/jgraph/drawio-mcp/commits/main \
+            | jq -r '.sha')
+          TODAY=$(date -u +%Y-%m-%d)
+
+          cat > drawio/UPSTREAM.md << UPSTREAM_EOF
+          # Upstream Tracking
+
+          | Field | Value |
+          |-------|-------|
+          | **Source repo** | [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) |
+          | **Source path** | \`skill-cli/drawio/SKILL.md\` |
+          | **License** | Apache 2.0 |
+          | **Vendored SHA** | \`${UPSTREAM_SHA}\` |
+          | **Last synced** | \`${TODAY}\` |
+
+          This file is updated automatically by the \`sync-drawio-skill\` GitHub Actions workflow.
+          UPSTREAM_EOF
+
+      - name: Bump patch version
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          jq '.version |= (split(".") | .[2] |= (tonumber + 1 | tostring) | join("."))' \
+            drawio/.claude-plugin/plugin.json > "$RUNNER_TEMP/plugin.json"
+          mv "$RUNNER_TEMP/plugin.json" drawio/.claude-plugin/plugin.json
+
+          jq '(.plugins[] | select(.name == "drawio")).version |= (split(".") | .[2] |= (tonumber + 1 | tostring) | join("."))' \
+            .claude-plugin/marketplace.json > "$RUNNER_TEMP/marketplace.json"
+          mv "$RUNNER_TEMP/marketplace.json" .claude-plugin/marketplace.json
+
+      - name: Create PR
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NEW_VERSION=$(jq -r '.version' drawio/.claude-plugin/plugin.json)
+          BRANCH="chore/sync-drawio-skill-$(date -u +%Y%m%d)-${GITHUB_RUN_ID}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add drawio/skills/drawio/SKILL.md drawio/UPSTREAM.md \
+            drawio/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git commit -m "chore(drawio): syncs upstream SKILL.md to v${NEW_VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create --head "$BRANCH" --base main --draft \
+            --title "chore(drawio): syncs upstream SKILL.md to v${NEW_VERSION}" \
+            --body "## Summary
+          - Syncs vendored SKILL.md from [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) main
+          - Auto-bumps drawio plugin version to ${NEW_VERSION}"

--- a/.github/workflows/sync-drawio-skill.yml
+++ b/.github/workflows/sync-drawio-skill.yml
@@ -41,8 +41,6 @@ jobs:
       - name: Update vendored files
         if: steps.diff.outputs.changed == 'true'
         run: |
-          cp "$RUNNER_TEMP/upstream-skill.md" drawio/skills/drawio/SKILL.md
-
           UPSTREAM_SHA=$(curl -sf \
             https://api.github.com/repos/jgraph/drawio-mcp/commits/main \
             | jq -r '.sha')
@@ -50,6 +48,12 @@ jobs:
             echo "::error::Could not extract valid commit SHA from GitHub API"
             exit 1
           fi
+
+          curl -sfL \
+            "https://raw.githubusercontent.com/jgraph/drawio-mcp/${UPSTREAM_SHA}/skill-cli/drawio/SKILL.md" \
+            -o drawio/skills/drawio/SKILL.md
+          test -s drawio/skills/drawio/SKILL.md || { echo "::error::SHA-pinned fetch failed"; exit 1; }
+
           TODAY=$(date -u +%Y-%m-%d)
 
           cat > drawio/UPSTREAM.md << UPSTREAM_EOF

--- a/.github/workflows/sync-drawio-skill.yml
+++ b/.github/workflows/sync-drawio-skill.yml
@@ -5,14 +5,15 @@ on:
     - cron: '0 8 * * 1'  # Weekly, Monday 08:00 UTC
   workflow_dispatch:  # Manual trigger for testing
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   sync:
     name: Sync upstream SKILL.md
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
@@ -39,9 +40,12 @@ jobs:
           cp "$RUNNER_TEMP/upstream-skill.md" drawio/skills/drawio/SKILL.md
 
           UPSTREAM_SHA=$(curl -sf \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/jgraph/drawio-mcp/commits/main \
             | jq -r '.sha')
+          if ! [[ "$UPSTREAM_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Could not extract valid commit SHA from GitHub API"
+            exit 1
+          fi
           TODAY=$(date -u +%Y-%m-%d)
 
           cat > drawio/UPSTREAM.md << UPSTREAM_EOF

--- a/.github/workflows/sync-drawio-skill.yml
+++ b/.github/workflows/sync-drawio-skill.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: sync-drawio-skill
+  cancel-in-progress: true
+
 jobs:
   sync:
     name: Sync upstream SKILL.md

--- a/.github/workflows/sync-drawio-skill.yml
+++ b/.github/workflows/sync-drawio-skill.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   sync:
-    name: Sync upstream SKILL.md
+    name: Sync upstream skill files
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -22,26 +22,34 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
 
-      - name: Fetch upstream SKILL.md
+      - name: Fetch upstream files
         run: |
           curl -sfL \
             https://raw.githubusercontent.com/jgraph/drawio-mcp/main/skill-cli/drawio/SKILL.md \
             -o "$RUNNER_TEMP/upstream-skill.md"
-          test -s "$RUNNER_TEMP/upstream-skill.md" || { echo "::error::Fetch failed or empty"; exit 1; }
+          test -s "$RUNNER_TEMP/upstream-skill.md" || { echo "::error::SKILL.md fetch failed or empty"; exit 1; }
+
+          curl -sfL \
+            https://raw.githubusercontent.com/jgraph/drawio-mcp/main/shared/xml-reference.md \
+            -o "$RUNNER_TEMP/upstream-xml-reference.md"
+          test -s "$RUNNER_TEMP/upstream-xml-reference.md" || { echo "::error::xml-reference.md fetch failed or empty"; exit 1; }
 
       - name: Check for changes
         id: diff
         run: |
-          if diff -q "$RUNNER_TEMP/upstream-skill.md" drawio/skills/drawio/SKILL.md > /dev/null 2>&1; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          fi
+          # Patch the upstream URL to match our local vendored reference (same regex as "Update vendored files" step)
+          perl -0777 -i -pe 's|fetch and follow the instructions at:\nhttps://raw\.githubusercontent\.com/jgraph/drawio-mcp/main/shared/xml-reference\.md|read and follow the instructions in the vendored sibling file `xml-reference.md` located in the same directory as this skill file.|s' "$RUNNER_TEMP/upstream-skill.md"
+          changed=false
+          diff -q "$RUNNER_TEMP/upstream-skill.md" drawio/skills/drawio/SKILL.md > /dev/null 2>&1 || changed=true
+          diff -q "$RUNNER_TEMP/upstream-xml-reference.md" drawio/skills/drawio/xml-reference.md > /dev/null 2>&1 || changed=true
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
 
       - name: Update vendored files
         if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          UPSTREAM_SHA=$(curl -sf \
+          UPSTREAM_SHA=$(curl -sf -H "Authorization: Bearer $GH_TOKEN" \
             https://api.github.com/repos/jgraph/drawio-mcp/commits/main \
             | jq -r '.sha')
           if ! [[ "$UPSTREAM_SHA" =~ ^[0-9a-f]{40}$ ]]; then
@@ -52,7 +60,19 @@ jobs:
           curl -sfL \
             "https://raw.githubusercontent.com/jgraph/drawio-mcp/${UPSTREAM_SHA}/skill-cli/drawio/SKILL.md" \
             -o drawio/skills/drawio/SKILL.md
-          test -s drawio/skills/drawio/SKILL.md || { echo "::error::SHA-pinned fetch failed"; exit 1; }
+          test -s drawio/skills/drawio/SKILL.md || { echo "::error::SHA-pinned SKILL.md fetch failed"; exit 1; }
+
+          curl -sfL \
+            "https://raw.githubusercontent.com/jgraph/drawio-mcp/${UPSTREAM_SHA}/shared/xml-reference.md" \
+            -o drawio/skills/drawio/xml-reference.md
+          test -s drawio/skills/drawio/xml-reference.md || { echo "::error::SHA-pinned xml-reference.md fetch failed"; exit 1; }
+
+          # Patch upstream URL to local vendored reference (same regex as "Check for changes" step)
+          perl -0777 -i -pe 's|fetch and follow the instructions at:\nhttps://raw\.githubusercontent\.com/jgraph/drawio-mcp/main/shared/xml-reference\.md|read and follow the instructions in the vendored sibling file `xml-reference.md` located in the same directory as this skill file.|s' drawio/skills/drawio/SKILL.md
+          if grep -q 'raw.githubusercontent.com.*xml-reference' drawio/skills/drawio/SKILL.md; then
+            echo "::error::SKILL.md still contains upstream xml-reference URL after patching — upstream may have changed the surrounding text"
+            exit 1
+          fi
 
           TODAY=$(date -u +%Y-%m-%d)
 
@@ -62,7 +82,7 @@ jobs:
           | Field | Value |
           |-------|-------|
           | **Source repo** | [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) |
-          | **Source path** | \`skill-cli/drawio/SKILL.md\` |
+          | **Source paths** | \`skill-cli/drawio/SKILL.md\`, \`shared/xml-reference.md\` |
           | **License** | Apache 2.0 |
           | **Vendored SHA** | \`${UPSTREAM_SHA}\` |
           | **Last synced** | \`${TODAY}\` |
@@ -92,13 +112,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add drawio/skills/drawio/SKILL.md drawio/UPSTREAM.md \
-            drawio/.claude-plugin/plugin.json .claude-plugin/marketplace.json
-          git commit -m "chore(drawio): syncs upstream SKILL.md to v${NEW_VERSION}"
+          git add drawio/skills/drawio/SKILL.md drawio/skills/drawio/xml-reference.md \
+            drawio/UPSTREAM.md drawio/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git commit -m "chore(drawio): syncs upstream skill files to v${NEW_VERSION}"
           git push origin "$BRANCH"
 
           gh pr create --head "$BRANCH" --base main --draft \
-            --title "chore(drawio): syncs upstream SKILL.md to v${NEW_VERSION}" \
+            --title "chore(drawio): syncs upstream skill files to v${NEW_VERSION}" \
             --body "## Summary
-          - Syncs vendored SKILL.md from [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) main
+          - Syncs vendored skill files from [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) main
           - Auto-bumps drawio plugin version to ${NEW_VERSION}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Python 3.13+. Ruff line-length 100, select `E,W,F,I,UP,B,SIM`. Tests in `dev-gua
 
 ## Repository Structure
 
-Personal Claude Code plugin marketplace with 10 plugins. Master registry: `.claude-plugin/marketplace.json`.
+Personal Claude Code plugin marketplace with 11 plugins. Master registry: `.claude-plugin/marketplace.json`.
 
 - **LSP plugins (5):** `pyright-uvx`, `vtsls-npx`, `gopls-go`, `vscode-html-css-npx`, `rust-analyzer-rustup`
 - **dev-guard/** — Tool selection guard, commit validation, pre-push review, subagent completion verification (only plugin with tests)
@@ -47,6 +47,7 @@ Personal Claude Code plugin marketplace with 10 plugins. Master registry: `.clau
 - **git-tools/** — Git history, hooks, commit review, contributing guide; SessionStart git instructions
 - **github-mcp/** — GitHub MCP server (HTTP, api.githubcopilot.com); full toolsets for PRs, issues, actions, code security
 - **jira/** — Jira integration via jira CLI (MCP temporarily disabled); OSAC defaults (project=MGMT, component=OSAC); skill (`/jira:jira`) and spawnable agent (`jira:jira-agent`)
+- **drawio/** — Vendored draw.io diagram generation skill from jgraph/drawio-mcp (Apache 2.0); weekly upstream sync via GHA
 
 Each plugin has `.claude-plugin/plugin.json`. Hooks register in `hooks/hooks.json`. Skills live in `skills/*/SKILL.md`.
 

--- a/drawio/.claude-plugin/plugin.json
+++ b/drawio/.claude-plugin/plugin.json
@@ -2,7 +2,5 @@
   "name": "drawio",
   "description": "Draw.io diagram generation skill — creates native .drawio files with optional PNG/SVG/PDF export via draw.io Desktop CLI. Vendored from jgraph/drawio-mcp (Apache 2.0).",
   "version": "1.0.0",
-  "author": {
-    "name": "wgordon17"
-  }
+  "author": { "name": "wgordon17" }
 }

--- a/drawio/.claude-plugin/plugin.json
+++ b/drawio/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "drawio",
+  "description": "Draw.io diagram generation skill — creates native .drawio files with optional PNG/SVG/PDF export via draw.io Desktop CLI. Vendored from jgraph/drawio-mcp (Apache 2.0).",
+  "version": "1.0.0",
+  "author": {
+    "name": "wgordon17"
+  }
+}

--- a/drawio/LICENSE
+++ b/drawio/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 JGraph Ltd
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/drawio/README.md
+++ b/drawio/README.md
@@ -1,0 +1,49 @@
+# drawio
+
+Vendored [draw.io](https://github.com/jgraph/drawio-mcp) diagram generation
+skill for Claude Code. Creates native `.drawio` files with optional export to
+PNG, SVG, or PDF via the draw.io Desktop CLI.
+
+## Prerequisites
+
+- **draw.io Desktop** — required for editing diagrams and CLI export
+  - macOS: `brew install --cask drawio`
+  - Linux: available via snap/apt/flatpak
+  - Windows: installer from [draw.io releases](https://github.com/jgraph/drawio-desktop/releases)
+- **@drawio/postprocess** (optional) — `npx @drawio/postprocess` for edge
+  routing optimization. Skipped silently if unavailable.
+
+## Usage
+
+Invoke the skill with `/drawio` followed by a diagram description:
+
+- `/drawio flowchart for user login` → `user-login.drawio`
+- `/drawio png architecture overview` → `architecture-overview.drawio.png`
+- `/drawio svg ER diagram for users` → `users-er.drawio.svg`
+
+## Supported Formats
+
+| Format | Embed XML | Notes |
+|--------|-----------|-------|
+| `.drawio` | N/A | Native — always generated |
+| `.drawio.png` | Yes | Viewable everywhere, editable in draw.io |
+| `.drawio.svg` | Yes | Scalable, editable in draw.io |
+| `.drawio.pdf` | Yes | Printable, editable in draw.io |
+
+## Upstream Tracking
+
+The vendored SKILL.md is synced weekly from
+[jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) via the
+`sync-drawio-skill` GitHub Actions workflow. Changes arrive as PRs.
+
+The skill also fetches
+[`shared/xml-reference.md`](https://github.com/jgraph/drawio-mcp/blob/main/shared/xml-reference.md)
+from upstream at runtime via GitHub raw URL. This reference is intentionally
+NOT vendored — it stays fresh automatically without sync PRs.
+
+See [UPSTREAM.md](UPSTREAM.md) for the current vendored commit SHA.
+
+## License
+
+The vendored skill content is licensed under Apache 2.0 by JGraph Ltd.
+See [LICENSE](LICENSE).

--- a/drawio/README.md
+++ b/drawio/README.md
@@ -36,10 +36,10 @@ The vendored SKILL.md is synced weekly from
 [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) via the
 `sync-drawio-skill` GitHub Actions workflow. Changes arrive as PRs.
 
-The skill also fetches
+The skill also vendors
 [`shared/xml-reference.md`](https://github.com/jgraph/drawio-mcp/blob/main/shared/xml-reference.md)
-from upstream at runtime via GitHub raw URL. This reference is intentionally
-NOT vendored — it stays fresh automatically without sync PRs.
+from upstream alongside SKILL.md, synced at the same SHA. Both files are
+updated together by the `sync-drawio-skill` workflow.
 
 See [UPSTREAM.md](UPSTREAM.md) for the current vendored commit SHA.
 

--- a/drawio/UPSTREAM.md
+++ b/drawio/UPSTREAM.md
@@ -1,0 +1,11 @@
+# Upstream Tracking
+
+| Field | Value |
+|-------|-------|
+| **Source repo** | [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) |
+| **Source path** | `skill-cli/drawio/SKILL.md` |
+| **License** | Apache 2.0 |
+| **Vendored SHA** | `b3bcf98f0cfe49e431e4503ad3a8e6c59de9cd12` |
+| **Last synced** | `2026-04-20` |
+
+This file is updated automatically by the `sync-drawio-skill` GitHub Actions workflow.

--- a/drawio/UPSTREAM.md
+++ b/drawio/UPSTREAM.md
@@ -3,7 +3,7 @@
 | Field | Value |
 |-------|-------|
 | **Source repo** | [jgraph/drawio-mcp](https://github.com/jgraph/drawio-mcp) |
-| **Source path** | `skill-cli/drawio/SKILL.md` |
+| **Source paths** | `skill-cli/drawio/SKILL.md`, `shared/xml-reference.md` |
 | **License** | Apache 2.0 |
 | **Vendored SHA** | `b3bcf98f0cfe49e431e4503ad3a8e6c59de9cd12` |
 | **Last synced** | `2026-04-20` |

--- a/drawio/skills/drawio/SKILL.md
+++ b/drawio/skills/drawio/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: drawio
+description: Always use when user asks to create, generate, draw, or design a diagram, flowchart, architecture diagram, ER diagram, sequence diagram, class diagram, network diagram, mockup, wireframe, or UI sketch, or mentions draw.io, drawio, drawoi, .drawio files, or diagram export to PNG/SVG/PDF.
+---
+
+# Draw.io Diagram Skill
+
+Generate draw.io diagrams as native `.drawio` files. Optionally export to PNG, SVG, or PDF with the diagram XML embedded (so the exported file remains editable in draw.io).
+
+## How to create a diagram
+
+1. **Generate draw.io XML** in mxGraphModel format for the requested diagram
+2. **Write the XML** to a `.drawio` file in the current working directory using the Write tool
+3. **Post-process edge routing** (optional): If `npx @drawio/postprocess` is available, run it on the `.drawio` file to optimize edge routing (simplify waypoints, fix edge-vertex collisions, straighten approach angles). Skip silently if not available — do not install it or ask the user about it
+4. **If the user requested an export format** (png, svg, pdf), locate the draw.io CLI (see below), export with `--embed-diagram`, then delete the source `.drawio` file. If the CLI is not found, keep the `.drawio` file and tell the user they can install the draw.io desktop app to enable export, or open the `.drawio` file directly
+5. **Open the result** — the exported file if exported, or the `.drawio` file otherwise. If the open command fails, print the file path so the user can open it manually
+
+## Choosing the output format
+
+Check the user's request for a format preference. Examples:
+
+- `/drawio create a flowchart` → `flowchart.drawio`
+- `/drawio png flowchart for login` → `login-flow.drawio.png`
+- `/drawio svg: ER diagram` → `er-diagram.drawio.svg`
+- `/drawio pdf architecture overview` → `architecture-overview.drawio.pdf`
+
+If no format is mentioned, just write the `.drawio` file and open it in draw.io. The user can always ask to export later.
+
+### Supported export formats
+
+| Format | Embed XML | Notes |
+|--------|-----------|-------|
+| `png` | Yes (`-e`) | Viewable everywhere, editable in draw.io |
+| `svg` | Yes (`-e`) | Scalable, editable in draw.io |
+| `pdf` | Yes (`-e`) | Printable, editable in draw.io |
+| `jpg` | No | Lossy, no embedded XML support |
+
+PNG, SVG, and PDF all support `--embed-diagram` — the exported file contains the full diagram XML, so opening it in draw.io recovers the editable diagram.
+
+## draw.io CLI
+
+The draw.io desktop app includes a command-line interface for exporting.
+
+### Locating the CLI
+
+First, detect the environment, then locate the CLI accordingly:
+
+#### WSL2 (Windows Subsystem for Linux)
+
+WSL2 is detected when `/proc/version` contains `microsoft` or `WSL`:
+
+```bash
+grep -qi microsoft /proc/version 2>/dev/null && echo "WSL2"
+```
+
+On WSL2, use the Windows draw.io Desktop executable via `/mnt/c/...`:
+
+```bash
+DRAWIO_CMD=`/mnt/c/Program Files/draw.io/draw.io.exe`
+```
+
+The backtick quoting is required to handle the space in `Program Files` in bash.
+
+If draw.io is installed in a non-default location, check common alternatives:
+
+```bash
+# Default install path
+`/mnt/c/Program Files/draw.io/draw.io.exe`
+
+# Per-user install (if the above does not exist)
+`/mnt/c/Users/$WIN_USER/AppData/Local/Programs/draw.io/draw.io.exe`
+```
+
+#### macOS
+
+```bash
+/Applications/draw.io.app/Contents/MacOS/draw.io
+```
+
+#### Linux (native)
+
+```bash
+drawio   # typically on PATH via snap/apt/flatpak
+```
+
+#### Windows (native, non-WSL2)
+
+```
+"C:\Program Files\draw.io\draw.io.exe"
+```
+
+Use `which drawio` (or `where drawio` on Windows) to check if it's on PATH before falling back to the platform-specific path.
+
+### Export command
+
+```bash
+drawio -x -f <format> -e -b 10 -o <output> <input.drawio>
+```
+
+**WSL2 example:**
+
+```bash
+`/mnt/c/Program Files/draw.io/draw.io.exe` -x -f png -e -b 10 -o diagram.drawio.png diagram.drawio
+```
+
+Key flags:
+- `-x` / `--export`: export mode
+- `-f` / `--format`: output format (png, svg, pdf, jpg)
+- `-e` / `--embed-diagram`: embed diagram XML in the output (PNG, SVG, PDF only)
+- `-o` / `--output`: output file path
+- `-b` / `--border`: border width around diagram (default: 0)
+- `-t` / `--transparent`: transparent background (PNG only)
+- `-s` / `--scale`: scale the diagram size
+- `--width` / `--height`: fit into specified dimensions (preserves aspect ratio)
+- `-a` / `--all-pages`: export all pages (PDF only)
+- `-p` / `--page-index`: select a specific page (1-based)
+
+### Opening the result
+
+| Environment | Command |
+|-------------|---------|
+| macOS | `open <file>` |
+| Linux (native) | `xdg-open <file>` |
+| WSL2 | `cmd.exe /c start "" "$(wslpath -w <file>)"` |
+| Windows | `start <file>` |
+
+**WSL2 notes:**
+- `wslpath -w <file>` converts a WSL2 path (e.g. `/home/user/diagram.drawio`) to a Windows path (e.g. `C:\Users\...`). This is required because `cmd.exe` cannot resolve `/mnt/c/...` style paths.
+- The empty string `""` after `start` is required to prevent `start` from interpreting the filename as a window title.
+
+**WSL2 example:**
+
+```bash
+cmd.exe /c start "" "$(wslpath -w diagram.drawio)"
+```
+
+## File naming
+
+- Use a descriptive filename based on the diagram content (e.g., `login-flow`, `database-schema`)
+- Use lowercase with hyphens for multi-word names
+- For export, use double extensions: `name.drawio.png`, `name.drawio.svg`, `name.drawio.pdf` — this signals the file contains embedded diagram XML
+- After a successful export, delete the intermediate `.drawio` file — the exported file contains the full diagram
+
+## XML format
+
+A `.drawio` file is native mxGraphModel XML. Always generate XML directly — Mermaid and CSV formats require server-side conversion and cannot be saved as native files.
+
+### Basic structure
+
+Every diagram must have this structure:
+
+```xml
+<mxGraphModel adaptiveColors="auto">
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <!-- Diagram cells go here with parent="1" -->
+  </root>
+</mxGraphModel>
+```
+
+- Cell `id="0"` is the root layer
+- Cell `id="1"` is the default parent layer
+- All diagram elements use `parent="1"` unless using multiple layers
+
+## XML reference
+
+For the complete draw.io XML reference including common styles, edge routing, containers, layers, tags, metadata, dark mode colors, and XML well-formedness rules, fetch and follow the instructions at:
+https://raw.githubusercontent.com/jgraph/drawio-mcp/main/shared/xml-reference.md
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---------|-------|----------|
+| draw.io CLI not found | Desktop app not installed or not on PATH | Keep the `.drawio` file and tell the user to install the draw.io desktop app, or open the file manually |
+| Export produces empty/corrupt file | Invalid XML (e.g. double hyphens in comments, unescaped special characters) | Validate XML well-formedness before writing; see the XML well-formedness section below |
+| Diagram opens but looks blank | Missing root cells `id="0"` and `id="1"` | Ensure the basic mxGraphModel structure is complete |
+| Edges not rendering | Edge mxCell is self-closing (no child mxGeometry element) | Every edge must have `<mxGeometry relative="1" as="geometry" />` as a child element |
+| File won't open after export | Incorrect file path or missing file association | Print the absolute file path so the user can open it manually |
+
+## CRITICAL: XML well-formedness
+
+- **NEVER include ANY XML comments (`<!-- -->`) in the output.** XML comments are strictly forbidden — they waste tokens, can cause parse errors, and serve no purpose in diagram XML.
+- Escape special characters in attribute values: `&amp;`, `&lt;`, `&gt;`, `&quot;`
+- Always use unique `id` values for each `mxCell`

--- a/drawio/skills/drawio/SKILL.md
+++ b/drawio/skills/drawio/SKILL.md
@@ -165,8 +165,7 @@ Every diagram must have this structure:
 
 ## XML reference
 
-For the complete draw.io XML reference including common styles, edge routing, containers, layers, tags, metadata, dark mode colors, and XML well-formedness rules, fetch and follow the instructions at:
-https://raw.githubusercontent.com/jgraph/drawio-mcp/main/shared/xml-reference.md
+For the complete draw.io XML reference including common styles, edge routing, containers, layers, tags, metadata, dark mode colors, and XML well-formedness rules, read and follow the instructions in the vendored sibling file `xml-reference.md` located in the same directory as this skill file.
 
 ## Troubleshooting
 

--- a/drawio/skills/drawio/xml-reference.md
+++ b/drawio/skills/drawio/xml-reference.md
@@ -1,0 +1,485 @@
+# draw.io XML Reference
+
+Detailed reference for styles, edge routing, containers, layers, tags, metadata, and dark mode. Consult this when generating draw.io XML diagrams.
+
+## Reasoning budget (read this first)
+
+Your job is to declare the **logical structure** of the diagram — what nodes exist, what edges connect them, what labels they carry, what lane/container groups them. draw.io's edge router and (when available) a post-layout pass handle routing and placement; you do **not** need to do layout math.
+
+**Do NOT** in your reasoning:
+
+- Do NOT debate the topic. The user asked for a flowchart / architecture / sequence / etc. — pick one concrete scenario on your first impulse and commit. Never write "Actually, let me think of something else…" or pitch alternatives.
+- Do NOT debate flat-lanes vs nested-pools, horizontal vs vertical orientation, one vs multiple variations. Pick the first reasonable option (almost always: flat swimlanes, top-down or left-right based on what fits the content). Do not flip-flop.
+- Do NOT compute x/y coordinates in prose. No "column spacings of 160px totaling 1840px width — that's too wide, let me tighten to 1700…" loops. Use the rigid grid below; do the arithmetic in your head and write the XML.
+- Do NOT re-derive drawio mechanics (`horizontal=0`, `startSize=110`, nested-lane coordinates). Use the templates below as-is.
+- Do NOT enumerate columns ("customer lane columns 0-10, web app 1-7"). Place a node, move on.
+- Do NOT add `<Array as="points">` waypoints. Edges are routed automatically.
+- Do NOT set `exitX` / `exitY` / `entryX` / `entryY` connection-point overrides unless you have specific geometric intent.
+- Do NOT verify, re-check, or adjust coordinates after placing a node.
+- Do NOT narrate "building the diagram / finalizing the XML / now let me…". Just emit XML.
+- Do NOT write out lists of node positions as planning text. Emit them as `<mxCell>` elements directly.
+
+**Do** in your reasoning:
+
+- Identify the diagram type + actors/stages (1-2 short sentences).
+- Identify any grouping (swimlanes? containers? none?).
+- Go straight to XML.
+
+**Rigid grid — use for every XML diagram:**
+
+- Column x = `col_index * 180 + 40`  (col 0 = 40, col 1 = 220, col 2 = 400, …)
+- Row y = `row_index * 120 + 40`     (row 0 = 40, row 1 = 160, row 2 = 280, …)
+- Node size: rectangles `140×60`, diamonds `140×80`, circles `60×60`, documents `120×80`, cylinders `100×70`
+
+Pick a `(col, row)` for each node. Don't think about centers, gaps, or overlap — ELK handles routing between rough positions. Slight misalignment is invisible in the result.
+
+## General principles
+
+- **Use proper draw.io shapes and connectors** — choose the semantically correct shape for each element (e.g., `shape=cylinder3` for databases and tanks, `rhombus` for decisions, `shape=mxgraph.pid2valves.*` for valves in P&IDs). draw.io has extensive shape libraries; prefer domain-appropriate shapes over generic rectangles.
+- **Decide whether to search for shapes** — before generating a diagram, decide if it needs domain-specific shapes from draw.io's extended libraries. **Skip `search_shapes`** for standard diagram types that use basic geometric shapes: flowcharts, UML (class, sequence, state, activity), ERD, org charts, mind maps, Venn diagrams, timelines, wireframes, and any diagram using only rectangles, diamonds, circles, cylinders, and arrows. Also skip if the user explicitly asks to use basic/simple shapes or says not to search. **Use `search_shapes`** when the diagram requires industry-specific or branded icons: cloud architecture (AWS, Azure, GCP), network topology (Cisco, rack equipment), P&ID (valves, instruments, vessels), electrical/circuit diagrams, Kubernetes, BPMN with specific task types, or any domain where the user expects realistic/standardized symbols rather than labeled boxes.
+- **Match the language of labels to the user's language** — if the user writes in German, French, Japanese, etc., all diagram labels, titles, and annotations should be in that same language.
+
+## Common styles
+
+**Rounded rectangle:**
+```xml
+<mxCell id="2" value="Label" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+  <mxGeometry x="100" y="100" width="120" height="60" as="geometry"/>
+</mxCell>
+```
+
+**Diamond (decision):**
+```xml
+<mxCell id="3" value="Condition?" style="rhombus;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+  <mxGeometry x="100" y="200" width="120" height="80" as="geometry"/>
+</mxCell>
+```
+
+**Arrow (edge):**
+```xml
+<mxCell id="4" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;" edge="1" source="2" target="3" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+```
+
+**Labeled arrow:**
+```xml
+<mxCell id="5" value="Yes" style="edgeStyle=orthogonalEdgeStyle;html=1;" edge="1" source="3" target="6" parent="1">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+```
+
+## Style properties
+
+| Property | Values | Use for |
+|----------|--------|---------|
+| `rounded=1` | 0 or 1 | Rounded corners |
+| `whiteSpace=wrap` | wrap | Text wrapping |
+| `fillColor=#dae8fc` | Hex color | Background color |
+| `strokeColor=#6c8ebf` | Hex color | Border color |
+| `fontColor=#333333` | Hex color | Text color |
+| `shape=cylinder3` | shape name | Database cylinders |
+| `shape=mxgraph.flowchart.document` | shape name | Document shapes |
+| `ellipse` | style keyword | Circles/ovals |
+| `rhombus` | style keyword | Diamonds |
+| `edgeStyle=orthogonalEdgeStyle` | style keyword | Right-angle connectors |
+| `edgeStyle=elbowEdgeStyle` | style keyword | Elbow connectors |
+| `dashed=1` | 0 or 1 | Dashed lines |
+| `swimlane` | style keyword | Swimlane containers |
+| `group` | style keyword | Invisible container (pointerEvents=0) |
+| `container=1` | 0 or 1 | Enable container behavior on any shape |
+| `pointerEvents=0` | 0 or 1 | Prevent container from capturing child connections |
+| `html=1` | 0 or 1 | Enable HTML rendering in labels (required for `<b>`, `<br>`, `<font>`, etc.) |
+| `shape=umlLifeline;perimeter=lifelinePerimeter;size=16` | shape | UML sequence diagram lifeline (size = header height) |
+
+## HTML labels
+
+**Always include `html=1` in the style** when the `value` attribute contains any HTML tags (`<b>`, `<br>`, `<font>`, `<i>`, `<u>`, `<hr>`, `<p>`, `<table>`, etc.). Without `html=1`, HTML tags are displayed as literal text instead of being rendered.
+
+HTML in attribute values must be **XML-escaped**: `<` → `&lt;`, `>` → `&gt;`, `&` → `&amp;`, `"` → `&quot;`
+
+```xml
+<mxCell value="&lt;b&gt;Title&lt;/b&gt;&lt;br&gt;Description"
+        style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+  <mxGeometry x="100" y="100" width="120" height="60" as="geometry"/>
+</mxCell>
+```
+
+**Line breaks:** Use `&#xa;` (works with both `html=1` and `html=0`) or `&lt;br&gt;` (requires `html=1`) for line breaks — never use `\n`, which renders as literal backslash-n text instead of a newline.
+
+**Best practice:** Always include `html=1` in every cell style. This ensures labels render correctly whether they contain HTML or plain text — plain text is unaffected by the flag.
+
+**Bold/italic/underline:** Use `fontStyle` in the style string when the entire label should be bold (`fontStyle=1`), italic (`fontStyle=2`), or underline (`fontStyle=4`). Values can be combined via bitwise OR (e.g., `fontStyle=3` = bold+italic). Use HTML tags (`<b>`, `<i>`, `<u>`) only when formatting part of the label (e.g., bold title with normal description). Never combine `fontStyle` with HTML tags for the same effect — this is redundant and causes visible raw tags if `html=1` is missing.
+
+## Edges
+
+**CRITICAL: Every edge `mxCell` must contain a `<mxGeometry relative="1" as="geometry" />` child element.** Self-closing edge cells (e.g. `<mxCell ... edge="1" ... />`) are invalid and will not render correctly. Always use the expanded form:
+```xml
+<mxCell id="e1" edge="1" parent="1" source="a" target="b" style="...">
+  <mxGeometry relative="1" as="geometry" />
+</mxCell>
+```
+
+**Edge routing is automatic.** After the diagram renders, the viewer runs an ELK edge-routing pass that pins vertices and recomputes bend points + connection points. You do **not** need to:
+- Add `<mxPoint>` waypoints
+- Set `exitX` / `exitY` / `entryX` / `entryY`
+- Route around obstacles
+- Worry about edge-vertex collisions or parallel edge spacing
+
+Just declare `source` and `target` and let ELK do the routing. The ELK pass also reverts itself if it made routing worse — so your edges are at worst unchanged, never worse.
+
+**What you still choose: the edge style.** The style determines the overall look (orthogonal angles, curves, straight lines) — ELK honors the style family when routing.
+
+| Style | Syntax | Best for |
+|-------|--------|---------|
+| **Orthogonal** | `edgeStyle=orthogonalEdgeStyle` | Flowcharts, architecture, network diagrams, BPMN — any diagram with right-angle connectors |
+| **Straight** | no `edgeStyle` | UML class/sequence diagrams, direct point-to-point connections. For sequence diagram messages use `endSize=6;startSize=6;` to keep arrowheads small |
+| **Entity Relation** | `edgeStyle=entityRelationEdgeStyle` | ER diagrams — creates perpendicular stubs at both ends |
+| **Curved** | `curved=1` | Mind maps, informal diagrams |
+| **Elbow** | `edgeStyle=elbowEdgeStyle;elbow=vertical;` | Rarely needed — `orthogonalEdgeStyle` handles almost all cases; use this only for simple 1-bend linear flows |
+
+**Use a consistent edge style within each diagram.** Pick one based on diagram type and apply it to all edges: ER → `entityRelationEdgeStyle`; UML class → straight; mind maps → curved; flowcharts/architecture/network → `orthogonalEdgeStyle`.
+
+**Useful edge style attributes** that apply regardless of routing:
+- `rounded=1` — rounded corners at bend points (recommended for orthogonal)
+- `endArrow=classic` / `endArrow=none` — arrow heads
+- `dashed=1` — dashed line
+- `strokeColor=#...`, `strokeWidth=2` — color/width
+- Edge labels: set `value` directly on the edge cell
+
+## Containers and groups
+
+For architecture diagrams or any diagram with nested elements, use draw.io's proper parent-child containment — do **not** just place shapes on top of larger shapes.
+
+### How containment works
+
+Set `parent="containerId"` on child cells. Children use **relative coordinates** within the container.
+
+### Container types
+
+| Type | Style | When to use |
+|------|-------|-------------|
+| **Group** (invisible) | `group;` | No visual border needed, container has no connections. Includes `pointerEvents=0` so child connections are not captured |
+| **Swimlane** (titled) | `swimlane;startSize=30;` | Container needs a visible title bar/header, or the container itself has connections |
+| **Custom container** | Add `container=1;pointerEvents=0;` to any shape style | Any shape acting as a container without its own connections |
+
+### Key rules
+
+- **Edges to children inside containers naturally cross the container boundary** — this is correct and expected. Do not add extra waypoints or complex routing to avoid a parent container when connecting to shapes inside it.
+- **Always add `pointerEvents=0;`** to container styles that should not capture connections being rewired between children
+- Only omit `pointerEvents=0` when the container itself needs to be connectable — in that case, use `swimlane` style which handles this correctly (the client area is transparent for mouse events while the header remains connectable)
+- Children must set `parent="containerId"` and use coordinates **relative to the container**
+
+### Example: Architecture container with swimlane
+
+```xml
+<mxCell id="svc1" value="User Service" style="swimlane;startSize=30;fillColor=#dae8fc;strokeColor=#6c8ebf;html=1;" vertex="1" parent="1">
+  <mxGeometry x="100" y="100" width="300" height="200" as="geometry"/>
+</mxCell>
+<mxCell id="api1" value="REST API" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="svc1">
+  <mxGeometry x="20" y="40" width="120" height="60" as="geometry"/>
+</mxCell>
+<mxCell id="db1" value="Database" style="shape=cylinder3;whiteSpace=wrap;html=1;" vertex="1" parent="svc1">
+  <mxGeometry x="160" y="40" width="120" height="60" as="geometry"/>
+</mxCell>
+```
+
+### Example: Invisible group container
+
+```xml
+<mxCell id="grp1" value="" style="group;" vertex="1" parent="1">
+  <mxGeometry x="100" y="100" width="300" height="200" as="geometry"/>
+</mxCell>
+<mxCell id="c1" value="Component A" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="grp1">
+  <mxGeometry x="10" y="10" width="120" height="60" as="geometry"/>
+</mxCell>
+```
+
+### Swimlanes for grouped actors (BPMN-style flowcharts)
+
+Use **flat swimlanes** at `parent="1"`, stacked vertically. One row of nodes per lane.
+
+**Fixed values — do not compute or debate:**
+- Lane size: `x=0, y=lane_index*150, width=CANVAS_W, height=150`
+- Lane style: `swimlane;horizontal=0;startSize=110;fillColor=<pastel>;html=1;`
+- Child nodes inside a lane: `parent="<lane_id>"`, `x = 120 + col*180`, `y = 45` (always 45), size 140×60 (or 140×80 for diamonds)
+- Cross-lane edges: `parent="1"` (not inside a lane)
+
+Pick `CANVAS_W = max_col * 180 + 300`. Choose lane colors from `#f5f5f5, #e8f4f8, #fff0e6, #e8f5e9, #fff9e6, #fce4ec` in that order.
+
+```xml
+<mxCell id="lane1" value="Customer" style="swimlane;horizontal=0;startSize=110;fillColor=#f5f5f5;html=1;" vertex="1" parent="1">
+  <mxGeometry x="0" y="0" width="1800" height="150" as="geometry"/>
+</mxCell>
+<mxCell id="n1" value="Place Order" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="lane1">
+  <mxGeometry x="120" y="45" width="140" height="60" as="geometry"/>
+</mxCell>
+<mxCell id="lane2" value="System" style="swimlane;horizontal=0;startSize=110;fillColor=#e8f4f8;html=1;" vertex="1" parent="1">
+  <mxGeometry x="0" y="150" width="1800" height="150" as="geometry"/>
+</mxCell>
+<mxCell id="n2" value="Validate" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="lane2">
+  <mxGeometry x="300" y="45" width="140" height="60" as="geometry"/>
+</mxCell>
+<mxCell id="e1" edge="1" parent="1" source="n1" target="n2" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+```
+
+Do NOT nest lanes inside a pool. Do NOT vary lane heights. Do NOT compute title-area offset — it is always 110, children start at x=120 to clear it.
+
+### Nested architecture containers (cloud, infra, network topologies)
+
+For diagrams with **nested groupings** — VPC → Availability Zone → EC2 instance, Datacenter → Rack → Server, Region → Environment → Service — use nested swimlanes. This is where the AI most often flattens hierarchy that should be nested. Treat each level as a swimlane container.
+
+**Rules:**
+- Every container is a `swimlane` with `startSize=24` (title area at the top).
+- Child cells set `parent="<container_id>"` and use coordinates **relative to their parent** (origin 0,0 is the parent's top-left, below the title).
+- Edges between cells in **different** containers must have `parent="1"` (not a container) — otherwise they render inside the container and get clipped.
+- For industry-specific icons (AWS/Azure/GCP logos, Cisco equipment, etc.), call `search_shapes` to get the exact `style` string and substitute it into a regular vertex — the container structure stays the same.
+
+```xml
+<mxCell id="vpc" value="VPC" style="swimlane;startSize=24;fillColor=#dae8fc;strokeColor=#6c8ebf;html=1;" vertex="1" parent="1">
+  <mxGeometry x="0" y="0" width="720" height="360" as="geometry"/>
+</mxCell>
+<mxCell id="az1" value="AZ us-east-1a" style="swimlane;startSize=24;fillColor=#fff2cc;strokeColor=#d6b656;html=1;" vertex="1" parent="vpc">
+  <mxGeometry x="20" y="36" width="320" height="300" as="geometry"/>
+</mxCell>
+<mxCell id="web1" value="web-1" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="az1">
+  <mxGeometry x="30" y="40" width="120" height="60" as="geometry"/>
+</mxCell>
+<mxCell id="db1" value="db-1" style="shape=cylinder3;whiteSpace=wrap;html=1;" vertex="1" parent="az1">
+  <mxGeometry x="180" y="40" width="100" height="70" as="geometry"/>
+</mxCell>
+<mxCell id="az2" value="AZ us-east-1b" style="swimlane;startSize=24;fillColor=#fff2cc;strokeColor=#d6b656;html=1;" vertex="1" parent="vpc">
+  <mxGeometry x="360" y="36" width="340" height="300" as="geometry"/>
+</mxCell>
+<mxCell id="web2" value="web-2" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="az2">
+  <mxGeometry x="30" y="40" width="120" height="60" as="geometry"/>
+</mxCell>
+<mxCell id="e1" edge="1" parent="1" source="web1" target="web2" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+```
+
+### Cross-functional flowcharts (actor × phase grid, as a table)
+
+Cross-functional flowcharts show a process across **two axes at once** — actors (rows) and phases (columns). Use drawio's `table` shape, which auto-arranges cells into a grid via `childLayout=tableLayout`. This is the canonical draw.io pattern and is distinct from plain swimlanes (which only group on one axis).
+
+**Structure:**
+- Outer container: `shape=table;childLayout=tableLayout;startSize=0;collapsible=0;fillColor=none;`
+- Rows are children of the table: `shape=tableRow;horizontal=0;startSize=0;collapsible=0;`
+- Cells are children of rows — regular vertices, one per (actor, phase) intersection
+- Row heights and cell widths are set via `mxGeometry`; they tile automatically
+- First row = phase headers; first cell of every other row = actor label
+- Process nodes go INSIDE the appropriate cell (parent = cell id) at coordinates relative to the cell
+- Cross-cell edges must use `parent="1"` (same rule as containers)
+
+```xml
+<mxCell id="tbl" style="shape=table;childLayout=tableLayout;startSize=0;collapsible=0;fillColor=none;" vertex="1" parent="1">
+  <mxGeometry x="0" y="0" width="900" height="320" as="geometry"/>
+</mxCell>
+<mxCell id="r0" style="shape=tableRow;horizontal=0;startSize=0;collapsible=0;" vertex="1" parent="tbl">
+  <mxGeometry width="900" height="40" as="geometry"/>
+</mxCell>
+<mxCell id="h0" style="text;html=1;" vertex="1" parent="r0">
+  <mxGeometry width="140" height="40" as="geometry"/>
+</mxCell>
+<mxCell id="h1" value="Order" style="text;align=center;fontStyle=1;fillColor=#e8e8e8;" vertex="1" parent="r0">
+  <mxGeometry x="140" width="380" height="40" as="geometry"/>
+</mxCell>
+<mxCell id="h2" value="Fulfill" style="text;align=center;fontStyle=1;fillColor=#e8e8e8;" vertex="1" parent="r0">
+  <mxGeometry x="520" width="380" height="40" as="geometry"/>
+</mxCell>
+<mxCell id="r1" style="shape=tableRow;horizontal=0;startSize=0;collapsible=0;" vertex="1" parent="tbl">
+  <mxGeometry y="40" width="900" height="140" as="geometry"/>
+</mxCell>
+<mxCell id="a1" value="Customer" style="fillColor=#dae8fc;fontStyle=1;" vertex="1" parent="r1">
+  <mxGeometry width="140" height="140" as="geometry"/>
+</mxCell>
+<mxCell id="c_cust_order" style="fillColor=none;" vertex="1" parent="r1">
+  <mxGeometry x="140" width="380" height="140" as="geometry"/>
+</mxCell>
+<mxCell id="t_place" value="Place Order" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="c_cust_order">
+  <mxGeometry x="120" y="40" width="140" height="60" as="geometry"/>
+</mxCell>
+<mxCell id="c_cust_fulfill" style="fillColor=none;" vertex="1" parent="r1">
+  <mxGeometry x="520" width="380" height="140" as="geometry"/>
+</mxCell>
+<mxCell id="r2" style="shape=tableRow;horizontal=0;startSize=0;collapsible=0;" vertex="1" parent="tbl">
+  <mxGeometry y="180" width="900" height="140" as="geometry"/>
+</mxCell>
+<mxCell id="a2" value="System" style="fillColor=#d5e8d4;fontStyle=1;" vertex="1" parent="r2">
+  <mxGeometry width="140" height="140" as="geometry"/>
+</mxCell>
+<mxCell id="c_sys_order" style="fillColor=none;" vertex="1" parent="r2">
+  <mxGeometry x="140" width="380" height="140" as="geometry"/>
+</mxCell>
+<mxCell id="t_validate" value="Validate" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="c_sys_order">
+  <mxGeometry x="120" y="40" width="140" height="60" as="geometry"/>
+</mxCell>
+<mxCell id="c_sys_fulfill" style="fillColor=none;" vertex="1" parent="r2">
+  <mxGeometry x="520" width="380" height="140" as="geometry"/>
+</mxCell>
+<mxCell id="t_ship" value="Ship" style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="c_sys_fulfill">
+  <mxGeometry x="120" y="40" width="140" height="60" as="geometry"/>
+</mxCell>
+<mxCell id="e1" edge="1" parent="1" source="t_place" target="t_validate" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+<mxCell id="e2" edge="1" parent="1" source="t_validate" target="t_ship" style="edgeStyle=orthogonalEdgeStyle;rounded=1;html=1;">
+  <mxGeometry relative="1" as="geometry"/>
+</mxCell>
+```
+
+**When to use cross-functional tables vs flat swimlanes:**
+- Flat swimlanes — one-dimensional (actors only, or phases only). Simpler. Use this when you just need to show who does what in sequence.
+- Cross-functional table — two-dimensional (actors AND phases). Use this when **both** the actor and the process stage matter, and every step belongs to a specific (actor, phase) cell.
+
+**Do NOT** nest swimlanes inside a table row, do NOT set `startSize` on rows or cells (columns tile from `x=0`), and do NOT rely on the AI to produce exact widths that sum to the table width — close-enough totals are fine, the `tableLayout` normalizes them.
+
+## Layers
+
+Layers control visibility and z-order. Every cell belongs to exactly one layer. Use layers to manage diagram complexity — viewers can toggle layer visibility to show or hide groups of elements (e.g., "Physical Infrastructure" vs "Logical Network" vs "Security Zones").
+
+Cell `id="0"` is the root and cell `id="1"` is the default layer — both always exist. Additional layers are `mxCell` elements with `parent="0"`:
+
+```xml
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <mxCell id="2" value="Annotations" parent="0"/>
+    <mxCell id="10" value="Server" style="rounded=1;html=1;" vertex="1" parent="1">
+      <mxGeometry x="100" y="100" width="120" height="60" as="geometry"/>
+    </mxCell>
+    <mxCell id="20" value="Note: deprecated" style="text;" vertex="1" parent="2">
+      <mxGeometry x="100" y="170" width="120" height="30" as="geometry"/>
+    </mxCell>
+  </root>
+</mxGraphModel>
+```
+
+- A layer is an `mxCell` with `parent="0"` and no `vertex` or `edge` attribute
+- Assign shapes to a layer by setting `parent` to the layer's id
+- Later layers render on top of earlier layers (higher z-order)
+- Add `visible="0"` as an attribute on the layer cell to hide it by default
+- Use layers when the diagram has distinct conceptual groupings that viewers may want to toggle independently
+
+## Tags
+
+Tags are visual filters that let viewers show or hide elements by category. Unlike layers, a single element can have multiple tags, making tags ideal for cross-cutting concerns (e.g., tagging shapes as "critical", "v2", or "backend").
+
+Tags require wrapping `mxCell` in an `<object>` element. Tags are assigned via the `tags` attribute as a space-separated string:
+
+```xml
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <object id="2" label="Auth Service" tags="critical v2">
+      <mxCell style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxGeometry x="100" y="100" width="120" height="60" as="geometry"/>
+      </mxCell>
+    </object>
+    <object id="3" label="Legacy API" tags="critical deprecated">
+      <mxCell style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxGeometry x="300" y="100" width="120" height="60" as="geometry"/>
+      </mxCell>
+    </object>
+  </root>
+</mxGraphModel>
+```
+
+- Tags require the `<object>` wrapper — a plain `mxCell` cannot have tags
+- The `label` attribute on `<object>` replaces `value` on `mxCell`
+- Tags are space-separated in the `tags` attribute
+- Viewers filter the diagram by selecting tags in the draw.io UI (Edit > Tags)
+- Tags do not affect z-order or structural grouping — they are purely a visibility filter
+
+## Metadata and placeholders
+
+Metadata stores custom key-value properties on shapes as additional attributes on the `<object>` wrapper element. Combined with placeholders, metadata values can be displayed in labels — useful for data-driven diagrams showing status, owner, IP addresses, or versions on each shape.
+
+Set `placeholders="1"` on the `<object>` to enable `%propertyName%` substitution in the `label`:
+
+```xml
+<mxGraphModel>
+  <root>
+    <mxCell id="0"/>
+    <mxCell id="1" parent="0"/>
+    <object id="2" label="&lt;b&gt;%component%&lt;/b&gt;&lt;br&gt;Owner: %owner%&lt;br&gt;Status: %status%"
+            placeholders="1" component="Auth Service" owner="Team Backend" status="Active">
+      <mxCell style="rounded=1;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+        <mxGeometry x="100" y="100" width="160" height="80" as="geometry"/>
+      </mxCell>
+    </object>
+  </root>
+</mxGraphModel>
+```
+
+- Custom properties are plain XML attributes on `<object>` (e.g., `component="Auth Service"`)
+- Set `placeholders="1"` to enable `%key%` substitution in the label and tooltip
+- The label must use `html=1` style when using HTML formatting with placeholders
+- Placeholders resolve by walking up the containment hierarchy: shape attributes first, then parent container, then layer, then root — first match wins
+- Predefined placeholders work without custom properties: `%id%`, `%width%`, `%height%`, `%date%`, `%time%`, `%timestamp%`, `%page%`, `%pagenumber%`, `%pagecount%`, `%filename%`
+- Use `%%` for a literal percent sign in labels
+- Tags, metadata, and placeholders can all be combined on the same `<object>` element
+- Use metadata when shapes represent data records (servers, services, components) and you want to attach structured information beyond the visible label
+
+## Dark mode colors
+
+draw.io supports automatic dark mode rendering. How colors behave depends on the property:
+
+- **`strokeColor`, `fillColor`, `fontColor`** default to `"default"`, which renders as black in light theme and white in dark theme. When no explicit color is set, colors adapt automatically.
+- **Explicit colors** (e.g. `fillColor=#DAE8FC`) specify the light-mode color. The dark-mode color is computed automatically by inverting the RGB values (blending toward the inverse at 93%) and rotating the hue by 180° (via `mxUtils.getInverseColor`).
+- **`light-dark()` function** — To specify both colors explicitly, use `light-dark(lightColor,darkColor)` in the style string, e.g. `fontColor=light-dark(#7EA6E0,#FF0000)`. The first argument is used in light mode, the second in dark mode.
+
+To enable dark mode color adaptation, the `mxGraphModel` element must include `adaptiveColors="auto"`.
+
+When generating diagrams, you generally do not need to specify dark-mode colors — the automatic inversion handles most cases. Use `light-dark()` only when the automatic inverse color is unsatisfactory.
+
+## Automatic edge routing
+
+Every XML diagram rendered in the viewer automatically runs an ELK (Eclipse Layout Kernel) edge-routing pass **after** the initial render:
+
+1. Vertex positions are pinned (the AI's placement is respected — no vertex moves).
+2. ELK recomputes bend points + connection points for every edge (orthogonal routing).
+3. A metric (edge-vertex intersections) compares before vs. after. If ELK made collisions worse, the edge routing is reverted to your original.
+4. The exported XML (copy/clipboard, "Open in draw.io") reflects whatever is finally shown — so downstream consumers also get the cleaned-up edges.
+
+You do not need to request this. Place vertices where they belong and write edges naively — the viewer handles connector cleanup.
+
+This also means: there is no server-side post-processing pass. What you generate is what the viewer starts with; the ELK pass is the only correction.
+
+## Post-layout (optional, overrides vertex positions)
+
+For cases where you want a **full** re-layout — moving vertices to canonical positions — set the optional `postLayout` parameter on `create_diagram`. Vertices animate (morph) from their original positions to the algorithm's layout.
+
+| Value | ELK algorithm | Best for |
+|-------|---------------|----------|
+| `verticalFlow` | `layered` (DOWN) | Flowcharts, process diagrams |
+| `horizontalFlow` | `layered` (RIGHT) | Pipelines, swim lanes |
+| `tree` | `mrtree` | Org charts, decision trees, hierarchies |
+| `force` | `force` | Networks without clear hierarchy |
+| `stress` | `stress` | Small-to-mid general graphs (usually tighter than force) |
+| `radial` | `radial` | Concentric layers around a root |
+
+**Usually omit `postLayout`.** The automatic edge-routing pass above handles the common case. Only set `postLayout` when the user explicitly wants a canonical layout, or when you know vertex placement is significantly off.
+
+**When NOT to use:**
+- The user has asked for specific positions (swim lanes with exact lanes, architecture diagrams with meaningful spatial arrangement).
+- The diagram relies on containers/grouping where spatial layout encodes information.
+- For Mermaid diagrams — the native Mermaid layout already runs through full ELK; `postLayout` would override that with a different algorithm.
+
+## Style reference
+
+Complete style reference (all shape types, style properties, color palettes, HTML labels, and more): https://github.com/jgraph/drawio-mcp/blob/main/shared/style-reference.md
+
+XML Schema (XSD): https://github.com/jgraph/drawio-mcp/blob/main/shared/mxfile.xsd
+
+## CRITICAL: XML well-formedness
+
+When generating draw.io XML, the output **must** be well-formed XML:
+- **NEVER include ANY XML comments (`<!-- -->`) in the output.** XML comments are strictly forbidden — they waste tokens, can cause parse errors, and serve no purpose in diagram XML.
+- Escape special characters in attribute values: `&amp;`, `&lt;`, `&gt;`, `&quot;`
+- Always use unique `id` values for each `mxCell`


### PR DESCRIPTION
## Summary
- Adds drawio plugin vendoring SKILL.md from jgraph/drawio-mcp (Apache 2.0) with weekly GHA upstream sync
- Registers as 11th plugin in marketplace (metadata 3.2.0 to 3.3.0)