### PR TITLE
fix(region): change default CLOUD_ML_REGION from us-east5 to global

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.60.1",
+      "version": "1.61.0",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback",
-  "version": "1.60.1",
+  "version": "1.61.0",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -35,7 +35,7 @@ Fails open (exits 0) on any infrastructure error (import, auth, timeout, parse).
 
 Environment variables:
   ANTHROPIC_VERTEX_PROJECT_ID      -- GCP project ID (required)
-  CLOUD_ML_REGION                  -- Vertex AI region (default: us-east5)
+  CLOUD_ML_REGION                  -- Vertex AI region (default: global)
   ANTHROPIC_DEFAULT_SONNET_MODEL   -- model override (default: claude-sonnet-4-6)
 """
 
@@ -347,7 +347,7 @@ def _call_vertex(prompt: str) -> dict:
         _fail_open(f"anthropic[vertex] not available: {e}")
 
     project_id = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
-    region = os.environ.get("CLOUD_ML_REGION", "us-east5")
+    region = os.environ.get("CLOUD_ML_REGION", "global")
 
     if not project_id:
         _fail_open("ANTHROPIC_VERTEX_PROJECT_ID env var not set")

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -1881,34 +1881,42 @@ class TestCallVertexRegion:
 
     def test_default_region_is_global(self, monkeypatch):
         """CLOUD_ML_REGION absent → AnthropicVertex constructed with region='global'."""
-        from unittest.mock import MagicMock, patch
+        import sys
+        import types
+        from unittest.mock import MagicMock
 
-        mod = self._load_llm_module()
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "test-project")
         monkeypatch.delenv("CLOUD_ML_REGION", raising=False)
 
         mock_client = self._make_mock_client()
         mock_cls = MagicMock(return_value=mock_client)
+        fake_anthropic = types.ModuleType("anthropic")
+        fake_anthropic.AnthropicVertex = mock_cls
+        monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic)
 
-        with patch("anthropic.AnthropicVertex", mock_cls):
-            result = mod._call_vertex("test prompt")
+        mod = self._load_llm_module()
+        result = mod._call_vertex("test prompt")
 
         mock_cls.assert_called_once_with(project_id="test-project", region="global")
         assert result["decision"] == "pass"
 
     def test_region_from_env_var(self, monkeypatch):
         """CLOUD_ML_REGION='us-central1' → AnthropicVertex constructed with that region."""
-        from unittest.mock import MagicMock, patch
+        import sys
+        import types
+        from unittest.mock import MagicMock
 
-        mod = self._load_llm_module()
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "test-project")
         monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
 
         mock_client = self._make_mock_client()
         mock_cls = MagicMock(return_value=mock_client)
+        fake_anthropic = types.ModuleType("anthropic")
+        fake_anthropic.AnthropicVertex = mock_cls
+        monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic)
 
-        with patch("anthropic.AnthropicVertex", mock_cls):
-            result = mod._call_vertex("test prompt")
+        mod = self._load_llm_module()
+        result = mod._call_vertex("test prompt")
 
         mock_cls.assert_called_once_with(project_id="test-project", region="us-central1")
         assert result["decision"] == "pass"

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -1854,6 +1854,66 @@ class TestBuildPromptCriteria:
         assert "See </assistant-message> for details." not in prompt
 
 
+# ── Unit tests for _call_vertex region default ────────────────────────────────
+
+
+class TestCallVertexRegion:
+    """Unit tests for _call_vertex region parameter — default and env var override."""
+
+    @staticmethod
+    def _load_llm_module():
+        spec = importlib.util.spec_from_file_location("stop_hook_llm", LLM_SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    @staticmethod
+    def _make_mock_client():
+        from unittest.mock import MagicMock
+
+        mock_block = MagicMock()
+        mock_block.text = '{"decision": "pass", "reasoning": "ok", "findings": null}'
+        mock_message = MagicMock()
+        mock_message.content = [mock_block]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_message
+        return mock_client
+
+    def test_default_region_is_global(self, monkeypatch):
+        """CLOUD_ML_REGION absent → AnthropicVertex constructed with region='global'."""
+        from unittest.mock import MagicMock, patch
+
+        mod = self._load_llm_module()
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "test-project")
+        monkeypatch.delenv("CLOUD_ML_REGION", raising=False)
+
+        mock_client = self._make_mock_client()
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("anthropic.AnthropicVertex", mock_cls):
+            result = mod._call_vertex("test prompt")
+
+        mock_cls.assert_called_once_with(project_id="test-project", region="global")
+        assert result["decision"] == "pass"
+
+    def test_region_from_env_var(self, monkeypatch):
+        """CLOUD_ML_REGION='us-central1' → AnthropicVertex constructed with that region."""
+        from unittest.mock import MagicMock, patch
+
+        mod = self._load_llm_module()
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "test-project")
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-central1")
+
+        mock_client = self._make_mock_client()
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("anthropic.AnthropicVertex", mock_cls):
+            result = mod._call_vertex("test prompt")
+
+        mock_cls.assert_called_once_with(project_id="test-project", region="us-central1")
+        assert result["decision"] == "pass"
+
+
 # ── Unit tests for _detect_deferral_patterns ─────────────────────────────────
 
 

--- a/dev-guard/tests/test_stop_hook_llm_integration.py
+++ b/dev-guard/tests/test_stop_hook_llm_integration.py
@@ -77,7 +77,7 @@ def _call_evaluator(ctx: dict) -> dict:
     from anthropic import AnthropicVertex
 
     project_id = os.environ["ANTHROPIC_VERTEX_PROJECT_ID"]
-    region = os.environ.get("CLOUD_ML_REGION", "us-east5")
+    region = os.environ.get("CLOUD_ML_REGION", "global")
 
     client = AnthropicVertex(project_id=project_id, region=region)
     message = client.messages.create(

--- a/skill-eval/skill_eval/judge.py
+++ b/skill-eval/skill_eval/judge.py
@@ -1,7 +1,7 @@
 """Vertex AI judge adapter for DeepEval skill evaluation.
 
 Uses claude-sonnet-4-6 via AnthropicVertex for LLM-as-judge assessments.
