### PR TITLE
fix(dev-guard): adds .claire → .claude path hallucination guard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,7 +68,7 @@
       "name": "dev-guard",
       "version": "1.61.0",
       "source": "./dev-guard",
-      "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback",
+      "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback, path hallucination guard",
       "category": "quality",
       "tags": ["hooks", "git", "validation", "policies"],
       "author": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.61.0",
+      "version": "1.62.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback, path hallucination guard",
       "category": "quality",

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 .pytest_cache/
 hack/
 .serena
+.claire/

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
-  "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback",
-  "version": "1.61.0",
+  "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback, path hallucination guard",
+  "version": "1.62.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -86,6 +86,15 @@
         ]
       },
       {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run ${CLAUDE_PLUGIN_ROOT}/hooks/tool-selection-guard.py"
+          }
+        ]
+      },
+      {
         "matcher": "mcp__.*",
         "hooks": [
           {

--- a/dev-guard/hooks/hooks.json
+++ b/dev-guard/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Global hooks: git safety, commit validation, pre-push review, tool selection, quality stop gate, subagent completion verification, decision persistence, shared behavioral feedback",
+  "description": "Global hooks: git safety, commit validation, pre-push review, tool selection, quality stop gate, subagent completion verification, decision persistence, shared behavioral feedback, path hallucination guard",
   "hooks": {
     "SessionStart": [
       {

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -1844,42 +1844,55 @@ def _guard_plan_mode(tool_name: str) -> None:
         )
 
 
+_CLAIRE_PATH_RE = re.compile(r"(?<=[\s/])\.claire(?=[\s/]|$)|^\.claire(?=[\s/]|$)")
+
+
 def _guard_claire_typo(tool_name: str, tool_input: dict) -> None:
-    """Rewrite .claire → .claude in file paths (LLM hallucination mitigation).
+    """Correct .claire → .claude hallucinations (anthropics/claude-code#17893).
 
-    Claude models occasionally transpose '.claude' → '.claire' when constructing
-    paths from memory (anthropics/claude-code#17893). The Write tool auto-creates
-    intermediate directories, silently producing stray .claire/ trees. This guard
-    intercepts the typo and rewrites it before the tool executes.
+    Write/Edit/NotebookEdit/Read: silently rewrites the file_path via updatedInput.
+    Bash: blocks the command and tells the model to use .claude (cannot use updatedInput
+    for Bash because permissionDecision "allow" would bypass all other Bash guards).
     """
-    if tool_name not in ("Write", "Edit", "NotebookEdit"):
-        return
+    if tool_name in ("Write", "Edit", "NotebookEdit", "Read"):
+        path_key = "notebook_path" if tool_name == "NotebookEdit" else "file_path"
+        file_path = tool_input.get(path_key, "")
+        if not file_path:
+            return
 
-    path_key = "notebook_path" if tool_name == "NotebookEdit" else "file_path"
-    file_path = tool_input.get(path_key, "")
-    if not file_path:
-        return
+        parts = file_path.split("/")
+        if ".claire" not in parts:
+            return
 
-    parts = file_path.split("/")
-    if ".claire" not in parts:
-        return
+        corrected_parts = [".claude" if p == ".claire" else p for p in parts]
+        corrected = "/".join(corrected_parts)
 
-    corrected_parts = [".claude" if p == ".claire" else p for p in parts]
-    corrected = "/".join(corrected_parts)
+        corrected_input = dict(tool_input)
+        corrected_input[path_key] = corrected
 
-    corrected_input = dict(tool_input)
-    corrected_input[path_key] = corrected
-
-    _log_event("guard", "rewrite", rule="claire-typo", command=f"{file_path} → {corrected}")
-    print(
-        _hook_output(
-            "allow",
-            "Corrected .claire → .claude hallucination",
-            updated_input=corrected_input,
+        _log_event("guard", "rewrite", rule="claire-typo", command=f"{file_path} → {corrected}")
+        print(
+            _hook_output(
+                "allow",
+                "Corrected .claire → .claude hallucination",
+                updated_input=corrected_input,
+            )
         )
-    )
-    print(f"[claire-typo-guard] Corrected .claire → .claude: {corrected}", file=sys.stderr)
-    sys.exit(0)
+        print(f"[claire-typo-guard] Corrected .claire → .claude: {corrected}", file=sys.stderr)
+        sys.exit(0)
+
+    elif tool_name == "Bash":
+        command = tool_input.get("command", "")
+        if not command or not _CLAIRE_PATH_RE.search(command):
+            return
+        _exit_with_decision(
+            ".claire is a known LLM hallucination of .claude "
+            "(anthropics/claude-code#17893). "
+            "Replace .claire with .claude in your command and retry.",
+            "block",
+            rule_name="claire-typo-bash",
+            matched_segment=command[:80],
+        )
 
 
 _FETCH_PATTERN = re.compile(r"git\s+fetch\s+(upstream|origin)\b")

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -3770,11 +3770,13 @@ def main() -> None:
         _handle_post_tool_use(data)
         sys.exit(0)
 
-    # Increment tool call counter (PreToolUse only — Post hooks don't count)
-    if _session_id:
-        _increment_tool_counter(_session_id)
-
     tool_name = data.get("tool_name", "")
+
+    # Increment tool call counter (PreToolUse only — Post hooks don't count).
+    # Skip Read: it was added to PreToolUse solely for .claire path correction
+    # and counting it would inflate the metric vs its established baseline.
+    if _session_id and tool_name != "Read":
+        _increment_tool_counter(_session_id)
     tool_input = data.get("tool_input", {})
 
     _guard_tmp_path(tool_name, tool_input)

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -1844,6 +1844,44 @@ def _guard_plan_mode(tool_name: str) -> None:
         )
 
 
+def _guard_claire_typo(tool_name: str, tool_input: dict) -> None:
+    """Rewrite .claire → .claude in file paths (LLM hallucination mitigation).
+
+    Claude models occasionally transpose '.claude' → '.claire' when constructing
+    paths from memory (anthropics/claude-code#17893). The Write tool auto-creates
+    intermediate directories, silently producing stray .claire/ trees. This guard
+    intercepts the typo and rewrites it before the tool executes.
+    """
+    if tool_name not in ("Write", "Edit", "NotebookEdit"):
+        return
+
+    path_key = "notebook_path" if tool_name == "NotebookEdit" else "file_path"
+    file_path = tool_input.get(path_key, "")
+    if not file_path:
+        return
+
+    parts = file_path.split("/")
+    if ".claire" not in parts:
+        return
+
+    corrected_parts = [".claude" if p == ".claire" else p for p in parts]
+    corrected = "/".join(corrected_parts)
+
+    corrected_input = dict(tool_input)
+    corrected_input[path_key] = corrected
+
+    _log_event("guard", "rewrite", rule="claire-typo", command=f"{file_path} → {corrected}")
+    print(
+        _hook_output(
+            "allow",
+            "Corrected .claire → .claude hallucination",
+            updated_input=corrected_input,
+        )
+    )
+    print(f"[claire-typo-guard] Corrected .claire → .claude: {corrected}", file=sys.stderr)
+    sys.exit(0)
+
+
 _FETCH_PATTERN = re.compile(r"git\s+fetch\s+(upstream|origin)\b")
 
 
@@ -3726,6 +3764,7 @@ def main() -> None:
 
     _guard_tmp_path(tool_name, tool_input)
     _guard_plan_mode(tool_name)
+    _guard_claire_typo(tool_name, tool_input)
 
     if tool_name == "WebFetch":
         _handle_webfetch(tool_input)

--- a/dev-guard/hooks/tool-selection-guard.py
+++ b/dev-guard/hooks/tool-selection-guard.py
@@ -1844,7 +1844,9 @@ def _guard_plan_mode(tool_name: str) -> None:
         )
 
 
-_CLAIRE_PATH_RE = re.compile(r"(?<=[\s/])\.claire(?=[\s/]|$)|^\.claire(?=[\s/]|$)")
+_CLAIRE_PATH_RE = re.compile(
+    r"(?<=[\s/])\.claire(?=[^a-zA-Z0-9_-]|$)|^\.claire(?=[^a-zA-Z0-9_-]|$)"
+)
 
 
 def _guard_claire_typo(tool_name: str, tool_input: dict) -> None:

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1173,6 +1173,116 @@ class TestNonBashTmpBlocking:
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# .claire → .claude hallucination guard
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestClaireTypoGuard:
+    """LLM hallucination mitigation: .claire → .claude path rewriting."""
+
+    def test_write_claire_rewritten(self):
+        result = run_guard(
+            "Write",
+            {
+                "file_path": "/Users/foo/.claire/worktrees/agent-1/src/api/notifications.ts",
+                "content": "export {}",
+            },
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        hook = output["hookSpecificOutput"]
+        assert hook["permissionDecision"] == "allow"
+        assert hook["updatedInput"]["file_path"] == (
+            "/Users/foo/.claude/worktrees/agent-1/src/api/notifications.ts"
+        )
+        assert hook["updatedInput"]["content"] == "export {}"
+        assert ".claire" in result.stderr
+
+    def test_edit_claire_rewritten(self):
+        result = run_guard(
+            "Edit",
+            {
+                "file_path": "/Users/foo/.claire/settings.json",
+                "old_string": "a",
+                "new_string": "b",
+            },
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        hook = output["hookSpecificOutput"]
+        assert hook["updatedInput"]["file_path"] == "/Users/foo/.claude/settings.json"
+        assert hook["updatedInput"]["old_string"] == "a"
+
+    def test_notebook_claire_rewritten(self):
+        result = run_guard(
+            "NotebookEdit",
+            {
+                "notebook_path": "/Users/foo/.claire/notebooks/test.ipynb",
+                "command": "add",
+            },
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        hook = output["hookSpecificOutput"]
+        assert hook["updatedInput"]["notebook_path"] == ("/Users/foo/.claude/notebooks/test.ipynb")
+
+    def test_relative_claire_rewritten(self):
+        result = run_guard(
+            "Write",
+            {
+                "file_path": ".claire/worktrees/agent-1/file.ts",
+                "content": "",
+            },
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["hookSpecificOutput"]["updatedInput"]["file_path"] == (
+            ".claude/worktrees/agent-1/file.ts"
+        )
+
+    def test_claude_path_not_rewritten(self):
+        result = run_guard(
+            "Write",
+            {
+                "file_path": "/Users/foo/.claude/worktrees/agent-1/file.ts",
+                "content": "",
+            },
+        )
+        assert result.returncode == 0
+        assert not result.stdout.strip()
+
+    def test_claire_in_filename_not_rewritten(self):
+        result = run_guard(
+            "Write",
+            {
+                "file_path": "/Users/foo/project/claire_report.md",
+                "content": "",
+            },
+        )
+        assert result.returncode == 0
+        assert not result.stdout.strip()
+
+    def test_read_tool_not_affected(self):
+        result = run_guard(
+            "Read",
+            {
+                "file_path": "/Users/foo/.claire/settings.json",
+            },
+        )
+        assert result.returncode == 0
+        assert not result.stdout.strip()
+
+    def test_bash_tool_not_affected(self):
+        result = run_guard(
+            "Bash",
+            {
+                "command": "git status .claire/",
+            },
+        )
+        assert result.returncode == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # Whitespace edge cases
 # ═══════════════════════════════════════════════════════════════════════════════
 

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1226,6 +1226,7 @@ class TestClaireTypoGuard:
         output = json.loads(result.stdout)
         hook = output["hookSpecificOutput"]
         assert hook["updatedInput"]["notebook_path"] == ("/Users/foo/.claude/notebooks/test.ipynb")
+        assert hook["updatedInput"]["command"] == "add"
 
     def test_relative_claire_rewritten(self):
         result = run_guard(

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1329,6 +1329,7 @@ class TestClaireTypoGuard:
             },
         )
         assert result.returncode == 0
+        assert "claire-typo" not in (result.stdout + result.stderr)
 
     def test_bash_claire_in_grep_not_blocked(self):
         result = run_guard(
@@ -1338,6 +1339,7 @@ class TestClaireTypoGuard:
             },
         )
         assert result.returncode == 0
+        assert "claire-typo" not in (result.stdout + result.stderr)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1212,6 +1212,7 @@ class TestClaireTypoGuard:
         hook = output["hookSpecificOutput"]
         assert hook["updatedInput"]["file_path"] == "/Users/foo/.claude/settings.json"
         assert hook["updatedInput"]["old_string"] == "a"
+        assert hook["updatedInput"]["new_string"] == "b"
 
     def test_notebook_claire_rewritten(self):
         result = run_guard(
@@ -1238,6 +1239,20 @@ class TestClaireTypoGuard:
         output = json.loads(result.stdout)
         assert output["hookSpecificOutput"]["updatedInput"]["file_path"] == (
             ".claude/worktrees/agent-1/file.ts"
+        )
+
+    def test_multiple_claire_segments_rewritten(self):
+        result = run_guard(
+            "Write",
+            {
+                "file_path": "/Users/foo/.claire/projects/.claire/file.py",
+                "content": "",
+            },
+        )
+        assert result.returncode == 0
+        output = json.loads(result.stdout)
+        assert output["hookSpecificOutput"]["updatedInput"]["file_path"] == (
+            "/Users/foo/.claude/projects/.claude/file.py"
         )
 
     def test_claude_path_not_rewritten(self):

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1278,7 +1278,7 @@ class TestClaireTypoGuard:
         assert result.returncode == 0
         assert not result.stdout.strip()
 
-    def test_read_tool_not_affected(self):
+    def test_read_claire_rewritten(self):
         result = run_guard(
             "Read",
             {
@@ -1286,17 +1286,58 @@ class TestClaireTypoGuard:
             },
         )
         assert result.returncode == 0
-        assert not result.stdout.strip()
+        output = json.loads(result.stdout)
+        hook = output["hookSpecificOutput"]
+        assert hook["updatedInput"]["file_path"] == "/Users/foo/.claude/settings.json"
 
-    def test_bash_tool_not_affected(self):
+    def test_read_claude_not_rewritten(self):
         result = run_guard(
-            "Bash",
+            "Read",
             {
-                "command": "git status .claire/",
+                "file_path": "/Users/foo/.claude/settings.json",
             },
         )
         assert result.returncode == 0
-        assert "claire-typo" not in result.stdout
+        assert "claire-typo" not in (result.stdout + result.stderr)
+
+    def test_bash_claire_path_blocked(self):
+        result = run_guard(
+            "Bash",
+            {
+                "command": "mkdir -p /Users/foo/.claire/worktrees/agent-1/",
+            },
+        )
+        assert result.returncode == 2
+        assert ".claire" in result.stderr
+        assert ".claude" in result.stderr
+
+    def test_bash_claire_relative_blocked(self):
+        result = run_guard(
+            "Bash",
+            {
+                "command": "cp file.ts .claire/worktrees/agent-1/",
+            },
+        )
+        assert result.returncode == 2
+        assert ".claire" in result.stderr
+
+    def test_bash_claude_path_not_blocked(self):
+        result = run_guard(
+            "Bash",
+            {
+                "command": "git status .claude/",
+            },
+        )
+        assert result.returncode == 0
+
+    def test_bash_claire_in_grep_not_blocked(self):
+        result = run_guard(
+            "Bash",
+            {
+                "command": 'git log -S ".claire"',
+            },
+        )
+        assert result.returncode == 0
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1280,6 +1280,7 @@ class TestClaireTypoGuard:
             },
         )
         assert result.returncode == 0
+        assert "claire-typo" not in result.stdout
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -1321,6 +1321,36 @@ class TestClaireTypoGuard:
         assert result.returncode == 2
         assert ".claire" in result.stderr
 
+    def test_bash_claire_with_semicolon_blocked(self):
+        result = run_guard(
+            "Bash",
+            {
+                "command": "mkdir .claire;ls",
+            },
+        )
+        assert result.returncode == 2
+        assert "claire-typo" in result.stderr
+
+    def test_bash_claire_with_pipe_blocked(self):
+        result = run_guard(
+            "Bash",
+            {
+                "command": "ls .claire|wc -l",
+            },
+        )
+        assert result.returncode == 2
+        assert "claire-typo" in result.stderr
+
+    def test_bash_clairewood_not_blocked(self):
+        result = run_guard(
+            "Bash",
+            {
+                "command": "git status .clairewood/",
+            },
+        )
+        assert result.returncode == 0
+        assert "claire-typo" not in (result.stdout + result.stderr)
+
     def test_bash_claude_path_not_blocked(self):
         result = run_guard(
             "Bash",


### PR DESCRIPTION
## Summary
- Adds PreToolUse guard that rewrites .claire to .claude in Write/Edit/NotebookEdit file paths via updatedInput, mitigating anthropics/claude-code#17893
- Adds .claire/ to .gitignore as a safety net for Bash-based directory creation
- dev-guard 1.60.1 → 1.61.0