### PR TITLE
fix(code-quality): enforces standalone PR framing in incremental workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -66,7 +66,7 @@
     },
     {
       "name": "dev-guard",
-      "version": "1.62.2",
+      "version": "1.62.3",
       "source": "./dev-guard",
       "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback, path hallucination guard",
       "category": "quality",
@@ -77,7 +77,7 @@
     },
     {
       "name": "code-quality",
-      "version": "3.25.0",
+      "version": "3.26.0",
       "source": "./code-quality",
       "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning (with issue tracking and PR boundary markers), roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
       "category": "quality",

--- a/code-quality/.claude-plugin/plugin.json
+++ b/code-quality/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "code-quality",
   "description": "Code quality agents, development utilities, and orchestration skills: architecture, security, QA, performance, test execution, code review, code simplification, plan adherence, LSP navigation, uv-python, incremental planning (with issue tracking), roadmap lifecycle management, session management, deep-research (with Bridged mode), business-panel, file-audit, bug-investigation, unfuck, swarm, quality-gate, pr-review, plan-review, map-reduce, speculative, reflect, fix, index-repo, summarize, and test-plan",
-  "version": "3.25.0",
+  "version": "3.26.0",
   "author": { "name": "wgordon17" }
 }

--- a/code-quality/skills/incremental-planning/SKILL.md
+++ b/code-quality/skills/incremental-planning/SKILL.md
@@ -339,7 +339,10 @@ Write the plan file with a header containing:
   The grouping is determined during Phase 4 task writing based on logical cohesion, file
   overlap, and dependency structure — not mechanical line counting. Initially left blank in
   the header — populated after all tasks are written and PR assignments are finalized during
-  Phase 5 validation.
+  Phase 5 validation. These internal labels (`PR 1`, `PR 2`) are plan-file plumbing only —
+  they must NOT appear in PR titles, PR bodies, or user-facing messages. Each PR created
+  from a boundary is standalone work described by what it accomplishes, not by its position
+  in a sequence.
 - **PRs:** — (only when `**Workflow:** incremental`, populated during implementation)
   Tracks created PR numbers. Format: `PR 1: #42, PR 2: pending, PR 3: pending`. Updated
   by swarm as PRs are created. Initially all `pending`.

--- a/code-quality/skills/roadmap/SKILL.md
+++ b/code-quality/skills/roadmap/SKILL.md
@@ -387,7 +387,8 @@ Track A) because PR boundaries branch sequentially from main — each boundary c
 branch from main after the prior boundary's PR merges. Track B cannot start until Track A's
 PR merges. This is PR-level sequencing, not task-level — tasks WITHIN a
 single PR boundary may still be parallelizable if the swarm architect determines they are
-independent.
+independent. The `PR 1`, `PR 2` labels in the table are internal plumbing — each PR created
+from a boundary is standalone work described by what it accomplishes, never "Part X of Y".
 
 Completion tracking for intra-plan tracks uses the same branch merge detection as inter-plan
 tracks (primary: `gh pr list --state merged`, fallback: `git branch --merged main`).

--- a/code-quality/skills/roadmap/references/phase-schema.md
+++ b/code-quality/skills/roadmap/references/phase-schema.md
@@ -60,7 +60,7 @@ must appear as columns — do not add per-track metadata outside the table.
 | Track | Yes | Letter identifier (A, B, C...) |
 | Plan | Yes | Absolute path to the plan file |
 | Tasks | Yes | Task range from that plan (e.g., "Tasks 1-3", "Tasks 4-7", "All") |
-| PR | No | PR boundary number from the plan's `**PR:**` task field (e.g., "PR 1", "PR 2"). Use "—" when the plan has no `**Workflow:** incremental` header. For intra-plan PR boundary tracks, this identifies which PR boundary the track implements. |
+| PR | No | PR boundary number from the plan's `**PR:**` task field (e.g., "PR 1", "PR 2"). Use "—" when the plan has no `**Workflow:** incremental` header. For intra-plan PR boundary tracks, this identifies which PR boundary the track implements. This is internal plumbing — these labels must not appear in PR titles or bodies. |
 | Worktree Branch | Yes | Convention: `roadmap/phase-N/plan-name` (derived from plan filename) |
 | Depends On | Yes | Intra-phase track dependencies only — other tracks *within this phase* that must complete before this track starts. Inter-phase ordering is handled by the Prerequisites field. Use "None" when the track has no dependencies on other tracks in the same phase. |
 | Skill | Yes | Execution skill. Valid values: `/swarm` (full agent swarm — default for most implementation work), `/speculative` (competing implementations), or a custom skill path. The orchestrator invokes the specified skill in the track's worktree with the plan file and task range as arguments. |

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -151,8 +151,10 @@ If `fast` or absent: proceed with existing fire-and-forget behavior unchanged.
   the previous session completed implementation but crashed before creating the PR. The
   branch with the work should still exist. Before creating a PR: check if one already exists
   for the boundary's branch (`gh pr list --head feat/{plan-slug}-pr{N} --state open --json number`).