-Reads ANTHROPIC_VERTEX_PROJECT_ID and CLOUD_ML_REGION env vars.
+Reads ANTHROPIC_VERTEX_PROJECT_ID and CLOUD_ML_REGION env vars (default: global).
 
 Multi-trial averaging (K-trial):
   When k_samples > 1 and a schema is requested (the GEval scoring path),
@@ -56,7 +56,7 @@ class VertexSonnetJudge(DeepEvalBaseLLM):
         self._k_samples = k_samples
         self._eval_temperature = eval_temperature
         project_id = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
-        region = os.environ.get("CLOUD_ML_REGION", "us-east5")
+        region = os.environ.get("CLOUD_ML_REGION", "global")
         try:
             self.client = anthropic.AnthropicVertex(
                 project_id=project_id,

--- a/skill-eval/tests/test_skill_eval.py
+++ b/skill-eval/tests/test_skill_eval.py
@@ -785,6 +785,47 @@ class TestMultiTrialAveraging:
             # 4.5 is not one of the 11 discrete values (0.0, 0.1, ..., 1.0)
             # demonstrating the continuous score benefit
 
+    def test_constructor_default_region_is_global(self):
+        """When CLOUD_ML_REGION is absent, AnthropicVertex is called with region='global'."""
+        import os
+
+        env = {k: v for k, v in os.environ.items() if k != "CLOUD_ML_REGION"}
+        env["ANTHROPIC_VERTEX_PROJECT_ID"] = "test-project"
+        with (
+            patch("skill_eval.judge.anthropic.AnthropicVertex") as mock_vertex,
+            patch("skill_eval.judge.instructor.from_anthropic"),
+            patch.dict("os.environ", env, clear=True),
+        ):
+            from skill_eval.judge import VertexSonnetJudge
+
+            VertexSonnetJudge()
+            mock_vertex.assert_called_once_with(
+                project_id="test-project",
+                region="global",
+                timeout=600.0,
+            )
+
+    def test_constructor_cloud_ml_region_override(self):
+        """When CLOUD_ML_REGION is set, AnthropicVertex receives that region."""
+        import os
+
+        env = {k: v for k, v in os.environ.items()}
+        env["CLOUD_ML_REGION"] = "us-central1"
+        env["ANTHROPIC_VERTEX_PROJECT_ID"] = "test-project"
+        with (
+            patch("skill_eval.judge.anthropic.AnthropicVertex") as mock_vertex,
+            patch("skill_eval.judge.instructor.from_anthropic"),
+            patch.dict("os.environ", env, clear=True),
+        ):
+            from skill_eval.judge import VertexSonnetJudge
+
+            VertexSonnetJudge()
+            mock_vertex.assert_called_once_with(
+                project_id="test-project",
+                region="us-central1",
+                timeout=600.0,
+            )
+
 
 # ── Group 10: Eval integrity guard (--locked) ─────────────────────────────
 


### PR DESCRIPTION
## Summary
- Change all hardcoded us-east5 fallback defaults to global in dev-guard and skill-eval
- Affects stop-hook-llm.py, test_stop_hook_llm_integration.py, and judge.py