### PR TITLE
fix(dev-guard): makes fail-open events visible in stop-hook audit trail

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.62.1",
+      "version": "1.62.2",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback, path hallucination guard",
       "category": "quality",

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback, path hallucination guard",
-  "version": "1.62.1",
+  "version": "1.62.2",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/hooks/guard-stats.py
+++ b/dev-guard/hooks/guard-stats.py
@@ -150,20 +150,23 @@ def _stop_hook_stats(conn: sqlite3.Connection, since: str) -> None:
     passes = stats.get("llm_pass", 0)
     fails = stats.get("llm_fail", 0)
     errors = stats.get("llm_error", 0)
-    print(f"  LLM evaluations: {total}   Pass: {passes}   Fail: {fails}   Error: {errors}")
+    fail_opens = stats.get("llm_fail_open", 0)
+    infra_errors = errors + fail_opens
+    print(
+        f"  LLM evaluations: {total}   Pass: {passes}   Fail: {fails}"
+        f"   Error: {errors}   Fail-open: {fail_opens}"
+    )
     print("  (fast-exit invocations not counted — only events reaching LLM)")
 
-    if errors > 0:
-        error_pct = 100 * errors // total
-        print(
-            f"  ERROR RATE: {error_pct}% — LLM may be unreachable, "
-            f"stop hook is silently failing open"
-        )
+    if infra_errors > 0:
+        error_pct = 100 * infra_errors // total
+        print(f"  ERROR RATE: {error_pct}% — LLM may be unreachable, stop hook is failing open")
 
-    # Average LLM time (exclude errors)
+    # Average LLM time (exclude infrastructure errors)
     row = conn.execute(
         "SELECT AVG(llm_duration_ms) FROM stop_hook_events "
-        "WHERE ts > ? AND outcome != 'llm_error' AND llm_duration_ms IS NOT NULL",
+        "WHERE ts > ? AND outcome NOT IN ('llm_error', 'llm_fail_open') "
+        "AND llm_duration_ms IS NOT NULL",
         (since,),
     ).fetchone()
     if row and row[0]:

--- a/dev-guard/hooks/guard-stats.py
+++ b/dev-guard/hooks/guard-stats.py
@@ -189,6 +189,18 @@ def _stop_hook_stats(conn: sqlite3.Connection, since: str) -> None:
                 first = str(detail)[:60]
             print(f"    {ts[:10]}: {first}")
 