-  If found, use that PR number. If not found, create the draft PR (check branch exists via
-  `git branch -l`, push if needed). Then update the checkpoint with the PR number.
+  If found, use that PR number. If not found, create the draft PR following the PR framing
+  rules from step 5 of the boundary stop (standalone work, no serial numbering). Check
+  branch exists via `git branch -l`, push if needed. Then update the checkpoint with the
+  PR number.
 - Verify merged PRs: for entries with non-null `pr_number`, `git fetch origin {branch_base}`
   then confirm they are merged (primary: `gh pr view <number> --json state` checking for
   `"state": "MERGED"`, fallback: `git branch --merged {branch_base}` — same two-method
@@ -474,8 +476,10 @@ After completing all tasks in the current PR boundary (all components for tasks 
    After merge, invoke /swarm to continue with remaining tasks."
 9. Clean up: TeamDelete, exit swarm gracefully
 
-If this is the LAST PR boundary: do NOT checkpoint. Instead, proceed with normal Phase 6
-(docs) and Phase 7 (verification) completion flow. Clean up any existing checkpoint file.
+If this is the LAST PR boundary: skip the boundary stop (steps 1-9 above). Instead, proceed
+with normal Phase 4 → Phase 5 → Phase 6 (docs) → Phase 7 (verification) completion flow.
+The PR is created during Phase 7 completion — follow the same standalone PR framing rules
+(no serial numbering, no "Part X of Y"). Clean up any existing checkpoint file.
 
 ### Phase 3.5: BDD Step Writing (conditional)
 

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -433,7 +433,7 @@ After completing all tasks in the current PR boundary (all components for tasks 
 3. Spawn Verifier agent (tests + lint) — same agent as Phase 7 but invoked inline at
    boundary stop. Full test suite, not scoped. This is a Verifier agent invocation only,
    NOT the full Phase 7 pipeline (Phase 6 docs run only at final completion).
-   **Partial-feature test failures:** Compare test results against the Phase 0 baseline.
+   **Boundary-scoped test failures:** Compare test results against the Phase 0 baseline.
    Any test that was passing in baseline and now fails is a regression — blocking. Any NEW
    test (added by the current boundary's tasks) that fails is blocking. Tests that were
    already failing in baseline are pre-existing (handled by existing swarm convention).

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -423,7 +423,7 @@ After completing all tasks in the current PR boundary (all components for tasks 
    same core review agents as full Phase 4 (Security, QA, Code-Reviewer, Performance, plus
    any auto-detected domain reviewers from Phase 1) with `pr_boundary_files` — NOT via
    /pr-review skill, which reviews existing PRs. Plan Adherence and Phase 4.5 structural
-   analysts also run at boundary stops (structural analysts receive partial-feature briefing
+   analysts also run at boundary stops (structural analysts receive scoped-review briefing
    per the Phase 4.5 incremental workflow section).
 2. Run Phase 5 Fixer scoped to the current boundary's files only — the Lead passes
    `pr_boundary_files` to the Fixer agent's prompt (same mechanism as Phase 4 reviewers).
@@ -919,7 +919,7 @@ Phase 4: Parallel Review
 Phase 4.5: Structural Design Review (always runs)
   +-- Analyst 1: Concurrency & State (opus) ---------+
   +-- Analyst 2: Integration & Contract (opus) -------+--> Lead merges STRUCT findings
-  [incremental non-final: analysts briefed on partial feature — don't flag future-boundary gaps]
+  [incremental non-final: analysts review as standalone work — don't flag future-boundary gaps]
      |
      v
 Phase 5: Fix, Test Coverage & Simplify (if any findings exist)

--- a/code-quality/skills/swarm/SKILL.md
+++ b/code-quality/skills/swarm/SKILL.md
@@ -167,7 +167,7 @@ If `fast` or absent: proceed with existing fire-and-forget behavior unchanged.
   Apply the Branch Slug Sanitization Rules from `project-memory-reference.md`.
 - Create new branch for the next PR boundary: `feat/{plan-slug}-pr{N}` from
   `origin/{branch_base}` (using the `branch_base` field from the checkpoint, typically `main`)
-- Announce: "Resuming swarm from PR boundary {N}. PRs 1-{N-1} merged. Tasks remaining: {list}."
+- Announce: "Resuming swarm. Prior work merged. Remaining tasks: {list}."
   Include the checkpoint's `context_summary` in the Implementer's briefing so it has context
   about what was built in earlier boundaries.
 - **Resume Phase 0 variant:** Still run these Phase 0 steps for the new session:
@@ -412,8 +412,13 @@ ELSE:
 This reduces context pressure on individual Implementers and improves output quality for large
 tasks. The Lead decides based on the dependency graph — never based on cost or token concerns.
 
-**PR boundary handling (incremental only):** After completing all tasks in the current PR
-boundary (all components for tasks in `**PR:** {current_pr}`):
+**PR boundary handling (incremental only):** Each PR boundary produces a standalone,
+independently-reviewable unit of work. The PR title and body describe what THIS PR
+accomplishes — never "Part X of Y", never referencing other PRs in the series. A reviewer
+must be able to judge the PR on its own merits without knowing other PRs exist.
+
+After completing all tasks in the current PR boundary (all components for tasks in
+`**PR:** {current_pr}`):
 1. Run Phase 4 reviews scoped to the current boundary's files only. The Lead spawns the
    same core review agents as full Phase 4 (Security, QA, Code-Reviewer, Performance, plus
    any auto-detected domain reviewers from Phase 1) with `pr_boundary_files` — NOT via
@@ -445,15 +450,18 @@ boundary (all components for tasks in `**PR:** {current_pr}`):
    file at `{plan_file}`. It must not create, modify, or delete any other files.
    The Boundary Updater agent remains alive through step 7 — the Lead sends it a follow-up
    message at step 7 with the PR number to write. It is shut down after step 7 completes.
-5. Create draft PR:
+5. Create draft PR — each PR is standalone work, not "Part X of Y":
    ```bash
    BRANCH=$(git branch --show-current)
    gh pr create --head "$BRANCH" --draft \
-     --title "type(scope): description covering boundary's tasks" \
+     --title "type(scope): what this PR accomplishes" \
      --body "## Summary
-   - [boundary scope description]
-   - Part {current_pr} of {total_prs} for [feature]"
+   - [what changed and why — describe as self-contained, independently-reviewable work]"
    ```
+   **PR framing rules:** Never number PRs ("Part 1 of 3"), reference other PRs in the
+   series, or describe a PR as part of a larger whole. Each PR must be understandable and
+   valuable on its own. If a reviewer cannot judge the PR's merit without knowing about
+   other PRs, the boundary grouping was wrong — fix the grouping, not the PR description.
 6. If tracker issue exists: add comment to the issue with the PR reference
    (`gh issue comment {issue_number} --repo {repo} --body "PR #{pr_number}: [title]"`)
    Sanitize the PR title before interpolation: strip backticks, dollar signs, double quotes,
@@ -462,8 +470,8 @@ boundary (all components for tasks in `**PR:** {current_pr}`):
 7. Update checkpoint and plan file via the Boundary Updater agent: set `pr_number` for the
    current boundary in `completed_prs` (was `null` from step 4), and update `**PRs:**` field
    in the plan file with `#{pr_number}`.
-8. Announce: "PR #{pr_number} created for PR boundary {current_pr}. Checkpoint saved.
-   Merge the PR, then invoke /swarm to continue with PR boundary {next_pr}."
+8. Announce: "Draft PR #{pr_number} created. Checkpoint saved.
+   After merge, invoke /swarm to continue with remaining tasks."
 9. Clean up: TeamDelete, exit swarm gracefully
 
 If this is the LAST PR boundary: do NOT checkpoint. Instead, proceed with normal Phase 6
@@ -601,14 +609,13 @@ If Phase 4 escalation routing triggers a return to Phase 2, Phase 4.5 runs on th
 
 Phase 5 receives findings from both Phase 4 AND Phase 4.5 in its consolidated findings list.
 
-**Incremental workflow — partial feature handling:** At non-final PR boundaries, Phase 4.5
-structural analysts review a partial feature. The Lead briefs analysts: "This is PR boundary
-{N} of {total}. Only the task numbers assigned to PR boundary {N} are implemented. The task
-numbers assigned to subsequent PR boundaries will be implemented in subsequent boundaries.
-Flag structural issues in the CURRENT boundary's code, but do not flag missing integration
-points or incomplete data flows that are addressed by remaining tasks." Findings about
-genuinely missing contracts within the current boundary are valid; findings about
-not-yet-implemented future boundary work are not.
+**Incremental workflow — scoped review:** At non-final PR boundaries, Phase 4.5
+structural analysts review only the current boundary's code as standalone work. The Lead
+briefs analysts: "Review this code on its own merits as a self-contained unit of work.
+Flag structural issues in THIS code. Do not flag missing integration points or incomplete
+data flows that are addressed by tasks not yet implemented — those are separate work."
+Findings about genuinely missing contracts within the current boundary are valid; findings
+about not-yet-implemented work are not.
 At the FINAL PR boundary: Phase 4.5 runs normally (full system review).
 
 ### Phase 5: Fix, Test Coverage & Simplify

--- a/dev-guard/.claude-plugin/plugin.json
+++ b/dev-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dev-guard",
   "description": "Development environment policy enforcement: tool selection guard, commit validation, pre-push review, URL fetch guard, trust management, oc/kubectl introspection, subagent completion verification, decision persistence, anti-deferral enforcement, shared behavioral feedback, path hallucination guard",
-  "version": "1.62.2",
+  "version": "1.62.3",
   "author": { "name": "wgordon17" }
 }

--- a/dev-guard/references/shared-feedback.md
+++ b/dev-guard/references/shared-feedback.md
@@ -8,9 +8,14 @@ Cross-project behavioral rules injected into every session via the SessionStart 
 
 **Scope-bounded delivery is not deferral.** When a plan specifies `**Workflow:** incremental` with
 PR boundaries, completing work within the current PR boundary and proceeding to the next boundary
-is the designed workflow, not scope reduction. The plan structure determines delivery order — the
-agent does not decide what belongs in which PR. All planned work is completed; only the delivery
-sequence changes.
+is the designed workflow, not scope reduction. Each PR boundary delivers standalone, meaningful
+work — small enough to review, substantive enough to stand on its own. The agent does not decide
+what belongs in which PR. All planned work is completed; only the delivery sequence changes.
+
+**PRs are standalone work, not numbered parts.** Never describe a PR as "Part X of Y", "1 of 3",
+or reference other PRs in the series. Each PR title and body must be self-contained — a reviewer
+should understand its value without knowing about other PRs. Follow-up work is a separate concern
+addressed after the current PR merges.
 
 **No fabricated user deferral.** Do not claim the user "explicitly deferred" work unless the user actually said so in the current conversation. "Explicitly user-deferred" requires a citable user message — if you cannot cite it, the deferral is fabricated.
 

--- a/dev-guard/references/shared-feedback.md
+++ b/dev-guard/references/shared-feedback.md
@@ -13,9 +13,9 @@ work — small enough to review, substantive enough to stand on its own. The age
 what belongs in which PR. All planned work is completed; only the delivery sequence changes.
 
 **PRs are standalone work, not numbered parts.** Never describe a PR as "Part X of Y", "1 of 3",
-or reference other PRs in the series. Each PR title and body must be self-contained — a reviewer
-should understand its value without knowing about other PRs. Follow-up work is a separate concern
-addressed after the current PR merges.
+reference other PRs in the series, or describe a PR as part of a larger whole. Each PR title and
+body must be self-contained — a reviewer should understand its value without knowing about other
+PRs. Follow-up work is a separate concern addressed after the current PR merges.
 
 **No fabricated user deferral.** Do not claim the user "explicitly deferred" work unless the user actually said so in the current conversation. "Explicitly user-deferred" requires a citable user message — if you cannot cite it, the deferral is fabricated.
 

--- a/dev-guard/tests/test_plugin_integrity.py
+++ b/dev-guard/tests/test_plugin_integrity.py
@@ -172,6 +172,8 @@ LABEL_DEFINITIONS = REPO_ROOT / "code-quality" / "references" / "github-label-de
 TRACKER_FIELD_SPEC = REPO_ROOT / "code-quality" / "references" / "tracker-field-spec.md"
 PROJECT_MEMORY_REFERENCE = REPO_ROOT / "code-quality" / "references" / "project-memory-reference.md"
 SHARED_FEEDBACK = REPO_ROOT / "dev-guard" / "references" / "shared-feedback.md"
+ROADMAP_SKILL = REPO_ROOT / "code-quality" / "skills" / "roadmap" / "SKILL.md"
+PHASE_SCHEMA = REPO_ROOT / "code-quality" / "skills" / "roadmap" / "references" / "phase-schema.md"
 
 
 class TestCodeQualityReferenceIntegrity:
@@ -314,12 +316,37 @@ class TestCodeQualityReferenceIntegrity:
             "swarm/SKILL.md still contains 'Part {current_pr} of {total_prs}'. "
             "PR body template must not use serial numbering — each PR is standalone work."
         )
+        assert "PR framing rules" in content, (
+            "swarm/SKILL.md does not contain 'PR framing rules'. "
+            "The standalone PR framing rules section was deleted or altered."
+        )
 
     def test_shared_feedback_standalone_pr_rule(self):
         content = SHARED_FEEDBACK.read_text()
         assert "PRs are standalone work" in content, (
             "shared-feedback.md does not contain 'PRs are standalone work'. "
             "The standalone PR framing rule was deleted or altered."
+        )
+
+    def test_roadmap_standalone_pr_framing(self):
+        content = ROADMAP_SKILL.read_text()
+        assert 'never "Part X of Y"' in content, (
+            "roadmap/SKILL.md does not contain the standalone PR framing rule. "
+            "The rule was deleted or altered."
+        )
+
+    def test_incremental_planning_standalone_pr_framing(self):
+        content = INCREMENTAL_PLANNING_SKILL.read_text()
+        assert "must NOT appear in PR titles, PR bodies, or user-facing messages" in content, (
+            "incremental-planning/SKILL.md does not contain the standalone PR framing rule. "
+            "The rule was deleted or altered."
+        )
+
+    def test_phase_schema_internal_plumbing_rule(self):
+        content = PHASE_SCHEMA.read_text()
+        assert "internal plumbing" in content, (
+            "phase-schema.md does not contain 'internal plumbing'. "
+            "The PR column internal plumbing caveat was deleted or altered."
         )
 
     def test_project_memory_reference_contains_checkpoint_schema(self):
@@ -403,7 +430,6 @@ class TestPluginVersionParity:
 
 BUG_INVESTIGATION_SKILL = REPO_ROOT / "code-quality" / "skills" / "bug-investigation" / "SKILL.md"
 QUALITY_GATE_SKILL = REPO_ROOT / "code-quality" / "skills" / "quality-gate" / "SKILL.md"
-ROADMAP_SKILL = REPO_ROOT / "code-quality" / "skills" / "roadmap" / "SKILL.md"
 ARTIFACT_FORMATS = (
     REPO_ROOT / "code-quality" / "skills" / "summarize" / "references" / "artifact-formats.md"
 )

--- a/dev-guard/tests/test_plugin_integrity.py
+++ b/dev-guard/tests/test_plugin_integrity.py
@@ -171,6 +171,7 @@ SWARM_SKILL = REPO_ROOT / "code-quality" / "skills" / "swarm" / "SKILL.md"
 LABEL_DEFINITIONS = REPO_ROOT / "code-quality" / "references" / "github-label-definitions.md"
 TRACKER_FIELD_SPEC = REPO_ROOT / "code-quality" / "references" / "tracker-field-spec.md"
 PROJECT_MEMORY_REFERENCE = REPO_ROOT / "code-quality" / "references" / "project-memory-reference.md"
+SHARED_FEEDBACK = REPO_ROOT / "dev-guard" / "references" / "shared-feedback.md"
 
 
 class TestCodeQualityReferenceIntegrity:
@@ -305,6 +306,20 @@ class TestCodeQualityReferenceIntegrity:
         assert "**PRs:**" in content, (
             "swarm/SKILL.md does not contain '**PRs:**'. "
             "The PRs field extraction for incremental mode was deleted or altered."
+        )
+
+    def test_swarm_pr_template_no_serial_numbering(self):
+        content = SWARM_SKILL.read_text()
+        assert "Part {current_pr} of {total_prs}" not in content, (
+            "swarm/SKILL.md still contains 'Part {current_pr} of {total_prs}'. "
+            "PR body template must not use serial numbering — each PR is standalone work."
+        )
+
+    def test_shared_feedback_standalone_pr_rule(self):
+        content = SHARED_FEEDBACK.read_text()
+        assert "PRs are standalone work" in content, (
+            "shared-feedback.md does not contain 'PRs are standalone work'. "
+            "The standalone PR framing rule was deleted or altered."
         )
 
     def test_project_memory_reference_contains_checkpoint_schema(self):


### PR DESCRIPTION
## Summary
- Removes 'Part X of Y' serial numbering from swarm PR body template, announce messages, and reviewer briefings
- Adds explicit standalone-work principle across swarm, incremental-planning, roadmap, shared-feedback
- Internal plumbing (branch names, checkpoint schema, plan headers) unchanged — only user/reviewer-facing language fixed