+    # Recent fail-opens
+    fail_open_rows = conn.execute(
+        "SELECT ts, detail FROM stop_hook_events "
+        "WHERE ts > ? AND outcome = 'llm_fail_open' AND detail IS NOT NULL "
+        "ORDER BY ts DESC LIMIT 3",
+        (since,),
+    ).fetchall()
+    if fail_open_rows:
+        print("  Recent fail-opens:")
+        for ts, detail in fail_open_rows:
+            print(f"    {ts[:10]}: {str(detail)[:80]}")
+
 
 def _session_summaries(conn: sqlite3.Connection, since: str) -> None:
     rows = conn.execute(

--- a/dev-guard/hooks/guard-stats.py
+++ b/dev-guard/hooks/guard-stats.py
@@ -151,7 +151,7 @@ def _stop_hook_stats(conn: sqlite3.Connection, since: str) -> None:
     fails = stats.get("llm_fail", 0)
     errors = stats.get("llm_error", 0)
     fail_opens = stats.get("llm_fail_open", 0)
-    infra_errors = errors + fail_opens
+    infra_errors = errors + fail_opens  # as pct of all LLM evaluations below
     print(
         f"  LLM evaluations: {total}   Pass: {passes}   Fail: {fails}"
         f"   Error: {errors}   Fail-open: {fail_opens}"

--- a/dev-guard/hooks/stop-hook-llm.py
+++ b/dev-guard/hooks/stop-hook-llm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run
 # /// script
 # requires-python = ">=3.13"
-# dependencies = ["anthropic[vertex]>=0.40.0"]
+# dependencies = ["anthropic[vertex]>=0.59.0"]
 # ///
 """Stop Hook LLM Evaluator -- Sonnet quality gate via Vertex AI.
 
@@ -35,7 +35,7 @@ Fails open (exits 0) on any infrastructure error (import, auth, timeout, parse).
 
 Environment variables:
   ANTHROPIC_VERTEX_PROJECT_ID      -- GCP project ID (required)
-  CLOUD_ML_REGION                  -- Vertex AI region (default: global)
+  CLOUD_ML_REGION                  -- Vertex AI region (default: global; requires SDK >=0.59.0)
   ANTHROPIC_DEFAULT_SONNET_MODEL   -- model override (default: claude-sonnet-4-6)
 """
 

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -831,7 +831,7 @@ def _invoke_llm(
 
         reasoning = response.get("reasoning", "")
         if _FAIL_OPEN_SENTINEL in reasoning:
-            return decision, findings, True, reasoning
+            return decision, findings, True, reasoning[:500]
 
         return decision, findings, False, None
 

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -777,6 +777,7 @@ def _log_stop_event(
 # ── LLM Delegation ───────────────────────────────────────────────────────────
 
 
+# Must match the f-string prefix in stop-hook-llm.py:_fail_open
 _FAIL_OPEN_SENTINEL = "LLM evaluator failed open:"
 
 

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -830,7 +830,7 @@ def _invoke_llm(
             findings = None
 
         reasoning = response.get("reasoning", "")
-        if _FAIL_OPEN_SENTINEL in reasoning:
+        if isinstance(reasoning, str) and reasoning.startswith(_FAIL_OPEN_SENTINEL):
             return decision, findings, True, reasoning[:500]
 
         return decision, findings, False, None
@@ -1105,7 +1105,7 @@ def main() -> None:
 
     # ── Log the outcome ──────────────────────────────────────────────────────
     if llm_error:
-        is_fail_open = llm_detail and _FAIL_OPEN_SENTINEL in llm_detail
+        is_fail_open = isinstance(llm_detail, str) and llm_detail.startswith(_FAIL_OPEN_SENTINEL)
         outcome = "llm_fail_open" if is_fail_open else "llm_error"
         detail = llm_detail
     elif decision == "fail":

--- a/dev-guard/hooks/stop-hook.py
+++ b/dev-guard/hooks/stop-hook.py
@@ -777,16 +777,20 @@ def _log_stop_event(
 # ── LLM Delegation ───────────────────────────────────────────────────────────
 
 
+_FAIL_OPEN_SENTINEL = "LLM evaluator failed open:"
+
+
 def _invoke_llm(
     context: dict,
     plugin_root: str,
-) -> tuple[str, list[str] | None, bool]:
+) -> tuple[str, list[str] | None, bool, str | None]:
     """Invoke stop-hook-llm.py subprocess.
 
-    Returns (decision, findings, error) where:
+    Returns (decision, findings, error, detail) where:
       decision: 'pass' or 'fail'
       findings: list of finding strings, or None
       error: True if the LLM was unreachable/broken (fail-open)
+      detail: diagnostic string on error (stderr or fail-open reason)
     """
     llm_script = Path(plugin_root) / "hooks" / "stop-hook-llm.py"
 
@@ -797,20 +801,25 @@ def _invoke_llm(
             capture_output=True,
             timeout=_LLM_TIMEOUT,
         )
+
+        stderr_text = (
+            result.stderr.decode(errors="replace").strip()[:500] if result.stderr else None
+        )
+
         if result.returncode not in (0, 2):
-            return "pass", None, True
+            return "pass", None, True, stderr_text
 
         stdout = result.stdout.strip()
         if not stdout:
-            return "pass", None, True
+            return "pass", None, True, stderr_text
 
         try:
             response = json.loads(stdout)
         except (json.JSONDecodeError, ValueError):
-            return "pass", None, True
+            return "pass", None, True, stderr_text
 
         if not isinstance(response, dict):
-            return "pass", None, True
+            return "pass", None, True, stderr_text
 
         decision = response.get("decision", "pass")
         if decision not in ("pass", "fail"):
@@ -820,10 +829,14 @@ def _invoke_llm(
         if not isinstance(findings, list):
             findings = None
 
-        return decision, findings, False
+        reasoning = response.get("reasoning", "")
+        if _FAIL_OPEN_SENTINEL in reasoning:
+            return decision, findings, True, reasoning
 
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        return "pass", None, True
+        return decision, findings, False, None
+
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return "pass", None, True, f"{type(e).__name__}: {e}"
 
 
 # ── Exit Helpers ─────────────────────────────────────────────────────────────
@@ -1087,13 +1100,14 @@ def main() -> None:
     # ── Invoke LLM ───────────────────────────────────────────────────────────
     plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT", "")
     t0 = time.monotonic()
-    decision, findings, llm_error = _invoke_llm(llm_context, plugin_root)
+    decision, findings, llm_error, llm_detail = _invoke_llm(llm_context, plugin_root)
     llm_ms = int((time.monotonic() - t0) * 1000)
 
     # ── Log the outcome ──────────────────────────────────────────────────────
     if llm_error:
-        outcome = "llm_error"
-        detail = None
+        is_fail_open = llm_detail and _FAIL_OPEN_SENTINEL in llm_detail
+        outcome = "llm_fail_open" if is_fail_open else "llm_error"
+        detail = llm_detail
     elif decision == "fail":
         outcome = "llm_fail"
         detail = json.dumps(findings) if findings else None

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -96,6 +96,7 @@ def write_mock_llm(
     *,
     decision: str = "pass",
     findings: list[str] | None = None,
+    reasoning: str = "mock",
 ) -> None:
     """Write a mock stop-hook-llm.py stub to plugin_root/hooks/.
 
@@ -105,7 +106,7 @@ def write_mock_llm(
     hooks_dir = plugin_root / "hooks"
     hooks_dir.mkdir(parents=True, exist_ok=True)
     # Embed as a JSON string constant parsed at runtime — avoids null/None mismatch
-    result_json = json.dumps({"decision": decision, "reasoning": "mock", "findings": findings})
+    result_json = json.dumps({"decision": decision, "reasoning": reasoning, "findings": findings})
     stub = textwrap.dedent(f"""\
         #!/usr/bin/env -S uv run
         # /// script
@@ -813,6 +814,33 @@ class TestLLMSubprocess:
         """LLM script at unreachable path → FileNotFoundError → fail-open → exit 0."""
         payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
         result = run_hook(payload, state_path=state_path, plugin_root="/nonexistent/path")
+        assert result.returncode == 0
+
+    def test_fail_open_sentinel_detected_in_reasoning(self, tmp_path):
+        """LLM returns pass with fail-open sentinel → exit 0 but logged as llm_fail_open."""
+        plugin_root = tmp_path / "plugin"
+        write_mock_llm(
+            plugin_root,
+            decision="pass",
+            reasoning="LLM evaluator failed open: Vertex AI call failed: TimeoutError",
+        )
+        payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
+        result = run_hook(payload, state_path=state_path, plugin_root=str(plugin_root))
+        assert result.returncode == 0
+
+    def test_fail_open_sentinel_not_triggered_by_quoted_text(self, tmp_path):
+        """LLM reasoning quoting the sentinel mid-text → NOT classified as fail-open."""
+        plugin_root = tmp_path / "plugin"
+        write_mock_llm(
+            plugin_root,
+            decision="pass",
+            reasoning=(
+                "The assistant discussed the LLM evaluator failed open: pattern "
+                "in stop-hook-llm.py source code. This is legitimate code review."
+            ),
+        )
+        payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
+        result = run_hook(payload, state_path=state_path, plugin_root=str(plugin_root))
         assert result.returncode == 0
 
 

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -8,6 +8,7 @@ LLM subprocess invocation tested via a mock stop-hook-llm.py stub.
 import importlib.util
 import json
 import os
+import sqlite3
 import subprocess
 import textwrap
 import time
@@ -817,7 +818,7 @@ class TestLLMSubprocess:
         assert result.returncode == 0
 
     def test_fail_open_sentinel_detected_in_reasoning(self, tmp_path):
-        """LLM returns pass with fail-open sentinel → exit 0 but logged as llm_fail_open."""
+        """LLM returns pass with fail-open sentinel → exit 0, logged as llm_fail_open."""
         plugin_root = tmp_path / "plugin"
         write_mock_llm(
             plugin_root,
@@ -827,9 +828,17 @@ class TestLLMSubprocess:
         payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
         result = run_hook(payload, state_path=state_path, plugin_root=str(plugin_root))
         assert result.returncode == 0
+        db_path = state_path.parent / "test-guard.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT outcome FROM stop_hook_events ORDER BY ts DESC LIMIT 1"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "llm_fail_open"
 
     def test_fail_open_sentinel_not_triggered_by_quoted_text(self, tmp_path):
-        """LLM reasoning quoting the sentinel mid-text → NOT classified as fail-open."""
+        """LLM reasoning quoting the sentinel mid-text → logged as llm_pass, not fail-open."""
         plugin_root = tmp_path / "plugin"
         write_mock_llm(
             plugin_root,
@@ -842,6 +851,14 @@ class TestLLMSubprocess:
         payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
         result = run_hook(payload, state_path=state_path, plugin_root=str(plugin_root))
         assert result.returncode == 0
+        db_path = state_path.parent / "test-guard.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT outcome FROM stop_hook_events ORDER BY ts DESC LIMIT 1"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "llm_pass"
 
 
 # ── State file management ────────────────────────────────────────────────────

--- a/dev-guard/tests/test_stop_hook.py
+++ b/dev-guard/tests/test_stop_hook.py
@@ -804,18 +804,36 @@ class TestLLMSubprocess:
         assert output["reason"]  # non-empty reason
 
     def test_missing_llm_script_fails_open(self, tmp_path):
-        """No stop-hook-llm.py → subprocess fails → fail-open → exit 0."""
+        """No stop-hook-llm.py → subprocess fails → fail-open → exit 0, logged as llm_error."""
         (tmp_path / "plugin" / "hooks").mkdir(parents=True, exist_ok=True)
         # No llm script written
         payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
         result = run_hook(payload, state_path=state_path, plugin_root=str(tmp_path / "plugin"))
         assert result.returncode == 0
+        db_path = state_path.parent / "test-guard.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT outcome, detail FROM stop_hook_events ORDER BY ts DESC LIMIT 1"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "llm_error"
+        assert row[1] is not None
 
     def test_llm_unreachable_fails_open(self, tmp_path):
-        """LLM script at unreachable path → FileNotFoundError → fail-open → exit 0."""
+        """Unreachable path → FileNotFoundError → fail-open → exit 0, logged as llm_error."""
         payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
         result = run_hook(payload, state_path=state_path, plugin_root="/nonexistent/path")
         assert result.returncode == 0
+        db_path = state_path.parent / "test-guard.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT outcome, detail FROM stop_hook_events ORDER BY ts DESC LIMIT 1"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "llm_error"
+        assert row[1] is not None
 
     def test_fail_open_sentinel_detected_in_reasoning(self, tmp_path):
         """LLM returns pass with fail-open sentinel → exit 0, logged as llm_fail_open."""
@@ -831,11 +849,13 @@ class TestLLMSubprocess:
         db_path = state_path.parent / "test-guard.db"
         conn = sqlite3.connect(str(db_path))
         row = conn.execute(
-            "SELECT outcome FROM stop_hook_events ORDER BY ts DESC LIMIT 1"
+            "SELECT outcome, detail FROM stop_hook_events ORDER BY ts DESC LIMIT 1"
         ).fetchone()
         conn.close()
         assert row is not None
         assert row[0] == "llm_fail_open"
+        assert row[1] is not None
+        assert row[1].startswith("LLM evaluator failed open:")
 
     def test_fail_open_sentinel_not_triggered_by_quoted_text(self, tmp_path):
         """LLM reasoning quoting the sentinel mid-text → logged as llm_pass, not fail-open."""
@@ -859,6 +879,70 @@ class TestLLMSubprocess:
         conn.close()
         assert row is not None
         assert row[0] == "llm_pass"
+
+    def test_llm_nonzero_returncode_logs_llm_error_with_stderr(self, tmp_path):
+        """LLM subprocess exits with returncode 1 → llm_error, detail contains stderr text."""
+        plugin_root = tmp_path / "plugin"
+        hooks_dir = plugin_root / "hooks"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        stub = textwrap.dedent("""\
+            #!/usr/bin/env -S uv run
+            # /// script
+            # requires-python = ">=3.13"
+            # ///
+            import sys
+            print("subprocess failed hard", file=sys.stderr)
+            sys.exit(1)
+        """)
+        llm_script = hooks_dir / "stop-hook-llm.py"
+        llm_script.write_text(stub)
+        llm_script.chmod(0o755)
+
+        payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
+        result = run_hook(payload, state_path=state_path, plugin_root=str(plugin_root))
+        assert result.returncode == 0
+        db_path = state_path.parent / "test-guard.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT outcome, detail FROM stop_hook_events ORDER BY ts DESC LIMIT 1"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "llm_error"
+        assert row[1] is not None
+        assert "subprocess failed hard" in row[1]
+
+    def test_llm_empty_stdout_logs_llm_error_with_stderr(self, tmp_path):
+        """LLM subprocess exits 0 but produces no stdout → llm_error, detail contains stderr."""
+        plugin_root = tmp_path / "plugin"
+        hooks_dir = plugin_root / "hooks"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        stub = textwrap.dedent("""\
+            #!/usr/bin/env -S uv run
+            # /// script
+            # requires-python = ">=3.13"
+            # ///
+            import sys
+            print("no json available", file=sys.stderr)
+            sys.exit(0)
+        """)
+        llm_script = hooks_dir / "stop-hook-llm.py"
+        llm_script.write_text(stub)
+        llm_script.chmod(0o755)
+
+        payload, state_path = self._setup_with_edit_tool(tmp_path, "I've completed the changes.")
+        result = run_hook(payload, state_path=state_path, plugin_root=str(plugin_root))
+        assert result.returncode == 0
+        db_path = state_path.parent / "test-guard.db"
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT outcome, detail FROM stop_hook_events ORDER BY ts DESC LIMIT 1"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "llm_error"
+        assert row[1] is not None
+        assert "no json available" in row[1]
 
 
 # ── State file management ────────────────────────────────────────────────────

--- a/dev-guard/tests/test_tool_selection_guard.py
+++ b/dev-guard/tests/test_tool_selection_guard.py
@@ -5791,6 +5791,46 @@ class TestGuardStats:
         assert result.returncode == 0
         assert "last 1 days" in result.stdout
 
+    def test_stop_hook_stats_fail_open(self, session_db):
+        """Stop hook stats shows fail-open count, combined error rate, and recent fail-opens."""
+        env, db_path = session_db
+        run_guard("Bash", {"command": "date"}, env=env, payload_extra={"session_id": "s1"})
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS stop_hook_events "
+            "(id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT NOT NULL, session_id TEXT, "
+            "outcome TEXT NOT NULL, trigger_reasons TEXT, work_type TEXT, "
+            "llm_duration_ms INTEGER, detail TEXT)"
+        )
+        conn.commit()
+        ts = datetime.datetime.now(datetime.UTC).isoformat()
+        rows = [
+            (ts, "s1", "llm_pass", None, None, 120, None),
+            (ts, "s1", "llm_fail", None, None, 200, None),
+            (ts, "s1", "llm_error", None, None, None, "connection refused"),
+            (ts, "s1", "llm_fail_open", None, None, None, "timeout after 30s"),
+            (ts, "s1", "llm_fail_open", None, None, None, "API unreachable"),
+        ]
+        conn.executemany(
+            "INSERT INTO stop_hook_events "
+            "(ts, session_id, outcome, trigger_reasons, work_type, llm_duration_ms, detail) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        conn.commit()
+        conn.close()
+
+        result = subprocess.run(
+            ["uv", "run", GUARD_STATS_SCRIPT],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "Fail-open: 2" in result.stdout
+        assert "ERROR RATE: 60%" in result.stdout
+        assert "Recent fail-opens:" in result.stdout
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # MCP tool auto-approval guard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.13"
 
 [dependency-groups]
 dev = ["ruff>=0.9", "pytest>=8", "pytest-xdist>=3", "pyright>=1.1.408"]
-llm = ["anthropic[vertex]>=0.40.0"]
+llm = ["anthropic[vertex]>=0.59.0"]
 
 [tool.pytest.ini_options]
 testpaths = ["dev-guard/tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -414,7 +414,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3" },
     { name = "ruff", specifier = ">=0.9" },
 ]
-llm = [{ name = "anthropic", extras = ["vertex"], specifier = ">=0.40.0" }]
+llm = [{ name = "anthropic", extras = ["vertex"], specifier = ">=0.59.0" }]
 
 [[package]]
 name = "pluggy"


### PR DESCRIPTION
## Summary
- Detects fail-open responses from stop-hook-llm.py via reasoning sentinel and logs as distinct `llm_fail_open` outcome (previously indistinguishable from `llm_pass`)
- Captures subprocess stderr for diagnostics on error
- Bumps `anthropic[vertex]` minimum from `>=0.40.0` to `>=0.59.0` to encode the global region URL fix requirement