### PR TITLE
feat(skill-eval): adds composition evaluation framework for skill synergy testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 hack/
 .serena
 .claire/
+.skill-eval-worktrees/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint format test test-llm typecheck prek prek-install eval eval-prepush eval-update-baselines
+.PHONY: all lint format test test-llm typecheck prek prek-install eval eval-prepush eval-update-baselines eval-composition
 
 all: lint test typecheck  ## Full check suite (lint + test + typecheck)
 
@@ -33,3 +33,6 @@ eval:  ## Run skill evals for all skills with test cases
 
 eval-update-baselines:  ## Update baselines.json with current scores
 	cd skill-eval && uv run python -m skill_eval.cli --update-baselines
+
+eval-composition:  ## Run composition eval (set CONFIG=path/to/composition.json)
+	cd skill-eval && uv run python -m skill_eval.cli --composition $(CONFIG)

--- a/Makefile
+++ b/Makefile
@@ -34,5 +34,5 @@ eval:  ## Run skill evals for all skills with test cases
 eval-update-baselines:  ## Update baselines.json with current scores
 	cd skill-eval && uv run python -m skill_eval.cli --update-baselines
 
-eval-composition:  ## Run composition eval (set CONFIG=path/to/composition.json)
-	cd skill-eval && uv run python -m skill_eval.cli --composition $(CONFIG)
+eval-composition:  ## Run composition eval
+	cd skill-eval && uv run python -m skill_eval.cli --composition test_cases/composition.json

--- a/skill-eval/fixtures/composition/overspecified-auth-plan.md
+++ b/skill-eval/fixtures/composition/overspecified-auth-plan.md
@@ -1,0 +1,58 @@
+---
+scaffold:
+  files:
+    - requirements.txt
+    - app/__init__.py
+    - app/models.py
+    - tests/conftest.py
+  requirements:
+    - flask
+    - pytest
+planted_issues:
+  - Step 12 uses hashlib.sha256 for token generation (should use secrets)
+  - Step 23 creates separate middleware files per role (over-engineering)
+  - Step 31 asserts exact error message string in tests (brittle)
+---
+
+# Auth Plan: JWT Authentication with RBAC in Flask
+
+## Goal
+Add JWT-based authentication and role-based access control to the Flask app.
+
+## Steps
+
+1. Open `app/__init__.py` and add `from flask import Flask, request, jsonify` at the top.
+2. Add `SECRET_KEY = "mysecret"` to the Flask app config dict.
+3. Create `app/models.py` and define a `User` class with `id`, `username`, `password_hash`, and `role` fields.
+4. Import `hashlib` in `app/models.py`.
+5. Define `User.set_password(raw)` as `self.password_hash = hashlib.sha256(raw.encode()).hexdigest()`.
+6. Define `User.check_password(raw)` comparing `hashlib.sha256(raw.encode()).hexdigest()` to `self.password_hash`.
+7. In `app/__init__.py`, define a `/login` route that accepts POST with JSON `username` and `password`.
+8. In the login handler, query the User model for a matching username.
+9. Call `user.check_password(data['password'])` and return 401 if it fails.
+10. Import `hashlib` at the top of `app/__init__.py`.
+11. Build a token payload dict with `user_id`, `role`, and `exp` fields set to `int(time.time()) + 3600`.
+12. Generate the token as `hashlib.sha256((str(payload['user_id']) + SECRET_KEY).encode()).hexdigest()`.
+13. Return the token in a JSON response as `{"token": token}`.
+14. Create `app/middleware_admin.py` for admin role verification logic.
+15. Create `app/middleware_user.py` for user role verification logic.
+16. Create `app/middleware_superuser.py` for superuser role verification logic.
+17. In `app/middleware_admin.py`, import `request` and define `verify_admin()` that reads the `Authorization` header.
+18. In `app/middleware_user.py`, define `verify_user()` with the same header-reading logic.
+19. In `app/middleware_superuser.py`, define `verify_superuser()` similarly.
+20. In each middleware file, split the header on space and get the token part.
+21. Reconstruct the expected hash using the same `hashlib.sha256` approach from step 12.
+22. Compare the reconstructed hash to the token; return 403 if they don't match.
+23. Import each middleware module separately in every route file that needs it.
+24. Create a `/admin/dashboard` route in `app/__init__.py` that calls `verify_admin()`.
+25. Create a `/user/profile` route that calls `verify_user()`.
+26. Return 200 with `{"status": "ok"}` from each protected route on success.
+27. Create `tests/conftest.py` with a `client` fixture using `app.test_client()`.
+28. Create `tests/test_auth.py` with a test for successful login.
+29. In the login test, POST to `/login` and assert the response status is 200.
+30. Assert the response JSON contains a `token` key.
+31. Assert the token value equals the exact string `hashlib.sha256(("1" + "mysecret").encode()).hexdigest()`.
+32. Add a test for failed login: POST with wrong password, assert status 401.
+33. Assert the response JSON equals `{"error": "Invalid credentials"}` exactly.
+34. Add a test for the admin route: POST to `/login`, extract token, GET `/admin/dashboard` with `Authorization: Bearer <token>`.
+35. Assert status 200 and body equals `{"status": "ok"}` exactly.

--- a/skill-eval/fixtures/composition/overspecified-crud-plan.md
+++ b/skill-eval/fixtures/composition/overspecified-crud-plan.md
@@ -1,0 +1,59 @@
+---
+scaffold:
+  files:
+    - requirements.txt
+    - app/__init__.py
+    - app/models.py
+    - tests/conftest.py
+  requirements:
+    - flask
+    - sqlalchemy
+    - pytest
+planted_issues:
+  - Step 8 uses raw SQL queries (should use SQLAlchemy ORM)
+  - Step 15 uses offset-based pagination (suboptimal for large datasets)
+  - Step 22 uses if/elif chain validation (should use schema library)
+---
+
+# CRUD Plan: Paginated REST API in Flask
+
+## Goal
+Build a CRUD REST API for a `Widget` resource with paginated list support.
+
+## Steps
+
+1. Open `app/models.py` and add `from sqlalchemy import Column, Integer, String, Text` at the top.
+2. Define a `Widget` class inheriting from `Base` with `id`, `name`, and `description` columns.
+3. Add `__tablename__ = "widgets"` to the Widget class.
+4. In `app/__init__.py`, import Flask, request, jsonify, and the db instance.
+5. Import the `Widget` model from `app.models`.
+6. Define a `POST /widgets` route that reads JSON from `request.get_json()`.
+7. Extract `name` and `description` from the parsed JSON dict.
+8. Execute the insert using raw SQL: `db.engine.execute(f"INSERT INTO widgets (name, description) VALUES ('{name}', '{description}')")`.
+9. Commit the transaction with `db.session.commit()`.
+10. Query the newly created widget using `db.engine.execute(f"SELECT * FROM widgets WHERE name='{name}'").fetchone()`.
+11. Return the widget dict with status 201.
+12. Define a `GET /widgets` route that accepts `page` and `per_page` query parameters.
+13. Default `page` to 1 and `per_page` to 20 if not provided.
+14. Compute the offset as `(page - 1) * per_page`.
+15. Fetch paginated results using raw SQL: `db.engine.execute(f"SELECT * FROM widgets LIMIT {per_page} OFFSET {offset}").fetchall()`.
+16. Fetch total count using `db.engine.execute("SELECT COUNT(*) FROM widgets").scalar()`.
+17. Return `{"items": items, "page": page, "per_page": per_page, "total": total}`.
+18. Define a `GET /widgets/<int:id>` route.
+19. Fetch the widget using `db.engine.execute(f"SELECT * FROM widgets WHERE id={id}").fetchone()`.
+20. Return 404 if not found, otherwise return the widget dict.
+21. Define a `PUT /widgets/<int:id>` route that reads JSON from `request.get_json()`.
+22. Validate the input: `if 'name' not in data: return jsonify({"error": "name required"}), 400` followed by `elif not isinstance(data['name'], str): return jsonify({"error": "name must be string"}), 400` followed by `elif len(data['name']) == 0: return jsonify({"error": "name cannot be empty"}), 400` followed by `elif 'description' not in data: return jsonify({"error": "description required"}), 400` followed by `elif not isinstance(data['description'], str): return jsonify({"error": "description must be string"}), 400`.
+23. Execute the update using raw SQL: `db.engine.execute(f"UPDATE widgets SET name='{data['name']}', description='{data['description']}' WHERE id={id}")`.
+24. Commit with `db.session.commit()`.
+25. Return the updated widget dict.
+26. Define a `DELETE /widgets/<int:id>` route.
+27. Execute deletion using raw SQL: `db.engine.execute(f"DELETE FROM widgets WHERE id={id}")`.
+28. Commit with `db.session.commit()`.
+29. Return empty response with status 204.
+30. Create `tests/conftest.py` with a `client` fixture using `app.test_client()`.
+31. Create `tests/test_crud.py` with a test for POST: send valid JSON, assert status 201 and `id` in response.
+32. Add a test for GET list: assert status 200 and response contains `items` and `total` keys.
+33. Add a test for GET single: create a widget, GET by id, assert status 200.
+34. Add a test for GET 404: GET `/widgets/99999`, assert status 404.
+35. Add a test for DELETE: create a widget, DELETE by id, assert status 204.

--- a/skill-eval/fixtures/composition/planted-issues-diff.md
+++ b/skill-eval/fixtures/composition/planted-issues-diff.md
@@ -1,0 +1,96 @@
+---
+scaffold:
+  files:
+    - requirements.txt
+    - app/__init__.py
+    - app/models.py
+    - tests/conftest.py
+    - tests/test_app.py
+  requirements:
+    - flask
+    - sqlalchemy
+    - pytest
+planted_issues:
+  - SQL injection via string interpolation in query (app/__init__.py get_widget)
+  - Missing authorization check on delete endpoint (app/__init__.py delete_widget)
+  - Brittle test assertion on exact error message string (tests/test_app.py)
+---
+
+# Planted Issues Diff
+
+The following diff applies against the scaffold files and introduces 3 deliberate defects.
+Your task is to review this implementation and identify all issues.
+
+```diff
+--- a/app/__init__.py
++++ b/app/__init__.py
+@@ -1,4 +1,4 @@
+-# placeholder
++from flask import Flask, request, jsonify
++from app.models import db, Widget
++
++app = Flask(__name__)
++app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///app.db'
++db.init_app(app)
++
++
++@app.route('/widgets/<name>', methods=['GET'])
++def get_widget(name):
++    # BUG: SQL injection — user input interpolated directly into query string
++    result = db.engine.execute(f"SELECT * FROM widgets WHERE name='{name}'").fetchone()
++    if result is None:
++        return jsonify({'error': 'not found'}), 404
++    return jsonify(dict(result))
++
++
++@app.route('/widgets/<int:widget_id>', methods=['DELETE'])
++def delete_widget(widget_id):
++    # BUG: no authorization check — any user can delete any widget
++    widget = Widget.query.get(widget_id)
++    if widget is None:
++        return jsonify({'error': 'not found'}), 404
++    db.session.delete(widget)
++    db.session.commit()
++    return '', 204
+--- a/app/models.py
++++ b/app/models.py
+@@ -1,1 +1,12 @@
+-# placeholder
++from flask_sqlalchemy import SQLAlchemy
++
++db = SQLAlchemy()
++
++
++class Widget(db.Model):
++    __tablename__ = 'widgets'
++    id = db.Column(db.Integer, primary_key=True)
++    name = db.Column(db.String(100), nullable=False)
++    description = db.Column(db.Text, default='')
++    owner_id = db.Column(db.Integer, nullable=False)
+--- a/tests/test_app.py
++++ b/tests/test_app.py
+@@ -1,1 +1,18 @@
+-# placeholder
++import pytest
++from app import app as flask_app
++
++
++@pytest.fixture
++def client():
++    flask_app.config['TESTING'] = True
++    with flask_app.test_client() as c:
++        yield c
++
++
++def test_get_missing_widget(client):
++    resp = client.get('/widgets/nonexistent')
++    assert resp.status_code == 404
++    # BUG: brittle assertion — exact error message string will break if message changes
++    assert resp.get_json() == {'error': 'not found'}
++
++
++def test_delete_widget_no_auth(client):
++    resp = client.delete('/widgets/1')
++    # This should be 403, but no auth check exists — it returns 404 or 204
++    assert resp.status_code in (404, 204)
+```

--- a/skill-eval/fixtures/composition/planted-issues-diff.md
+++ b/skill-eval/fixtures/composition/planted-issues-diff.md
@@ -36,7 +36,6 @@ Your task is to review this implementation and identify all issues.
 +
 +@app.route('/widgets/<name>', methods=['GET'])
 +def get_widget(name):
-+    # BUG: SQL injection — user input interpolated directly into query string
 +    result = db.engine.execute(f"SELECT * FROM widgets WHERE name='{name}'").fetchone()
 +    if result is None:
 +        return jsonify({'error': 'not found'}), 404
@@ -45,7 +44,6 @@ Your task is to review this implementation and identify all issues.
 +
 +@app.route('/widgets/<int:widget_id>', methods=['DELETE'])
 +def delete_widget(widget_id):
-+    # BUG: no authorization check — any user can delete any widget
 +    widget = Widget.query.get(widget_id)
 +    if widget is None:
 +        return jsonify({'error': 'not found'}), 404
@@ -85,12 +83,10 @@ Your task is to review this implementation and identify all issues.
 +def test_get_missing_widget(client):
 +    resp = client.get('/widgets/nonexistent')
 +    assert resp.status_code == 404
-+    # BUG: brittle assertion — exact error message string will break if message changes
 +    assert resp.get_json() == {'error': 'not found'}
 +
 +
-+def test_delete_widget_no_auth(client):
++def test_delete_widget(client):
 +    resp = client.delete('/widgets/1')
-+    # This should be 403, but no auth check exists — it returns 404 or 204
 +    assert resp.status_code in (404, 204)
 ```

--- a/skill-eval/fixtures/composition/terse-auth-plan.md
+++ b/skill-eval/fixtures/composition/terse-auth-plan.md
@@ -1,0 +1,35 @@
+---
+scaffold:
+  files:
+    - requirements.txt
+    - app/__init__.py
+    - app/models.py
+    - tests/conftest.py
+  requirements:
+    - flask
+    - pytest
+planted_issues:
+  - Should choose PyJWT over manual JWT parsing
+  - Should use decorator pattern for role checking
+  - Should generate tokens with secrets.token_urlsafe() not custom hash
+---
+
+# Auth Plan: JWT Authentication with RBAC in Flask
+
+## Goal
+Add JWT-based authentication and role-based access control to the Flask app.
+Users should be able to log in and receive a token. Protected endpoints should
+reject unauthenticated requests and enforce role restrictions.
+
+## Outcomes Required
+- Login endpoint issues a signed JWT on valid credentials
+- Token verification middleware rejects invalid or expired tokens
+- Role checking enforces admin vs user access on protected routes
+- Tokens are generated securely
+- Tests cover the happy path and key failure cases
+
+## Notes
+The existing app uses Flask patterns with SQLAlchemy models. Follow project
+conventions. The implementation details (library choice, abstraction structure,
+decorator vs middleware approach) are up to you — focus on correctness and
+security.

--- a/skill-eval/fixtures/composition/terse-crud-plan.md
+++ b/skill-eval/fixtures/composition/terse-crud-plan.md
@@ -1,0 +1,38 @@
+---
+scaffold:
+  files:
+    - requirements.txt
+    - app/__init__.py
+    - app/models.py
+    - tests/conftest.py
+  requirements:
+    - flask
+    - sqlalchemy
+    - pytest
+planted_issues:
+  - Should use SQLAlchemy ORM queries not raw SQL
+  - Should use keyset/cursor pagination not offset for large datasets
+  - Should use a schema validation library not manual if/elif chains
+---
+
+# CRUD Plan: Paginated REST API in Flask
+
+## Goal
+Build a CRUD REST API for a `Widget` resource with paginated list support.
+The API should support create, read, update, delete operations and return
+paginated results on the list endpoint.
+
+## Outcomes Required
+- POST /widgets creates a new widget and returns it
+- GET /widgets returns a paginated list with metadata
+- GET /widgets/<id> returns a single widget or 404
+- PUT /widgets/<id> updates and returns the widget
+- DELETE /widgets/<id> deletes the widget and returns 204
+- Pagination works correctly for large datasets
+- Input validation rejects malformed requests with 400
+
+## Notes
+The app uses Flask with SQLAlchemy. Follow ORM conventions — avoid raw SQL.
+Pagination approach, validation strategy, and error handling structure
+are implementation decisions. Tests should cover CRUD operations and
+pagination edge cases.

--- a/skill-eval/pyproject.toml
+++ b/skill-eval/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "deepeval>=3.0",
     "instructor>=1.0,<2.0",
     "anthropic[vertex]>=0.80.0",
+    "pyyaml>=6.0",
 ]
 
 [dependency-groups]

--- a/skill-eval/skill_eval/cli.py
+++ b/skill-eval/skill_eval/cli.py
@@ -143,6 +143,25 @@ def _deferred_imports() -> tuple:
     )
 
 
+def _deferred_composition_imports() -> tuple:
+    """Import composition eval modules after setting DEEPEVAL env vars."""
+    os.environ["DEEPEVAL_DISABLE_TIMEOUTS"] = "true"
+    os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "YES"
+    from skill_eval.judge import VertexSonnetJudge
+    from skill_eval.runner import (
+        compare_composition_results,
+        load_composition_config,
+        run_composition_eval,
+    )
+
+    return (
+        VertexSonnetJudge,
+        load_composition_config,
+        run_composition_eval,
+        compare_composition_results,
+    )
+
+
 def _eval_skills(
     skill_dirs: list[Path],
     repo_root: Path,
@@ -300,6 +319,55 @@ def _write_baselines(all_results: list[dict]) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _mode_composition(config_path: Path, repo_root: Path) -> bool:
+    """--composition mode: run composition eval from a JSON config file."""
+    (
+        VertexSonnetJudge,
+        load_composition_config,
+        run_composition_eval,
+        compare_composition_results,
+    ) = _deferred_composition_imports()
+
+    try:
+        config = load_composition_config(config_path)
+    except FileNotFoundError:
+        print(f"[skill-eval] Composition config not found: {config_path}", file=sys.stderr)
+        return False
+
+    compositions = config.get("compositions", [])
+    if not compositions:
+        print("[skill-eval] No compositions found in config", file=sys.stderr)
+        return True
+
+    judge = VertexSonnetJudge()
+    all_passed = True
+
+    for composition in compositions:
+        name = composition.get("name", "?")
+        print(f"  [composition] {name}...")
+        try:
+            result = run_composition_eval(composition, repo_root, judge)
+        except Exception as exc:
+            print(f"  [error] {name}: {exc}", file=sys.stderr)
+            all_passed = False
+            continue
+
+        if result.infra_error:
+            print(f"  [error] {name}: infra error during chain execution", file=sys.stderr)
+            all_passed = False
+            continue
+
+        print(f"\n{'Metric':<30} {'Score':>8}  Status")
+        print("-" * 50)
+        for metric, score in result.final_scores.items():
+            print(f"  {metric:<28} {score:>8.3f}")
+
+        if not result.final_scores:
+            print(f"  {name}: no rubrics configured — chain executed successfully")
+
+    return all_passed
+
+
 def _mode_prepush(repo_root: Path) -> bool:
     """Default pre-push mode: detect changed skills and eval them."""
     try:
@@ -407,6 +475,11 @@ def main() -> None:
         action="store_true",
         help="Run --all and write results to baselines.json",
     )
+    group.add_argument(
+        "--composition",
+        metavar="PATH",
+        help="Run composition eval from a JSON config file",
+    )
     parser.add_argument(
         "--locked",
         action="store_true",
@@ -457,6 +530,8 @@ def main() -> None:
         passed = _mode_all(repo_root)
     elif args.update_baselines:
         passed = _mode_update_baselines(repo_root)
+    elif args.composition:
+        passed = _mode_composition(Path(args.composition), repo_root)
     else:
         passed = _mode_prepush(repo_root)
 

--- a/skill-eval/skill_eval/cli.py
+++ b/skill-eval/skill_eval/cli.py
@@ -118,10 +118,15 @@ def _verify_eval_integrity(repo_root: Path) -> tuple[bool, list[str]]:
 # ---------------------------------------------------------------------------
 
 
-def _deferred_imports() -> tuple:
-    """Import eval modules after setting DEEPEVAL env vars."""
+def _configure_deepeval_env() -> None:
+    """Set DEEPEVAL environment variables required before importing eval modules."""
     os.environ["DEEPEVAL_DISABLE_TIMEOUTS"] = "true"
     os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "YES"
+
+
+def _deferred_imports() -> tuple:
+    """Import eval modules after setting DEEPEVAL env vars."""
+    _configure_deepeval_env()
     from skill_eval.judge import VertexSonnetJudge
     from skill_eval.runner import (
         compare_baselines,
@@ -145,8 +150,7 @@ def _deferred_imports() -> tuple:
 
 def _deferred_composition_imports() -> tuple:
     """Import composition eval modules after setting DEEPEVAL env vars."""
-    os.environ["DEEPEVAL_DISABLE_TIMEOUTS"] = "true"
-    os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "YES"
+    _configure_deepeval_env()
     from skill_eval.judge import VertexSonnetJudge
     from skill_eval.runner import (
         compare_composition_results,

--- a/skill-eval/skill_eval/cli.py
+++ b/skill-eval/skill_eval/cli.py
@@ -319,7 +319,9 @@ def _write_baselines(all_results: list[dict]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _mode_composition(config_path: Path, repo_root: Path) -> bool:
+def _mode_composition(
+    config_path: Path, repo_root: Path, composition_name: str | None = None
+) -> bool:
     """--composition mode: run composition eval from a JSON config file."""
     (
         VertexSonnetJudge,
@@ -335,6 +337,14 @@ def _mode_composition(config_path: Path, repo_root: Path) -> bool:
         return False
 
     compositions = config.get("compositions", [])
+    if composition_name:
+        compositions = [c for c in compositions if c.get("name") == composition_name]
+        if not compositions:
+            print(
+                f"[skill-eval] No composition named {composition_name!r} in config",
+                file=sys.stderr,
+            )
+            return False
     if not compositions:
         print("[skill-eval] No compositions found in config", file=sys.stderr)
         return True
@@ -497,6 +507,11 @@ def main() -> None:
         help="Run composition eval from a JSON config file",
     )
     parser.add_argument(
+        "--composition-name",
+        metavar="NAME",
+        help="Run only the named composition (used with --composition for selective runs)",
+    )
+    parser.add_argument(
         "--locked",
         action="store_true",
         help=(
@@ -547,7 +562,7 @@ def main() -> None:
     elif args.update_baselines:
         passed = _mode_update_baselines(repo_root)
     elif args.composition:
-        passed = _mode_composition(Path(args.composition), repo_root)
+        passed = _mode_composition(Path(args.composition), repo_root, args.composition_name)
     else:
         passed = _mode_prepush(repo_root)
 

--- a/skill-eval/skill_eval/cli.py
+++ b/skill-eval/skill_eval/cli.py
@@ -344,26 +344,42 @@ def _mode_composition(config_path: Path, repo_root: Path) -> bool:
 
     for composition in compositions:
         name = composition.get("name", "?")
-        print(f"  [composition] {name}...")
+        configs = composition.get("configs", [])
+        print(f"  [composition] {name} ({len(configs)} config(s))...")
+
         try:
-            result = run_composition_eval(composition, repo_root, judge)
+            results = run_composition_eval(composition, repo_root, judge)
         except Exception as exc:
             print(f"  [error] {name}: {exc}", file=sys.stderr)
             all_passed = False
             continue
 
-        if result.infra_error:
-            print(f"  [error] {name}: infra error during chain execution", file=sys.stderr)
-            all_passed = False
-            continue
+        for config_name, result in results.items():
+            if result.infra_error:
+                print(
+                    f"  [error] {name}/{config_name}: infra error during chain execution",
+                    file=sys.stderr,
+                )
+                all_passed = False
+                continue
 
-        print(f"\n{'Metric':<30} {'Score':>8}  Status")
-        print("-" * 50)
-        for metric, score in result.final_scores.items():
-            print(f"  {metric:<28} {score:>8.3f}")
+            print(f"\n  [{name}/{config_name}]")
+            print(f"  {'Metric':<30} {'Score':>8}")
+            print("  " + "-" * 40)
+            for metric, score in result.final_scores.items():
+                print(f"    {metric:<28} {score:>8.3f}")
 
-        if not result.final_scores:
-            print(f"  {name}: no rubrics configured — chain executed successfully")
+            if not result.final_scores:
+                print("    no rubrics configured — chain executed successfully")
+
+        # Compare all non-baseline configs against the first config as baseline.
+        if len(results) > 1 and configs:
+            baseline_config = configs[0]["name"]
+            comparison = compare_composition_results(results, baseline_config)
+            if comparison["degradation_detected"]:
+                all_passed = False
+            for report in comparison["reports"].values():
+                print(report)
 
     return all_passed
 

--- a/skill-eval/skill_eval/rubrics.py
+++ b/skill-eval/skill_eval/rubrics.py
@@ -1855,6 +1855,90 @@ FOLLOW_THROUGH_RUBRIC = {
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# 24. IMPLEMENTER JUDGMENT (composition eval)
+#     Tests whether an implementer exercises independent judgment when following
+#     a plan — making purposeful technical decisions rather than mechanically
+#     transcribing plan steps. High scores require the implementer to treat the
+#     plan as a goal guide, not a checklist, and demonstrate agency in HOW the
+#     goal is achieved.
+# ──────────────────────────────────────────────────────────────────────────────
+
+IMPLEMENTER_JUDGMENT_RUBRIC = {
+    "name": "implementer_judgment",
+    "evaluation_steps": [
+        (
+            "Check whether the implementation demonstrates independent technical"
+            " decisions — library selection, error handling strategy, abstraction"
+            " boundaries, naming — that go beyond what the plan prescribes"
+        ),
+        (
+            "Check whether the implementation mechanically transcribes plan"
+            " steps verbatim, or whether it translates plan goals into code"
+            " using the implementer's own judgment about HOW to achieve them"
+        ),
+        (
+            "Compare the implementation against the expected output (answer key)"
+            " behaviors — check whether key independent decisions listed in the"
+            " answer key (e.g., 'uses secrets.token_urlsafe', 'decorator pattern')"
+            " appear in the actual output, not just plan-dictated choices"
+        ),
+        (
+            "Check whether the implementation treats the plan as a checklist"
+            " (steps executed in order, minimal deviation) versus a goal guide"
+            " (goal understood, implementation path chosen independently)"
+        ),
+    ],
+    "evaluation_params": [
+        LLMTestCaseParams.INPUT,
+        LLMTestCaseParams.ACTUAL_OUTPUT,
+        LLMTestCaseParams.EXPECTED_OUTPUT,
+    ],
+    "rubric": [
+        Rubric(
+            score_range=(0, 0),
+            expected_outcome=(
+                "Implementation mechanically follows every plan step in"
+                " sequence — no library choices, no structural decisions,"
+                " no error handling beyond what the plan names explicitly"
+            ),
+        ),
+        Rubric(
+            score_range=(3, 3),
+            expected_outcome=(
+                "Implementation makes 1-2 small choices (variable naming,"
+                " minor formatting) but otherwise transcribes plan steps"
+                " without exercising judgment on approach or structure"
+            ),
+        ),
+        Rubric(
+            score_range=(5, 5),
+            expected_outcome=(
+                "Implementation makes some independent decisions but remains"
+                " noticeably rigid — follows plan ordering, avoids choosing"
+                " between equivalent approaches, defers to plan wording"
+            ),
+        ),
+        Rubric(
+            score_range=(8, 8),
+            expected_outcome=(
+                "Implementation clearly exercises judgment: selects libraries,"
+                " structures abstractions, or handles errors in ways that go"
+                " beyond plan prescriptions and reflect purposeful choices"
+            ),
+        ),
+        Rubric(
+            score_range=(10, 10),
+            expected_outcome=(
+                "Plan treated as a goal guide — implementer independently"
+                " chooses approach, library, abstraction pattern, and error"
+                " strategy; plan steps are a destination, not a script"
+            ),
+        ),
+    ],
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # REGISTRY
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -1884,4 +1968,5 @@ RUBRIC_REGISTRY: dict[str, dict] = {
     "pr_depth": PR_DEPTH_RUBRIC,
     "convention_adherence": CONVENTION_ADHERENCE_RUBRIC,
     "follow_through": FOLLOW_THROUGH_RUBRIC,
+    "implementer_judgment": IMPLEMENTER_JUDGMENT_RUBRIC,
 }

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -16,12 +16,16 @@ from __future__ import annotations
 import functools
 import json
 import logging
+import os
 import re
 import subprocess
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import yaml
 
 if TYPE_CHECKING:
     from deepeval.models.base_model import DeepEvalBaseLLM
@@ -983,3 +987,509 @@ def compare_baselines(
         current = current_scores.get(metric, 0.0)
         lines.append(f"  {metric}: {current:.3f} (baseline={baseline:.3f})")
     return True, "\n".join(lines)
+
+
+# ── Composition evaluation ───────────────────────────────────────────────────
+
+# Regex for fixture key validation in composition context (allows subdirectory paths).
+_COMPOSITION_FIXTURE_KEY_RE = re.compile(r"^[a-zA-Z0-9_][a-zA-Z0-9_/-]*$")
+
+# Regex for skill name validation in composition steps.
+_SKILL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+# Regex for sanitizing secrets from stderr.
+_STDERR_SECRET_RE = re.compile(r"(?i)(key|token|secret|password|auth)[=: ]\S+")
+
+
+@dataclass
+class ChainStepResult:
+    skill_name: str
+    skill_output: str
+    capture_name: str | None
+
+
+@dataclass
+class CompositionConfig:
+    name: str
+    steps: list[dict]
+
+
+@dataclass
+class CompositionResult:
+    config_name: str
+    step_results: list[ChainStepResult]
+    final_scores: dict[str, float]
+    trial_scores: list[dict[str, float]] | None
+    infra_error: bool = False
+
+
+def load_composition_config(path: Path) -> dict:
+    """Load a composition config JSON file.
+
+    Args:
+        path: Absolute path to the composition JSON file.
+
+    Returns:
+        Dict with "compositions" key containing the list of compositions.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Composition config not found: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_composition_fixture(fixture_key: str, repo_root: Path) -> str:
+    """Load a composition fixture file, returning full content including frontmatter.
+
+    Fixture files live at ``skill-eval/fixtures/{fixture_key}.md``.
+    The full file content (including YAML frontmatter) is returned — the
+    caller is responsible for parsing the frontmatter separately.
+
+    Args:
+        fixture_key: Path-like key (e.g. "composition/terse-auth-plan").
+            Validated with pattern ``^[a-zA-Z0-9_][a-zA-Z0-9_/-]*$``.
+        repo_root: Repository root for path boundary check.
+
+    Returns:
+        Full fixture file content as string.
+
+    Raises:
+        ValueError: If fixture_key fails validation.
+        FileNotFoundError: If the fixture file does not exist.
+        OSError: If the file cannot be read.
+    """
+    if not _COMPOSITION_FIXTURE_KEY_RE.match(fixture_key):
+        raise ValueError(f"Invalid fixture key: {fixture_key!r}")
+
+    fixture_root = repo_root / "skill-eval" / "fixtures"
+    candidate = fixture_root / f"{fixture_key}.md"
+
+    # Path boundary check BEFORE reading.
+    try:
+        resolved = candidate.resolve()
+    except OSError as exc:
+        raise OSError(f"Cannot resolve fixture path {candidate}: {exc}") from exc
+
+    if not resolved.is_relative_to(fixture_root.resolve()):
+        raise ValueError(f"Fixture key {fixture_key!r} resolves outside fixture root")
+
+    if not candidate.is_file():
+        raise FileNotFoundError(f"Fixture not found: {candidate}")
+
+    return candidate.read_text(encoding="utf-8")
+
+
+def _build_context_preamble(repo_root: Path) -> str | None:
+    """Build CLAUDE.md context preamble for composition steps.
+
+    Returns:
+        Joined CLAUDE.md layers as a string, or None if no layers found.
+    """
+    layers = load_context_layers(repo_root)
+    if not layers:
+        return None
+    return "\n\n".join(layers.values())
+
+
+def _scaffold_worktree(trial_root: Path, scaffold_spec: dict) -> None:
+    """Populate an empty worktree with scaffold files and initial commit.
+
+    The worktree must have been created with ``git worktree add --no-checkout``.
+    This function creates the scaffold files and makes the first commit.
+
+    Args:
+        trial_root: Absolute path to the worktree root (empty directory).
+        scaffold_spec: Dict with "files" (list of relative paths) and
+            "requirements" (list of package names for requirements.txt).
+    """
+    files: list[str] = scaffold_spec.get("files", [])
+    requirements: list[str] = scaffold_spec.get("requirements", [])
+
+    for rel_path in files:
+        # Validate: relative only, no path traversal.
+        p = Path(rel_path)
+        if p.is_absolute():
+            raise ValueError(f"Scaffold file path must be relative: {rel_path!r}")
+        for part in p.parts:
+            if part == "..":
+                raise ValueError(f"Scaffold file path contains '..': {rel_path!r}")
+        target = trial_root / p
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("", encoding="utf-8")
+
+    # Write requirements.txt from scaffold spec.
+    req_path = trial_root / "requirements.txt"
+    req_path.write_text("\n".join(requirements) + "\n", encoding="utf-8")
+
+    # Write a minimal pre-commit config to prevent hook failures.
+    (trial_root / ".pre-commit-config.yaml").write_text("repos: []\n", encoding="utf-8")
+
+    subprocess.run(["git", "add", "-A"], cwd=trial_root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", "scaffold"],
+        cwd=trial_root,
+        check=True,
+        capture_output=True,
+    )
+
+
+def execute_chain(
+    steps: list[dict],
+    repo_root: Path,
+    context_preamble: str | None,
+    initial_captures: dict[str, str] | None = None,
+    timeout_seconds: int = 120,
+) -> list[ChainStepResult]:
+    """Execute a chain of skill steps sequentially, threading outputs between steps.
+
+    Each step invokes ``claude`` CLI with the skill bundle as system prompt.
+    Step prompts may reference outputs of prior steps via ``{capture_name}``
+    and can reference initial captures via their key names.
+
+    Prior step outputs are XML-wrapped at storage time to prevent prompt injection:
+    ``<prior-step-output skill="name">...</prior-step-output>``.
+
+    Args:
+        steps: List of step dicts. Each dict must have "skill" (skill name relative
+            to a plugin dir) and "prompt" (template string). Optional: "capture_as"
+            (name to store output under), "skill_dir" (override for skill resolution),
+            "rubrics" (list of rubric names for this step's output).
+        repo_root: Repository root for skill bundle resolution.
+        context_preamble: CLAUDE.md content to prepend to each step's prompt.
+        initial_captures: Pre-populated captures (e.g. fixture content). NOT
+            XML-wrapped — trusted input from the eval harness.
+        timeout_seconds: Per-step subprocess timeout in seconds.
+
+    Returns:
+        List of ChainStepResult, one per step.
+
+    Raises:
+        RuntimeError: If a step's skill bundle cannot be resolved.
+        subprocess.TimeoutExpired: If a step exceeds timeout_seconds.
+    """
+    captures: dict[str, str] = dict(initial_captures or {})
+    results: list[ChainStepResult] = []
+
+    for step in steps:
+        skill_name = step["skill"]
+        if not _SKILL_NAME_RE.match(skill_name):
+            raise ValueError(f"Invalid skill name in chain step: {skill_name!r}")
+
+        prompt_template: str = step["prompt"]
+        capture_as: str | None = step.get("capture_as")
+
+        # Resolve {variable} references using regex — NOT str.format_map to
+        # avoid KeyError on unrelated braces in the template.
+        def _replace(m: re.Match) -> str:  # noqa: ANN001
+            key = m.group(1)
+            return captures.get(key, m.group(0))
+
+        resolved_prompt = re.sub(r"\{([^}]+)\}", _replace, prompt_template)
+
+        # Resolve skill bundle from the repo.
+        # Skills live under {plugin}/skills/{skill_name}/ — search all plugins.
+        skill_dir: Path | None = None
+        if "skill_dir" in step:
+            skill_dir = Path(step["skill_dir"])
+        else:
+            for plugin_dir in repo_root.iterdir():
+                candidate = plugin_dir / "skills" / skill_name
+                if (candidate / "SKILL.md").is_file():
+                    skill_dir = candidate
+                    break
+
+        if skill_dir is None:
+            raise RuntimeError(f"Could not find skill directory for {skill_name!r}")
+
+        bundle = resolve_skill_bundle(skill_dir, repo_root=repo_root)
+        if bundle is None:
+            raise RuntimeError(f"Could not resolve skill bundle for {skill_name!r}")
+
+        # Build the full prompt (context + skill instructions + task).
+        parts = ["You are an AI assistant following the instructions below.\n"]
+        if context_preamble:
+            parts.append(
+                "=== BEHAVIORAL CONTEXT (CLAUDE.md) ===\n"
+                f"{context_preamble}\n"
+                "=== END BEHAVIORAL CONTEXT ===\n\n"
+            )
+        parts.append(
+            "Follow the skill instructions exactly as written.\n\n"
+            "=== SKILL INSTRUCTIONS ===\n"
+            f"{bundle}\n"
+            "=== END SKILL INSTRUCTIONS ===\n\n"
+            f"Task:\n{resolved_prompt}"
+        )
+        full_prompt = "".join(parts)
+
+        # Invoke claude CLI.
+        cmd = [
+            "claude",
+            "--print",
+            "--output-format",
+            "text",
+            "--append-system-prompt",
+            "",
+            "--permission-mode",
+            "bypassPermissions",
+        ]
+        env = {**os.environ, "CLAUDECODE": ""}
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=full_prompt,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                env=env,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("Step %r timed out after %ds", skill_name, timeout_seconds)
+            raise
+
+        if proc.returncode != 0:
+            sanitized_stderr = _STDERR_SECRET_RE.sub(r"\1=[REDACTED]", proc.stderr or "")
+            logger.warning(
+                "Step %r exited with code %d: %s",
+                skill_name,
+                proc.returncode,
+                sanitized_stderr[:500],
+            )
+
+        output = proc.stdout.strip()
+
+        if not output:
+            logger.warning("Step %r produced empty output", skill_name)
+        elif len(output) < 20:  # noqa: PLR2004
+            logger.warning("Step %r produced suspiciously short output: %r", skill_name, output)
+
+        # Store with XML wrapping to prevent injection of prompt delimiters.
+        if capture_as:
+            captures[capture_as] = (
+                f'<prior-step-output skill="{skill_name}">{output}</prior-step-output>'
+            )
+
+        results.append(
+            ChainStepResult(
+                skill_name=skill_name,
+                skill_output=output,
+                capture_name=capture_as,
+            )
+        )
+
+    return results
+
+
+def run_composition_eval(
+    composition: dict,
+    repo_root: Path,
+    judge: DeepEvalBaseLLM,
+    n_trials: int = 1,
+) -> CompositionResult:
+    """Run one composition: execute the step chain and score the final output.
+
+    For each trial:
+    1. Create an isolated git worktree with scaffold files.
+    2. Execute the step chain.
+    3. Score the final step output with rubric metrics.
+
+    Args:
+        composition: A composition dict from the config's "compositions" list.
+            Required keys: "name", "fixture_key", "steps", "rubrics".
+            Optional: "expected_behaviors" (list[str]).
+        repo_root: Repository root.
+        judge: DeepEvalBaseLLM for scoring.
+        n_trials: Number of trial runs (scores are averaged).
+
+    Returns:
+        CompositionResult with averaged scores and step results from the last trial.
+    """
+    from deepeval.test_case import LLMTestCase
+
+    name: str = composition["name"]
+    fixture_key: str = composition["fixture_key"]
+    rubric_names: list[str] = composition["rubrics"]
+    steps: list[dict] = composition["steps"]
+    expected_behaviors: list[str] = composition.get("expected_behaviors", [])
+
+    fixture_content = load_composition_fixture(fixture_key, repo_root)
+
+    # Parse YAML frontmatter for scaffold spec.
+    scaffold_spec: dict = {}
+    lines = fixture_content.split("\n")
+    if lines and _FRONTMATTER_RE.match(lines[0]):
+        for i in range(1, len(lines)):
+            if _FRONTMATTER_RE.match(lines[i]):
+                frontmatter_text = "\n".join(lines[1:i])
+                scaffold_spec = yaml.safe_load(frontmatter_text) or {}
+                scaffold_spec = scaffold_spec.get("scaffold", {})
+                break
+
+    context_preamble = _build_context_preamble(repo_root)
+
+    # Prune stale worktrees before creating new ones.
+    subprocess.run(
+        ["git", "worktree", "prune"],
+        cwd=repo_root,
+        capture_output=True,
+    )
+
+    trial_scores: list[dict[str, float]] = []
+    last_step_results: list[ChainStepResult] = []
+
+    for trial_idx in range(n_trials):
+        trial_root = repo_root / ".skill-eval-worktrees" / f"{name}-trial-{trial_idx}"
+        trial_root.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            subprocess.run(
+                ["git", "worktree", "add", "--no-checkout", "--detach", str(trial_root), "HEAD"],
+                cwd=repo_root,
+                check=True,
+                capture_output=True,
+            )
+
+            if scaffold_spec:
+                _scaffold_worktree(trial_root, scaffold_spec)
+
+            try:
+                step_results = execute_chain(
+                    steps,
+                    repo_root,
+                    context_preamble,
+                    initial_captures={"fixture": fixture_content},
+                )
+                last_step_results = step_results
+            except Exception as exc:
+                logger.warning("Chain execution failed for %r trial %d: %s", name, trial_idx, exc)
+                return CompositionResult(
+                    config_name=name,
+                    step_results=[],
+                    final_scores={},
+                    trial_scores=None,
+                    infra_error=True,
+                )
+
+            final_output = step_results[-1].skill_output if step_results else ""
+            final_prompt = steps[-1].get("prompt", "") if steps else ""
+
+            sanitized_expected = []
+            for e in expected_behaviors:
+                for delim in _PROMPT_DELIMITERS:
+                    e = e.replace(delim, "")
+                e = e.strip()
+                if e:
+                    sanitized_expected.append(e)
+
+            llm_tc = LLMTestCase(
+                input=final_prompt,
+                actual_output=final_output,
+                expected_output="\n".join(sanitized_expected) if sanitized_expected else None,
+            )
+
+            metrics = build_metrics(rubric_names, judge) if rubric_names else []
+            tc_scores: dict[str, float] = {}
+            for metric in metrics:
+                try:
+                    metric.measure(llm_tc)
+                    tc_scores[metric.name] = metric.score if metric.score is not None else 0.0
+                except Exception as exc:
+                    logger.warning("Metric %s failed: %s", metric.name, exc)
+
+            trial_scores.append(tc_scores)
+
+        finally:
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", str(trial_root)],
+                cwd=repo_root,
+                capture_output=True,
+            )
+
+    # Average scores across trials.
+    all_metric_names: set[str] = set()
+    for ts in trial_scores:
+        all_metric_names.update(ts.keys())
+
+    final_scores: dict[str, float] = {}
+    for metric_name in all_metric_names:
+        vals = [ts[metric_name] for ts in trial_scores if metric_name in ts]
+        final_scores[metric_name] = sum(vals) / len(vals) if vals else 0.0
+
+    return CompositionResult(
+        config_name=name,
+        step_results=last_step_results,
+        final_scores=final_scores,
+        trial_scores=trial_scores,
+    )
+
+
+def compare_composition_results(
+    current: CompositionResult,
+    baseline: CompositionResult,
+    tolerance: float = 0.15,
+) -> tuple[bool, str]:
+    """Compare a composition result against a baseline.
+
+    Args:
+        current: The current eval's CompositionResult.
+        baseline: The baseline CompositionResult to compare against.
+        tolerance: Maximum allowed score drop before flagging degradation.
+
+    Returns:
+        Tuple of (degradation_detected: bool, report: str).
+        degradation_detected is True when any metric drops more than tolerance.
+    """
+    name = current.config_name
+
+    if current.infra_error:
+        return True, f"{name}: INFRA ERROR — chain execution failed"
+
+    if baseline.infra_error:
+        return False, f"{name}: baseline had infra error — treating as pass"
+
+    current_scores = current.final_scores
+    baseline_scores = baseline.final_scores
+
+    if not baseline_scores:
+        return False, f"{name}: no baseline scores — treating as pass"
+
+    regressions: list[str] = []
+    deltas: dict[str, float] = {}
+
+    for metric, base_val in baseline_scores.items():
+        curr_val = current_scores.get(metric)
+        if curr_val is None:
+            regressions.append(f"  {metric}: missing from current (baseline={base_val:.3f})")
+            continue
+        delta = curr_val - base_val
+        deltas[metric] = delta
+        drop = base_val - curr_val
+        if drop > tolerance:
+            regressions.append(
+                f"  {metric}: {curr_val:.3f} vs baseline {base_val:.3f}"
+                f" (drop={drop:.3f} > tolerance={tolerance:.3f})"
+            )
+
+    degradation_detected = len(regressions) > 0
+
+    # Build ASCII table.
+    all_metrics = sorted(set(list(current_scores.keys()) + list(baseline_scores.keys())))
+    header = f"{'Metric':<30} {'Current':>8} {'Baseline':>8} {'Delta':>8}"
+    separator = "-" * len(header)
+    table_lines = [f"\n{name}", header, separator]
+    for metric in all_metrics:
+        curr_val = current_scores.get(metric, 0.0)
+        base_val = baseline_scores.get(metric, 0.0)
+        delta = curr_val - base_val
+        flag = " !" if delta < -tolerance else ""
+        table_lines.append(f"  {metric:<28} {curr_val:>8.3f} {base_val:>8.3f} {delta:>+8.3f}{flag}")
+
+    status_line = f"\nStatus: {'DEGRADATION DETECTED' if degradation_detected else 'PASS'}"
+    if regressions:
+        status_line += "\n" + "\n".join(regressions)
+
+    report = "\n".join(table_lines) + status_line
+    return degradation_detected, report

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -1327,13 +1327,7 @@ def _run_single_config(
                     trial_idx,
                     exc,
                 )
-                return CompositionResult(
-                    config_name=config_name,
-                    step_results=[],
-                    final_scores={},
-                    trial_scores=None,
-                    infra_error=True,
-                )
+                continue
 
             final_output = step_results[-1].skill_output if step_results else ""
             final_prompt = steps[-1].get("prompt_template", "") if steps else ""
@@ -1372,6 +1366,15 @@ def _run_single_config(
                 cwd=repo_root,
                 capture_output=True,
             )
+
+    if not trial_scores:
+        return CompositionResult(
+            config_name=config_name,
+            step_results=[],
+            final_scores={},
+            trial_scores=None,
+            infra_error=True,
+        )
 
     all_metric_names: set[str] = set()
     for ts in trial_scores:

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -50,6 +50,7 @@ _RE_ANGLE = re.compile(
     re.DOTALL,
 )
 
+_MIN_STEP_OUTPUT_LEN: int = 50
 
 # Skill-goal rubrics that use EXPECTED_OUTPUT and require expected_behaviors.
 # Shared between load_eval_config() validation and tests.
@@ -1033,7 +1034,7 @@ class ChainStepResult:
     skill_name: str
     skill_output: str
     capture_name: str | None
-    resolved_prompt: str = ""
+    resolved_prompt: str = ""  # populated only for the final chain step; "" for all prior steps
 
 
 @dataclass
@@ -1315,7 +1316,7 @@ def execute_chain(
         if not output:
             logger.warning("Step %r produced empty output", skill_name)
             output = f"[empty output from {skill_name}]"
-        elif len(output) < 50:  # noqa: PLR2004
+        elif len(output) < _MIN_STEP_OUTPUT_LEN:
             logger.warning("Step %r produced suspect short output: %r", skill_name, output)
             output = f"[suspect output from {skill_name}]: {output[:100]}"
 
@@ -1362,7 +1363,7 @@ def _run_single_config(
 
     sanitized_expected = _sanitize_expected_behaviors(expected_behaviors)
     trial_scores: list[dict[str, float]] = []
-    last_step_results: list[ChainStepResult] = []
+    trial_step_results: list[list[ChainStepResult]] = []
 
     for trial_idx in range(n_trials):
         suffix = uuid.uuid4().hex[:8]
@@ -1393,7 +1394,7 @@ def _run_single_config(
                     initial_captures={"fixture": fixture_content},
                     skill_repo_root=repo_root,
                 )
-                last_step_results = step_results
+                trial_step_results.append(step_results)
             except Exception as exc:
                 print(
                     f"  trial {trial_idx + 1}/{n_trials} ({config_name}): FAILED — {exc}",
@@ -1409,10 +1410,9 @@ def _run_single_config(
                 continue
 
             final_output = step_results[-1].skill_output if step_results else ""
-            final_prompt = step_results[-1].resolved_prompt if step_results else ""
 
             llm_tc = LLMTestCase(
-                input=final_prompt,
+                input=fixture_content,
                 actual_output=final_output,
                 expected_output="\n".join(sanitized_expected) if sanitized_expected else None,
             )
@@ -1421,13 +1421,20 @@ def _run_single_config(
             if assertions:
                 metrics.append(build_assertion_metrics(assertions))
 
-            tc_scores: dict[str, float] = {}
-            for metric in metrics:
+            def _score_one(metric: object, _tc: object = llm_tc) -> tuple[str, float]:
                 try:
-                    metric.measure(llm_tc)
-                    tc_scores[metric.name] = metric.score if metric.score is not None else 0.0
+                    metric.measure(_tc)  # type: ignore[union-attr]
+                    return metric.name, metric.score if metric.score is not None else 0.0  # type: ignore[union-attr]
                 except Exception as exc:
-                    logger.warning("Metric %s failed: %s", metric.name, exc)
+                    m_name = getattr(metric, "name", type(metric).__name__)
+                    logger.warning("Metric %s failed: %s", m_name, exc)
+                    return m_name, 0.0
+
+            tc_scores: dict[str, float] = {}
+            if metrics:
+                with ThreadPoolExecutor(max_workers=len(metrics)) as metric_pool:
+                    for name, score in metric_pool.map(_score_one, metrics):
+                        tc_scores[name] = score
 
             trial_scores.append(tc_scores)
             score_summary = ", ".join(f"{k}={v:.2f}" for k, v in tc_scores.items())
@@ -1442,6 +1449,8 @@ def _run_single_config(
                 cwd=repo_root,
                 capture_output=True,
             )
+
+    last_step_results = trial_step_results[-1] if trial_step_results else []
 
     if not trial_scores:
         return CompositionResult(

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -1009,12 +1009,6 @@ class ChainStepResult:
 
 
 @dataclass
-class CompositionConfig:
-    name: str
-    steps: list[dict]
-
-
-@dataclass
 class CompositionResult:
     config_name: str
     step_results: list[ChainStepResult]
@@ -1253,10 +1247,16 @@ def execute_chain(
 
         if not output:
             logger.warning("Step %r produced empty output", skill_name)
-        elif len(output) < 20:  # noqa: PLR2004
-            logger.warning("Step %r produced suspiciously short output: %r", skill_name, output)
+            output = f"[empty output from {skill_name}]"
+        elif len(output) < 50:  # noqa: PLR2004
+            logger.warning("Step %r produced suspect short output: %r", skill_name, output)
+            output = f"[suspect output from {skill_name}]: {output[:100]}"
 
-        # Store with XML wrapping to prevent injection of prompt delimiters.
+        # Strip prompt delimiters from output before storage to prevent injection.
+        for delim in _PROMPT_DELIMITERS:
+            output = output.replace(delim, "")
+
+        # Store with XML wrapping for trust boundary.
         if capture_as:
             captures[capture_as] = (
                 f'<prior-step-output skill="{skill_name}">{output}</prior-step-output>'

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -1236,6 +1236,7 @@ def execute_chain(
                 text=True,
                 timeout=timeout_seconds,
                 env=env,
+                cwd=str(repo_root),
             )
         except subprocess.TimeoutExpired:
             logger.warning("Step %r timed out after %ds", skill_name, timeout_seconds)
@@ -1243,11 +1244,9 @@ def execute_chain(
 
         if proc.returncode != 0:
             sanitized_stderr = _STDERR_SECRET_RE.sub(r"\1=[REDACTED]", proc.stderr or "")
-            logger.warning(
-                "Step %r exited with code %d: %s",
-                skill_name,
-                proc.returncode,
-                sanitized_stderr[:500],
+            raise RuntimeError(
+                f"claude CLI failed (step {skill_name!r}, exit {proc.returncode}): "
+                f"{sanitized_stderr[:500]}"
             )
 
         output = proc.stdout.strip()

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -18,8 +18,10 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import threading
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -997,8 +999,38 @@ _COMPOSITION_FIXTURE_KEY_RE = re.compile(r"^[a-zA-Z0-9_][a-zA-Z0-9_/-]*$")
 # Regex for skill name validation in composition steps.
 _SKILL_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
-# Regex for sanitizing secrets from stderr.
-_STDERR_SECRET_RE = re.compile(r"(?i)(key|token|secret|password|auth)[=: ]\S+")
+# Regex for sanitizing secrets from stderr — matches keyword=value patterns
+# including quoted values ("val" / 'val') and bare values.
+_STDERR_SECRET_RE = re.compile(
+    r"(?i)(key|token|secret|password|auth|credential)"
+    r"""[=: ]+(?:"[^"]*"|'[^']*'|\S+)"""
+)
+# Standalone API key patterns (Anthropic, Google OAuth, AWS).
+_STDERR_API_KEY_RE = re.compile(r"sk-[a-zA-Z0-9]{10,}|ya29\.[a-zA-Z0-9_-]+|AKIA[A-Z0-9]{12,}")
+
+# Environment variables forwarded to claude CLI subprocesses.
+# Restricted to prevent leaking unrelated secrets (DB passwords, etc.).
+_SUBPROCESS_ENV_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "PATH",
+        "HOME",
+        "TMPDIR",
+        "LANG",
+        "SHELL",
+        "USER",
+        "LOGNAME",
+        "TERM",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_VERTEX_PROJECT_ID",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_CLOUD_PROJECT",
+        "CLOUD_ML_REGION",
+        "CLOUDSDK_CONFIG",
+    }
+)
 
 
 @dataclass
@@ -1164,8 +1196,9 @@ def execute_chain(
     """
     captures: dict[str, str] = dict(initial_captures or {})
     results: list[ChainStepResult] = []
+    total_steps = len(steps)
 
-    for step in steps:
+    for step_idx, step in enumerate(steps, 1):
         skill_name = step["skill"]
         if not _SKILL_NAME_RE.match(skill_name):
             raise ValueError(f"Invalid skill name in chain step: {skill_name!r}")
@@ -1216,13 +1249,20 @@ def execute_chain(
             "--print",
             "--output-format",
             "text",
-            *(["--bare"] if step.get("bare", False) else []),
+            *(["--bare"] if bare_mode else []),
             "--append-system-prompt",
             bundle,
             "--permission-mode",
             "bypassPermissions",
         ]
-        env = {**os.environ, "CLAUDECODE": ""}
+        env = {k: v for k, v in os.environ.items() if k in _SUBPROCESS_ENV_ALLOWLIST}
+        env["CLAUDECODE"] = ""
+
+        print(
+            f"    step {step_idx}/{total_steps}: {skill_name}"
+            f" (timeout={timeout_seconds}s, {'bare' if bare_mode else 'full'})...",
+            flush=True,
+        )
 
         try:
             proc = subprocess.run(
@@ -1235,15 +1275,25 @@ def execute_chain(
                 cwd=str(repo_root),
             )
         except subprocess.TimeoutExpired:
-            logger.warning("Step %r timed out after %ds", skill_name, timeout_seconds)
+            print(f"    step {step_idx}/{total_steps}: {skill_name} TIMED OUT", flush=True)
             raise
 
         if proc.returncode != 0:
-            sanitized_stderr = _STDERR_SECRET_RE.sub(r"\1=[REDACTED]", proc.stderr or "")
+            sanitized = _STDERR_SECRET_RE.sub(r"\1=[REDACTED]", proc.stderr or "")
+            sanitized = _STDERR_API_KEY_RE.sub("[REDACTED_KEY]", sanitized)
+            print(
+                f"    step {step_idx}/{total_steps}: {skill_name} FAILED (exit {proc.returncode})",
+                flush=True,
+            )
             raise RuntimeError(
                 f"claude CLI failed (step {skill_name!r}, exit {proc.returncode}): "
-                f"{sanitized_stderr[:500]}"
+                f"{sanitized[:200]}"
             )
+
+        print(
+            f"    step {step_idx}/{total_steps}: {skill_name} done ({len(proc.stdout)} chars)",
+            flush=True,
+        )
 
         output = proc.stdout.strip()
 
@@ -1298,9 +1348,14 @@ def _run_single_config(
     last_step_results: list[ChainStepResult] = []
 
     for trial_idx in range(n_trials):
-        worktree_name = f"{composition_name}-{config_name}-trial-{trial_idx}"
+        suffix = uuid.uuid4().hex[:8]
+        worktree_name = f"{config_name}-t{trial_idx}-{suffix}"
         trial_root = repo_root / ".skill-eval-worktrees" / worktree_name
         trial_root.parent.mkdir(parents=True, exist_ok=True)
+        print(
+            f"  trial {trial_idx + 1}/{n_trials} ({config_name}): creating worktree...",
+            flush=True,
+        )
 
         try:
             subprocess.run(
@@ -1322,6 +1377,10 @@ def _run_single_config(
                 )
                 last_step_results = step_results
             except Exception as exc:
+                print(
+                    f"  trial {trial_idx + 1}/{n_trials} ({config_name}): FAILED — {exc}",
+                    flush=True,
+                )
                 logger.warning(
                     "Chain execution failed for %r config %r trial %d: %s",
                     composition_name,
@@ -1361,6 +1420,11 @@ def _run_single_config(
                     logger.warning("Metric %s failed: %s", metric.name, exc)
 
             trial_scores.append(tc_scores)
+            score_summary = ", ".join(f"{k}={v:.2f}" for k, v in tc_scores.items())
+            print(
+                f"  trial {trial_idx + 1}/{n_trials} ({config_name}): scored [{score_summary}]",
+                flush=True,
+            )
 
         finally:
             subprocess.run(
@@ -1441,16 +1505,22 @@ def run_composition_eval(
                 scaffold_spec = scaffold_spec.get("scaffold", {})
                 break
 
-    # Prune stale worktrees before creating new ones.
+    # Holistic pre-run cleanup: remove stale worktree directories from prior
+    # runs (crash recovery, kill -9, OOM), then prune git worktree metadata.
+    worktree_dir = repo_root / ".skill-eval-worktrees"
+    if worktree_dir.is_dir():
+        shutil.rmtree(worktree_dir, ignore_errors=True)
     subprocess.run(
         ["git", "worktree", "prune"],
         cwd=repo_root,
         capture_output=True,
     )
 
+    total_configs = len(configs)
     results: dict[str, CompositionResult] = {}
-    for config in configs:
+    for config_idx, config in enumerate(configs, 1):
         config_name = config["name"]
+        print(f"\n  config {config_idx}/{total_configs}: {config_name}", flush=True)
         results[config_name] = _run_single_config(
             composition_name=name,
             config=config,

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -69,6 +69,7 @@ SKILL_GOAL_RUBRICS: frozenset[str] = frozenset(
         "pr_depth",
         "convention_adherence",
         "follow_through",
+        "implementer_judgment",
     }
 )
 

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -843,12 +843,7 @@ def run_eval(
 
         # Wire expected_behaviors as expected_output for competency rubrics.
         expected = tc.get("expected_behaviors", [])
-        sanitized = []
-        for e in expected:
-            for delim in _PROMPT_DELIMITERS:
-                e = e.replace(delim, "")
-            sanitized.append(e.strip())
-        sanitized = [e for e in sanitized if e]
+        sanitized = _sanitize_expected_behaviors(expected)
         llm_tc = LLMTestCase(
             input=prompt,
             actual_output=response,
@@ -1038,6 +1033,7 @@ class ChainStepResult:
     skill_name: str
     skill_output: str
     capture_name: str | None
+    resolved_prompt: str = ""
 
 
 @dataclass
@@ -1107,6 +1103,18 @@ def load_composition_fixture(fixture_key: str, repo_root: Path) -> str:
     return candidate.read_text(encoding="utf-8")
 
 
+def _sanitize_expected_behaviors(behaviors: list[str]) -> list[str]:
+    """Strip prompt delimiters, trim whitespace, and remove empty strings."""
+    result = []
+    for e in behaviors:
+        for delim in _PROMPT_DELIMITERS:
+            e = e.replace(delim, "")
+        e = e.strip()
+        if e:
+            result.append(e)
+    return result
+
+
 def _build_context_preamble(repo_root: Path) -> str | None:
     """Build CLAUDE.md context preamble for composition steps.
 
@@ -1166,6 +1174,7 @@ def execute_chain(
     repo_root: Path,
     context_preamble: str | None,
     initial_captures: dict[str, str] | None = None,
+    skill_repo_root: Path | None = None,
 ) -> list[ChainStepResult]:
     """Execute a chain of skill steps sequentially, threading outputs between steps.
 
@@ -1181,10 +1190,13 @@ def execute_chain(
             code-quality/skills/), "prompt_template" (template string), and
             "timeout_seconds" (int, required). Optional: "capture_as" (name to
             store output under), "bare" (bool, passes --bare to claude CLI).
-        repo_root: Repository root for skill bundle resolution.
+        repo_root: Working directory for subprocess CWD.
         context_preamble: CLAUDE.md content to prepend to each step's task prompt.
         initial_captures: Pre-populated captures (e.g. fixture content). NOT
             XML-wrapped — trusted input from the eval harness.
+        skill_repo_root: Repository root for skill bundle resolution. Falls back
+            to ``repo_root`` when None. Use when ``repo_root`` is a worktree that
+            lacks ``code-quality/skills/``.
 
     Returns:
         List of ChainStepResult, one per step.
@@ -1219,14 +1231,17 @@ def execute_chain(
             resolved_prompt = prompt_template
 
         # Resolve skill bundle from code-quality/skills/.
+        _skill_root = skill_repo_root if skill_repo_root is not None else repo_root
         if "skill_dir" in step:
             skill_dir = Path(step["skill_dir"])
+            if not skill_dir.resolve().is_relative_to(_skill_root.resolve()):
+                raise ValueError(f"skill_dir {skill_dir!r} resolves outside skill repo root")
         else:
-            skill_dir = repo_root / "code-quality" / "skills" / skill_name
+            skill_dir = _skill_root / "code-quality" / "skills" / skill_name
         if not (skill_dir / "SKILL.md").is_file():
             raise RuntimeError(f"Could not find skill directory for {skill_name!r}")
 
-        bundle = resolve_skill_bundle(skill_dir, repo_root=repo_root)
+        bundle = resolve_skill_bundle(skill_dir, repo_root=_skill_root)
         if bundle is None:
             raise RuntimeError(f"Could not resolve skill bundle for {skill_name!r}")
 
@@ -1319,6 +1334,7 @@ def execute_chain(
                 skill_name=skill_name,
                 skill_output=output,
                 capture_name=capture_as,
+                resolved_prompt=resolved_prompt if step_idx == total_steps else "",
             )
         )
 
@@ -1344,6 +1360,7 @@ def _run_single_config(
     steps: list[dict] = config["steps"]
     context_preamble = _build_context_preamble(repo_root)
 
+    sanitized_expected = _sanitize_expected_behaviors(expected_behaviors)
     trial_scores: list[dict[str, float]] = []
     last_step_results: list[ChainStepResult] = []
 
@@ -1374,6 +1391,7 @@ def _run_single_config(
                     trial_root,
                     context_preamble,
                     initial_captures={"fixture": fixture_content},
+                    skill_repo_root=repo_root,
                 )
                 last_step_results = step_results
             except Exception as exc:
@@ -1391,15 +1409,7 @@ def _run_single_config(
                 continue
 
             final_output = step_results[-1].skill_output if step_results else ""
-            final_prompt = steps[-1].get("prompt_template", "") if steps else ""
-
-            sanitized_expected = []
-            for e in expected_behaviors:
-                for delim in _PROMPT_DELIMITERS:
-                    e = e.replace(delim, "")
-                e = e.strip()
-                if e:
-                    sanitized_expected.append(e)
+            final_prompt = step_results[-1].resolved_prompt if step_results else ""
 
             llm_tc = LLMTestCase(
                 input=final_prompt,
@@ -1494,7 +1504,8 @@ def run_composition_eval(
 
     fixture_content = load_composition_fixture(fixture_key, repo_root)
 
-    # Parse YAML frontmatter for scaffold spec.
+    # Parse YAML frontmatter for scaffold spec, then strip it from fixture_content
+    # so the answer key (planted_issues, etc.) does not leak into LLM prompts.
     scaffold_spec: dict = {}
     lines = fixture_content.split("\n")
     if lines and _FRONTMATTER_RE.match(lines[0]):
@@ -1503,7 +1514,10 @@ def run_composition_eval(
                 frontmatter_text = "\n".join(lines[1:i])
                 scaffold_spec = yaml.safe_load(frontmatter_text) or {}
                 scaffold_spec = scaffold_spec.get("scaffold", {})
+                fixture_content = "\n".join(lines[i + 1 :]).lstrip("\n")
                 break
+        else:
+            raise ValueError(f"Fixture {fixture_key!r} has unterminated YAML frontmatter")
 
     # Holistic pre-run cleanup: remove stale worktree directories from prior
     # runs (crash recovery, kill -9, OOM), then prune git worktree metadata.
@@ -1570,22 +1584,20 @@ def compare_composition_results(
         if config_name == baseline_config:
             continue
 
-        name = config_name
-
         if result.infra_error:
-            reports[name] = f"{name}: INFRA ERROR — chain execution failed"
+            reports[config_name] = f"{config_name}: INFRA ERROR — chain execution failed"
             any_degradation = True
             continue
 
         if baseline.infra_error:
-            reports[name] = f"{name}: baseline had infra error — treating as pass"
+            reports[config_name] = f"{config_name}: baseline had infra error — treating as pass"
             continue
 
         current_scores = result.final_scores
         baseline_scores = baseline.final_scores
 
         if not baseline_scores:
-            reports[name] = f"{name}: no baseline scores — treating as pass"
+            reports[config_name] = f"{config_name}: no baseline scores — treating as pass"
             continue
 
         regressions: list[str] = []
@@ -1606,10 +1618,10 @@ def compare_composition_results(
         if degradation_detected:
             any_degradation = True
 
-        all_metrics = sorted(set(list(current_scores.keys()) + list(baseline_scores.keys())))
+        all_metrics = sorted(current_scores.keys() | baseline_scores.keys())
         header = f"{'Metric':<30} {'Current':>8} {'Baseline':>8} {'Delta':>8}"
         separator = "-" * len(header)
-        table_lines = [f"\n{name} (vs {baseline_config})", header, separator]
+        table_lines = [f"\n{config_name} (vs {baseline_config})", header, separator]
         for metric in all_metrics:
             curr_val = current_scores.get(metric, 0.0)
             base_val = baseline_scores.get(metric, 0.0)
@@ -1623,6 +1635,6 @@ def compare_composition_results(
         if regressions:
             status_line += "\n" + "\n".join(regressions)
 
-        reports[name] = "\n".join(table_lines) + status_line
+        reports[config_name] = "\n".join(table_lines) + status_line
 
     return {"degradation_detected": any_degradation, "reports": reports}

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -1197,8 +1197,10 @@ def execute_chain(
         if bundle is None:
             raise RuntimeError(f"Could not resolve skill bundle for {skill_name!r}")
 
-        # Build the task prompt, prepending context preamble if present.
-        if context_preamble:
+        # Build the task prompt. Bare steps skip context preamble (repo context
+        # intentionally excluded — only the skill bundle provides instructions).
+        bare_mode = step.get("bare", False)
+        if context_preamble and not bare_mode:
             task_input = (
                 "=== BEHAVIORAL CONTEXT (CLAUDE.md) ===\n"
                 f"{context_preamble}\n"

--- a/skill-eval/skill_eval/runner.py
+++ b/skill-eval/skill_eval/runner.py
@@ -1140,11 +1140,10 @@ def execute_chain(
     repo_root: Path,
     context_preamble: str | None,
     initial_captures: dict[str, str] | None = None,
-    timeout_seconds: int = 120,
 ) -> list[ChainStepResult]:
     """Execute a chain of skill steps sequentially, threading outputs between steps.
 
-    Each step invokes ``claude`` CLI with the skill bundle as system prompt.
+    Each step invokes ``claude`` CLI with the skill bundle as --append-system-prompt.
     Step prompts may reference outputs of prior steps via ``{capture_name}``
     and can reference initial captures via their key names.
 
@@ -1152,22 +1151,22 @@ def execute_chain(
     ``<prior-step-output skill="name">...</prior-step-output>``.
 
     Args:
-        steps: List of step dicts. Each dict must have "skill" (skill name relative
-            to a plugin dir) and "prompt" (template string). Optional: "capture_as"
-            (name to store output under), "skill_dir" (override for skill resolution),
-            "rubrics" (list of rubric names for this step's output).
+        steps: List of step dicts. Each dict must have "skill" (skill name under
+            code-quality/skills/), "prompt_template" (template string), and
+            "timeout_seconds" (int, required). Optional: "capture_as" (name to
+            store output under), "bare" (bool, passes --bare to claude CLI).
         repo_root: Repository root for skill bundle resolution.
-        context_preamble: CLAUDE.md content to prepend to each step's prompt.
+        context_preamble: CLAUDE.md content to prepend to each step's task prompt.
         initial_captures: Pre-populated captures (e.g. fixture content). NOT
             XML-wrapped — trusted input from the eval harness.
-        timeout_seconds: Per-step subprocess timeout in seconds.
 
     Returns:
         List of ChainStepResult, one per step.
 
     Raises:
         RuntimeError: If a step's skill bundle cannot be resolved.
-        subprocess.TimeoutExpired: If a step exceeds timeout_seconds.
+        KeyError: If a step is missing required "timeout_seconds" key.
+        subprocess.TimeoutExpired: If a step exceeds its timeout_seconds.
     """
     captures: dict[str, str] = dict(initial_captures or {})
     results: list[ChainStepResult] = []
@@ -1177,61 +1176,53 @@ def execute_chain(
         if not _SKILL_NAME_RE.match(skill_name):
             raise ValueError(f"Invalid skill name in chain step: {skill_name!r}")
 
-        prompt_template: str = step["prompt"]
+        prompt_template: str = step["prompt_template"]
         capture_as: str | None = step.get("capture_as")
+        timeout_seconds: int = step["timeout_seconds"]
 
-        # Resolve {variable} references using regex — NOT str.format_map to
-        # avoid KeyError on unrelated braces in the template.
-        def _replace(m: re.Match) -> str:  # noqa: ANN001
-            key = m.group(1)
-            return captures.get(key, m.group(0))
+        # Resolve {variable} references using known capture keys only.
+        if captures:
+            capture_keys = "|".join(re.escape(k) for k in captures)
+            resolved_prompt = re.sub(
+                r"\{(" + capture_keys + r")\}",
+                lambda m: captures[m.group(1)],
+                prompt_template,
+            )
+        else:
+            resolved_prompt = prompt_template
 
-        resolved_prompt = re.sub(r"\{([^}]+)\}", _replace, prompt_template)
-
-        # Resolve skill bundle from the repo.
-        # Skills live under {plugin}/skills/{skill_name}/ — search all plugins.
-        skill_dir: Path | None = None
+        # Resolve skill bundle from code-quality/skills/.
         if "skill_dir" in step:
             skill_dir = Path(step["skill_dir"])
         else:
-            for plugin_dir in repo_root.iterdir():
-                candidate = plugin_dir / "skills" / skill_name
-                if (candidate / "SKILL.md").is_file():
-                    skill_dir = candidate
-                    break
-
-        if skill_dir is None:
+            skill_dir = repo_root / "code-quality" / "skills" / skill_name
+        if not (skill_dir / "SKILL.md").is_file():
             raise RuntimeError(f"Could not find skill directory for {skill_name!r}")
 
         bundle = resolve_skill_bundle(skill_dir, repo_root=repo_root)
         if bundle is None:
             raise RuntimeError(f"Could not resolve skill bundle for {skill_name!r}")
 
-        # Build the full prompt (context + skill instructions + task).
-        parts = ["You are an AI assistant following the instructions below.\n"]
+        # Build the task prompt, prepending context preamble if present.
         if context_preamble:
-            parts.append(
+            task_input = (
                 "=== BEHAVIORAL CONTEXT (CLAUDE.md) ===\n"
                 f"{context_preamble}\n"
                 "=== END BEHAVIORAL CONTEXT ===\n\n"
+                f"{resolved_prompt}"
             )
-        parts.append(
-            "Follow the skill instructions exactly as written.\n\n"
-            "=== SKILL INSTRUCTIONS ===\n"
-            f"{bundle}\n"
-            "=== END SKILL INSTRUCTIONS ===\n\n"
-            f"Task:\n{resolved_prompt}"
-        )
-        full_prompt = "".join(parts)
+        else:
+            task_input = resolved_prompt
 
-        # Invoke claude CLI.
+        # Invoke claude CLI. Bundle goes via --append-system-prompt; task via stdin.
         cmd = [
             "claude",
             "--print",
             "--output-format",
             "text",
+            *(["--bare"] if step.get("bare", False) else []),
             "--append-system-prompt",
-            "",
+            bundle,
             "--permission-mode",
             "bypassPermissions",
         ]
@@ -1240,7 +1231,7 @@ def execute_chain(
         try:
             proc = subprocess.run(
                 cmd,
-                input=full_prompt,
+                input=task_input,
                 capture_output=True,
                 text=True,
                 timeout=timeout_seconds,
@@ -1283,65 +1274,31 @@ def execute_chain(
     return results
 
 
-def run_composition_eval(
-    composition: dict,
+def _run_single_config(
+    composition_name: str,
+    config: dict,
+    fixture_content: str,
+    scaffold_spec: dict,
+    rubric_names: list[str],
+    expected_behaviors: list[str],
+    assertions: list[str],
     repo_root: Path,
     judge: DeepEvalBaseLLM,
-    n_trials: int = 1,
+    n_trials: int,
 ) -> CompositionResult:
-    """Run one composition: execute the step chain and score the final output.
-
-    For each trial:
-    1. Create an isolated git worktree with scaffold files.
-    2. Execute the step chain.
-    3. Score the final step output with rubric metrics.
-
-    Args:
-        composition: A composition dict from the config's "compositions" list.
-            Required keys: "name", "fixture_key", "steps", "rubrics".
-            Optional: "expected_behaviors" (list[str]).
-        repo_root: Repository root.
-        judge: DeepEvalBaseLLM for scoring.
-        n_trials: Number of trial runs (scores are averaged).
-
-    Returns:
-        CompositionResult with averaged scores and step results from the last trial.
-    """
+    """Run one config's chain for all trials and return averaged CompositionResult."""
     from deepeval.test_case import LLMTestCase
 
-    name: str = composition["name"]
-    fixture_key: str = composition["fixture_key"]
-    rubric_names: list[str] = composition["rubrics"]
-    steps: list[dict] = composition["steps"]
-    expected_behaviors: list[str] = composition.get("expected_behaviors", [])
-
-    fixture_content = load_composition_fixture(fixture_key, repo_root)
-
-    # Parse YAML frontmatter for scaffold spec.
-    scaffold_spec: dict = {}
-    lines = fixture_content.split("\n")
-    if lines and _FRONTMATTER_RE.match(lines[0]):
-        for i in range(1, len(lines)):
-            if _FRONTMATTER_RE.match(lines[i]):
-                frontmatter_text = "\n".join(lines[1:i])
-                scaffold_spec = yaml.safe_load(frontmatter_text) or {}
-                scaffold_spec = scaffold_spec.get("scaffold", {})
-                break
-
+    config_name: str = config["name"]
+    steps: list[dict] = config["steps"]
     context_preamble = _build_context_preamble(repo_root)
-
-    # Prune stale worktrees before creating new ones.
-    subprocess.run(
-        ["git", "worktree", "prune"],
-        cwd=repo_root,
-        capture_output=True,
-    )
 
     trial_scores: list[dict[str, float]] = []
     last_step_results: list[ChainStepResult] = []
 
     for trial_idx in range(n_trials):
-        trial_root = repo_root / ".skill-eval-worktrees" / f"{name}-trial-{trial_idx}"
+        worktree_name = f"{composition_name}-{config_name}-trial-{trial_idx}"
+        trial_root = repo_root / ".skill-eval-worktrees" / worktree_name
         trial_root.parent.mkdir(parents=True, exist_ok=True)
 
         try:
@@ -1358,15 +1315,21 @@ def run_composition_eval(
             try:
                 step_results = execute_chain(
                     steps,
-                    repo_root,
+                    trial_root,
                     context_preamble,
                     initial_captures={"fixture": fixture_content},
                 )
                 last_step_results = step_results
             except Exception as exc:
-                logger.warning("Chain execution failed for %r trial %d: %s", name, trial_idx, exc)
+                logger.warning(
+                    "Chain execution failed for %r config %r trial %d: %s",
+                    composition_name,
+                    config_name,
+                    trial_idx,
+                    exc,
+                )
                 return CompositionResult(
-                    config_name=name,
+                    config_name=config_name,
                     step_results=[],
                     final_scores={},
                     trial_scores=None,
@@ -1374,7 +1337,7 @@ def run_composition_eval(
                 )
 
             final_output = step_results[-1].skill_output if step_results else ""
-            final_prompt = steps[-1].get("prompt", "") if steps else ""
+            final_prompt = steps[-1].get("prompt_template", "") if steps else ""
 
             sanitized_expected = []
             for e in expected_behaviors:
@@ -1391,6 +1354,9 @@ def run_composition_eval(
             )
 
             metrics = build_metrics(rubric_names, judge) if rubric_names else []
+            if assertions:
+                metrics.append(build_assertion_metrics(assertions))
+
             tc_scores: dict[str, float] = {}
             for metric in metrics:
                 try:
@@ -1408,7 +1374,6 @@ def run_composition_eval(
                 capture_output=True,
             )
 
-    # Average scores across trials.
     all_metric_names: set[str] = set()
     for ts in trial_scores:
         all_metric_names.update(ts.keys())
@@ -1419,77 +1384,171 @@ def run_composition_eval(
         final_scores[metric_name] = sum(vals) / len(vals) if vals else 0.0
 
     return CompositionResult(
-        config_name=name,
+        config_name=config_name,
         step_results=last_step_results,
         final_scores=final_scores,
         trial_scores=trial_scores,
     )
 
 
-def compare_composition_results(
-    current: CompositionResult,
-    baseline: CompositionResult,
-    tolerance: float = 0.15,
-) -> tuple[bool, str]:
-    """Compare a composition result against a baseline.
+def run_composition_eval(
+    composition: dict,
+    repo_root: Path,
+    judge: DeepEvalBaseLLM,
+    n_trials: int = 1,
+) -> dict[str, CompositionResult]:
+    """Run all configs of a composition and return results keyed by config name.
+
+    For each config in composition["configs"]:
+      For each trial 0..n_trials:
+        1. Create an isolated git worktree with scaffold files.
+        2. Execute the config's step chain in the worktree.
+        3. Score the final step output with rubric metrics.
+      Average scores across trials, build CompositionResult.
 
     Args:
-        current: The current eval's CompositionResult.
-        baseline: The baseline CompositionResult to compare against.
+        composition: A composition dict from the config's "compositions" list.
+            Required keys: "name", "fixture", "rubrics", "configs".
+            Optional: "expected_behaviors" (list[str]), "assertions" (list[str]).
+        repo_root: Repository root.
+        judge: DeepEvalBaseLLM for scoring.
+        n_trials: Number of trial runs per config (scores are averaged).
+
+    Returns:
+        dict mapping config name -> CompositionResult.
+    """
+    name: str = composition["name"]
+    fixture_key: str = composition["fixture"]
+    rubric_names: list[str] = composition["rubrics"]
+    configs: list[dict] = composition["configs"]
+    expected_behaviors: list[str] = composition.get("expected_behaviors", [])
+    assertions: list[str] = composition.get("assertions", [])
+
+    fixture_content = load_composition_fixture(fixture_key, repo_root)
+
+    # Parse YAML frontmatter for scaffold spec.
+    scaffold_spec: dict = {}
+    lines = fixture_content.split("\n")
+    if lines and _FRONTMATTER_RE.match(lines[0]):
+        for i in range(1, len(lines)):
+            if _FRONTMATTER_RE.match(lines[i]):
+                frontmatter_text = "\n".join(lines[1:i])
+                scaffold_spec = yaml.safe_load(frontmatter_text) or {}
+                scaffold_spec = scaffold_spec.get("scaffold", {})
+                break
+
+    # Prune stale worktrees before creating new ones.
+    subprocess.run(
+        ["git", "worktree", "prune"],
+        cwd=repo_root,
+        capture_output=True,
+    )
+
+    results: dict[str, CompositionResult] = {}
+    for config in configs:
+        config_name = config["name"]
+        results[config_name] = _run_single_config(
+            composition_name=name,
+            config=config,
+            fixture_content=fixture_content,
+            scaffold_spec=scaffold_spec,
+            rubric_names=rubric_names,
+            expected_behaviors=expected_behaviors,
+            assertions=assertions,
+            repo_root=repo_root,
+            judge=judge,
+            n_trials=n_trials,
+        )
+
+    return results
+
+
+def compare_composition_results(
+    results: dict[str, CompositionResult],
+    baseline_config: str,
+    tolerance: float = 0.15,
+) -> dict:
+    """Compare each non-baseline config against the baseline config.
+
+    Args:
+        results: Dict mapping config name -> CompositionResult (from run_composition_eval).
+        baseline_config: Config name to use as the comparison baseline.
         tolerance: Maximum allowed score drop before flagging degradation.
 
     Returns:
-        Tuple of (degradation_detected: bool, report: str).
-        degradation_detected is True when any metric drops more than tolerance.
+        Dict with keys:
+          "degradation_detected" (bool): True if any config shows degradation.
+          "reports" (dict[str, str]): Per-config comparison report strings.
     """
-    name = current.config_name
+    baseline = results.get(baseline_config)
+    if baseline is None:
+        return {
+            "degradation_detected": True,
+            "reports": {
+                baseline_config: f"Baseline config {baseline_config!r} not found in results"
+            },
+        }
 
-    if current.infra_error:
-        return True, f"{name}: INFRA ERROR — chain execution failed"
+    reports: dict[str, str] = {}
+    any_degradation = False
 
-    if baseline.infra_error:
-        return False, f"{name}: baseline had infra error — treating as pass"
-
-    current_scores = current.final_scores
-    baseline_scores = baseline.final_scores
-
-    if not baseline_scores:
-        return False, f"{name}: no baseline scores — treating as pass"
-
-    regressions: list[str] = []
-    deltas: dict[str, float] = {}
-
-    for metric, base_val in baseline_scores.items():
-        curr_val = current_scores.get(metric)
-        if curr_val is None:
-            regressions.append(f"  {metric}: missing from current (baseline={base_val:.3f})")
+    for config_name, result in results.items():
+        if config_name == baseline_config:
             continue
-        delta = curr_val - base_val
-        deltas[metric] = delta
-        drop = base_val - curr_val
-        if drop > tolerance:
-            regressions.append(
-                f"  {metric}: {curr_val:.3f} vs baseline {base_val:.3f}"
-                f" (drop={drop:.3f} > tolerance={tolerance:.3f})"
+
+        name = config_name
+
+        if result.infra_error:
+            reports[name] = f"{name}: INFRA ERROR — chain execution failed"
+            any_degradation = True
+            continue
+
+        if baseline.infra_error:
+            reports[name] = f"{name}: baseline had infra error — treating as pass"
+            continue
+
+        current_scores = result.final_scores
+        baseline_scores = baseline.final_scores
+
+        if not baseline_scores:
+            reports[name] = f"{name}: no baseline scores — treating as pass"
+            continue
+
+        regressions: list[str] = []
+
+        for metric, base_val in baseline_scores.items():
+            curr_val = current_scores.get(metric)
+            if curr_val is None:
+                regressions.append(f"  {metric}: missing from current (baseline={base_val:.3f})")
+                continue
+            drop = base_val - curr_val
+            if drop > tolerance:
+                regressions.append(
+                    f"  {metric}: {curr_val:.3f} vs baseline {base_val:.3f}"
+                    f" (drop={drop:.3f} > tolerance={tolerance:.3f})"
+                )
+
+        degradation_detected = len(regressions) > 0
+        if degradation_detected:
+            any_degradation = True
+
+        all_metrics = sorted(set(list(current_scores.keys()) + list(baseline_scores.keys())))
+        header = f"{'Metric':<30} {'Current':>8} {'Baseline':>8} {'Delta':>8}"
+        separator = "-" * len(header)
+        table_lines = [f"\n{name} (vs {baseline_config})", header, separator]
+        for metric in all_metrics:
+            curr_val = current_scores.get(metric, 0.0)
+            base_val = baseline_scores.get(metric, 0.0)
+            delta = curr_val - base_val
+            flag = " !" if delta < -tolerance else ""
+            table_lines.append(
+                f"  {metric:<28} {curr_val:>8.3f} {base_val:>8.3f} {delta:>+8.3f}{flag}"
             )
 
-    degradation_detected = len(regressions) > 0
+        status_line = f"\nStatus: {'DEGRADATION DETECTED' if degradation_detected else 'PASS'}"
+        if regressions:
+            status_line += "\n" + "\n".join(regressions)
 
-    # Build ASCII table.
-    all_metrics = sorted(set(list(current_scores.keys()) + list(baseline_scores.keys())))
-    header = f"{'Metric':<30} {'Current':>8} {'Baseline':>8} {'Delta':>8}"
-    separator = "-" * len(header)
-    table_lines = [f"\n{name}", header, separator]
-    for metric in all_metrics:
-        curr_val = current_scores.get(metric, 0.0)
-        base_val = baseline_scores.get(metric, 0.0)
-        delta = curr_val - base_val
-        flag = " !" if delta < -tolerance else ""
-        table_lines.append(f"  {metric:<28} {curr_val:>8.3f} {base_val:>8.3f} {delta:>+8.3f}{flag}")
+        reports[name] = "\n".join(table_lines) + status_line
 
-    status_line = f"\nStatus: {'DEGRADATION DETECTED' if degradation_detected else 'PASS'}"
-    if regressions:
-        status_line += "\n" + "\n".join(regressions)
-
-    report = "\n".join(table_lines) + status_line
-    return degradation_detected, report
+    return {"degradation_detected": any_degradation, "reports": reports}

--- a/skill-eval/test_cases/composition.json
+++ b/skill-eval/test_cases/composition.json
@@ -459,6 +459,94 @@
           ]
         }
       ]
+    },
+    {
+      "name": "swarm-quality-gate-degradation",
+      "description": "Tests whether repeated quality-gate cycles after swarm degrade review rigor (rubber-stamping)",
+      "rubrics": ["phase_completion"],
+      "fixture": "composition/terse-auth-plan",
+      "configs": [
+        {
+          "name": "swarm-only",
+          "steps": [
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{fixture}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
+        },
+        {
+          "name": "swarm-1-gate",
+          "steps": [
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{fixture}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Run quality gate on this implementation:\n{swarm_output}",
+              "capture_as": "gate_1",
+              "timeout_seconds": 1200
+            }
+          ]
+        },
+        {
+          "name": "swarm-2-gates",
+          "steps": [
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{fixture}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Run quality gate on this implementation:\n{swarm_output}",
+              "capture_as": "gate_1",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Run quality gate again on this implementation:\n{swarm_output}\n\nPrior gate results:\n{gate_1}",
+              "capture_as": "gate_2",
+              "timeout_seconds": 1200
+            }
+          ]
+        },
+        {
+          "name": "swarm-3-gates",
+          "steps": [
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{fixture}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Run quality gate on this implementation:\n{swarm_output}",
+              "capture_as": "gate_1",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Run quality gate again:\n{swarm_output}\n\nPrior gate:\n{gate_1}",
+              "capture_as": "gate_2",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Run quality gate a third time:\n{swarm_output}\n\nPrior gates:\n{gate_1}\n{gate_2}",
+              "capture_as": "gate_3",
+              "timeout_seconds": 1200
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/skill-eval/test_cases/composition.json
+++ b/skill-eval/test_cases/composition.json
@@ -74,57 +74,129 @@
     },
     {
       "name": "pr-review-fix-gate-degradation",
-      "description": "Tests whether repeated pr-review/fix cycles before gate reduces finding completeness",
+      "description": "Tests whether fix quality degrades and gate rubber-stamps after multiple pr-review/fix/gate cycles",
       "rubrics": ["phase_completion"],
       "fixture": "composition/planted-issues-diff",
       "configs": [
         {
-          "name": "1-review-cycle",
+          "name": "1-cycle",
           "steps": [
             {
               "skill": "pr-review",
               "prompt_template": "Review this diff for issues:\n{fixture}",
               "capture_as": "review_output",
+              "timeout_seconds": 900
+            },
+            {
+              "skill": "fix",
+              "prompt_template": "Fix the issues found in this review:\n{review_output}\n\nOriginal diff:\n{fixture}",
+              "capture_as": "fix_output",
+              "timeout_seconds": 600
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Run quality gate on these changes:\n{fix_output}",
+              "capture_as": "gate_output",
               "timeout_seconds": 1200
             }
           ]
         },
         {
-          "name": "2-review-cycles",
+          "name": "2-cycles",
           "steps": [
             {
               "skill": "pr-review",
               "prompt_template": "Review this diff for issues:\n{fixture}",
               "capture_as": "review_1",
+              "timeout_seconds": 900
+            },
+            {
+              "skill": "fix",
+              "prompt_template": "Fix the issues found in this review:\n{review_1}\n\nOriginal diff:\n{fixture}",
+              "capture_as": "fix_1",
+              "timeout_seconds": 600
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Run quality gate on these changes:\n{fix_1}",
+              "capture_as": "gate_1",
               "timeout_seconds": 1200
             },
             {
               "skill": "pr-review",
-              "prompt_template": "Review this diff again (prior review attached):\n{fixture}\n\nPrior review:\n{review_1}",
-              "capture_as": "review_output",
-              "timeout_seconds": 1200
-            }
-          ]
-        },
-        {
-          "name": "3-review-cycles",
-          "steps": [
-            {
-              "skill": "pr-review",
-              "prompt_template": "Review this diff for issues:\n{fixture}",
-              "capture_as": "review_1",
-              "timeout_seconds": 1200
-            },
-            {
-              "skill": "pr-review",
-              "prompt_template": "Review this diff again (prior review attached):\n{fixture}\n\nPrior review:\n{review_1}",
+              "prompt_template": "Review the fixed code again:\n{fix_1}\n\nPrior gate feedback:\n{gate_1}",
               "capture_as": "review_2",
+              "timeout_seconds": 900
+            },
+            {
+              "skill": "fix",
+              "prompt_template": "Fix the issues from the second review:\n{review_2}\n\nPrior fix:\n{fix_1}",
+              "capture_as": "fix_2",
+              "timeout_seconds": 600
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Run quality gate on the updated changes:\n{fix_2}",
+              "capture_as": "gate_output",
+              "timeout_seconds": 1200
+            }
+          ]
+        },
+        {
+          "name": "3-cycles",
+          "steps": [
+            {
+              "skill": "pr-review",
+              "prompt_template": "Review this diff for issues:\n{fixture}",
+              "capture_as": "review_1",
+              "timeout_seconds": 900
+            },
+            {
+              "skill": "fix",
+              "prompt_template": "Fix the issues:\n{review_1}\n\nOriginal diff:\n{fixture}",
+              "capture_as": "fix_1",
+              "timeout_seconds": 600
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Quality gate:\n{fix_1}",
+              "capture_as": "gate_1",
               "timeout_seconds": 1200
             },
             {
               "skill": "pr-review",
-              "prompt_template": "Review this diff a third time (prior reviews attached):\n{fixture}\n\nPrior reviews:\n{review_1}\n{review_2}",
-              "capture_as": "review_output",
+              "prompt_template": "Review fixed code:\n{fix_1}\n\nGate feedback:\n{gate_1}",
+              "capture_as": "review_2",
+              "timeout_seconds": 900
+            },
+            {
+              "skill": "fix",
+              "prompt_template": "Fix issues:\n{review_2}\n\nPrior fix:\n{fix_1}",
+              "capture_as": "fix_2",
+              "timeout_seconds": 600
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Quality gate:\n{fix_2}",
+              "capture_as": "gate_2",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "pr-review",
+              "prompt_template": "Final review:\n{fix_2}\n\nGate feedback:\n{gate_2}",
+              "capture_as": "review_3",
+              "timeout_seconds": 900
+            },
+            {
+              "skill": "fix",
+              "prompt_template": "Final fix:\n{review_3}\n\nPrior fix:\n{fix_2}",
+              "capture_as": "fix_3",
+              "timeout_seconds": 600
+            },
+            {
+              "skill": "quality-gate",
+              "prompt_template": "Final quality gate:\n{fix_3}",
+              "capture_as": "gate_output",
               "timeout_seconds": 1200
             }
           ]

--- a/skill-eval/test_cases/composition.json
+++ b/skill-eval/test_cases/composition.json
@@ -1,0 +1,88 @@
+{
+  "compositions": [
+    {
+      "name": "terse-auth-plan-judgment",
+      "fixture_key": "composition/terse-auth-plan",
+      "rubrics": ["implementer_judgment"],
+      "expected_behaviors": [
+        "Chooses a JWT library (e.g. PyJWT) rather than manual token parsing",
+        "Uses secrets.token_urlsafe() or equivalent secure random generation",
+        "Applies decorator pattern or equivalent abstraction for role checking",
+        "Does not mechanically follow a step-by-step checklist"
+      ],
+      "steps": [
+        {
+          "skill": "incremental-planning",
+          "prompt": "{fixture}",
+          "capture_as": "plan_output"
+        },
+        {
+          "skill": "fix",
+          "prompt": "Implement the following plan:\n\n{plan_output}",
+          "capture_as": "implementation"
+        }
+      ]
+    },
+    {
+      "name": "overspecified-auth-plan-judgment",
+      "fixture_key": "composition/overspecified-auth-plan",
+      "rubrics": ["implementer_judgment"],
+      "expected_behaviors": [
+        "Does not use hashlib.sha256 for token generation — uses secrets or PyJWT",
+        "Does not create separate middleware files per role (avoids over-engineering)",
+        "Does not assert exact token hash strings in tests (avoids brittle assertions)",
+        "Shows independent judgment despite over-specified plan steps"
+      ],
+      "steps": [
+        {
+          "skill": "fix",
+          "prompt": "Implement the following plan:\n\n{fixture}",
+          "capture_as": "implementation"
+        }
+      ]
+    },
+    {
+      "name": "terse-crud-plan-judgment",
+      "fixture_key": "composition/terse-crud-plan",
+      "rubrics": ["implementer_judgment"],
+      "expected_behaviors": [
+        "Uses SQLAlchemy ORM queries, not raw SQL",
+        "Uses cursor-based or keyset pagination rather than OFFSET for scalability",
+        "Uses a schema validation library or structured approach instead of if/elif chains",
+        "Makes purposeful implementation decisions not dictated by the plan"
+      ],
+      "steps": [
+        {
+          "skill": "incremental-planning",
+          "prompt": "{fixture}",
+          "capture_as": "plan_output"
+        },
+        {
+          "skill": "fix",
+          "prompt": "Implement the following plan:\n\n{plan_output}",
+          "capture_as": "implementation"
+        }
+      ]
+    },
+    {
+      "name": "planted-issues-detection",
+      "fixture_key": "composition/planted-issues-diff",
+      "rubrics": ["finding_completeness", "severity_accuracy"],
+      "expected_behaviors": [
+        "Identifies SQL injection vulnerability (string interpolation in query)",
+        "Identifies missing authorization check on delete endpoint",
+        "Identifies brittle test assertion (exact error message string comparison)",
+        "Rates SQL injection as high severity",
+        "Rates missing auth check as high severity",
+        "Rates brittle assertion as low/medium severity"
+      ],
+      "steps": [
+        {
+          "skill": "quality-gate",
+          "prompt": "Review this implementation diff for issues:\n\n{fixture}",
+          "capture_as": "review_output"
+        }
+      ]
+    }
+  ]
+}

--- a/skill-eval/test_cases/composition.json
+++ b/skill-eval/test_cases/composition.json
@@ -77,6 +77,16 @@
       "description": "Tests whether fix quality degrades and gate rubber-stamps after multiple pr-review/fix/gate cycles",
       "rubrics": ["phase_completion"],
       "fixture": "composition/planted-issues-diff",
+      "expected_behaviors": [
+        "Identifies SQL injection via string interpolation in get_widget query",
+        "Identifies missing authorization check on delete_widget endpoint",
+        "Identifies brittle exact-string assertion in test_get_missing_widget",
+        "Fixes SQL injection with parameterized queries or ORM methods"
+      ],
+      "assertions": [
+        "not-contains: f\"SELECT * FROM widgets WHERE name='{name}'\"",
+        "contains: injection"
+      ],
       "configs": [
         {
           "name": "1-cycle",
@@ -208,6 +218,10 @@
       "description": "Tests whether deep-research before incremental-planning degrades plan quality",
       "rubrics": ["phase_completion"],
       "fixture": "composition/terse-auth-plan",
+      "assertions": [
+        "contains: JWT",
+        "contains: token"
+      ],
       "configs": [
         {
           "name": "baseline-no-research",
@@ -279,6 +293,7 @@
         "Applies decorator pattern or equivalent abstraction for role checking",
         "Does not mechanically follow a step-by-step checklist"
       ],
+      "assertions": ["not-contains: hashlib.sha256"],
       "configs": [
         {
           "name": "baseline-swarm-only",
@@ -387,6 +402,7 @@
         "Uses a schema validation library instead of if/elif chains",
         "Makes purposeful implementation decisions not dictated by the plan"
       ],
+      "assertions": ["not-contains: db.engine.execute"],
       "configs": [
         {
           "name": "baseline-no-review",
@@ -429,6 +445,7 @@
         "Does not use if/elif chains for input validation",
         "Shows independent judgment despite over-specified plan steps"
       ],
+      "assertions": ["not-contains: db.engine.execute"],
       "configs": [
         {
           "name": "baseline-no-review",
@@ -465,6 +482,10 @@
       "description": "Tests whether repeated quality-gate cycles after swarm degrade review rigor (rubber-stamping)",
       "rubrics": ["phase_completion"],
       "fixture": "composition/terse-auth-plan",
+      "assertions": [
+        "contains: JWT",
+        "not-contains: hashlib.sha256"
+      ],
       "configs": [
         {
           "name": "swarm-only",

--- a/skill-eval/test_cases/composition.json
+++ b/skill-eval/test_cases/composition.json
@@ -1,86 +1,263 @@
 {
   "compositions": [
     {
-      "name": "terse-auth-plan-judgment",
-      "fixture_key": "composition/terse-auth-plan",
-      "rubrics": ["implementer_judgment"],
+      "name": "plan-review-swarm-degradation",
+      "description": "Tests whether repeated plan-review before swarm degrades implementer judgment",
+      "rubrics": ["implementer_judgment", "phase_completion"],
+      "fixture": "composition/terse-auth-plan",
       "expected_behaviors": [
         "Chooses a JWT library (e.g. PyJWT) rather than manual token parsing",
         "Uses secrets.token_urlsafe() or equivalent secure random generation",
         "Applies decorator pattern or equivalent abstraction for role checking",
         "Does not mechanically follow a step-by-step checklist"
       ],
-      "steps": [
+      "assertions": ["not-contains: hashlib.sha256"],
+      "configs": [
         {
-          "skill": "incremental-planning",
-          "prompt": "{fixture}",
-          "capture_as": "plan_output"
+          "name": "baseline-no-review",
+          "steps": [
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{fixture}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
         },
         {
-          "skill": "fix",
-          "prompt": "Implement the following plan:\n\n{plan_output}",
-          "capture_as": "implementation"
-        }
-      ]
-    },
-    {
-      "name": "overspecified-auth-plan-judgment",
-      "fixture_key": "composition/overspecified-auth-plan",
-      "rubrics": ["implementer_judgment"],
-      "expected_behaviors": [
-        "Does not use hashlib.sha256 for token generation — uses secrets or PyJWT",
-        "Does not create separate middleware files per role (avoids over-engineering)",
-        "Does not assert exact token hash strings in tests (avoids brittle assertions)",
-        "Shows independent judgment despite over-specified plan steps"
-      ],
-      "steps": [
-        {
-          "skill": "fix",
-          "prompt": "Implement the following plan:\n\n{fixture}",
-          "capture_as": "implementation"
-        }
-      ]
-    },
-    {
-      "name": "terse-crud-plan-judgment",
-      "fixture_key": "composition/terse-crud-plan",
-      "rubrics": ["implementer_judgment"],
-      "expected_behaviors": [
-        "Uses SQLAlchemy ORM queries, not raw SQL",
-        "Uses cursor-based or keyset pagination rather than OFFSET for scalability",
-        "Uses a schema validation library or structured approach instead of if/elif chains",
-        "Makes purposeful implementation decisions not dictated by the plan"
-      ],
-      "steps": [
-        {
-          "skill": "incremental-planning",
-          "prompt": "{fixture}",
-          "capture_as": "plan_output"
+          "name": "1-review-cycle",
+          "steps": [
+            {
+              "skill": "plan-review",
+              "prompt_template": "Review this plan:\n{fixture}",
+              "capture_as": "review_output",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan (incorporating review feedback):\n{fixture}\n\nReview feedback:\n{review_output}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
         },
         {
-          "skill": "fix",
-          "prompt": "Implement the following plan:\n\n{plan_output}",
-          "capture_as": "implementation"
+          "name": "3-review-cycles",
+          "steps": [
+            {
+              "skill": "plan-review",
+              "prompt_template": "Review this plan:\n{fixture}",
+              "capture_as": "review_1",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "plan-review",
+              "prompt_template": "Review this plan (updated after prior feedback):\n{fixture}\n\nPrior review:\n{review_1}",
+              "capture_as": "review_2",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "plan-review",
+              "prompt_template": "Review this plan (updated after two rounds of feedback):\n{fixture}\n\nPrior reviews:\n{review_1}\n{review_2}",
+              "capture_as": "review_3",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan (incorporating all review feedback):\n{fixture}\n\nReview feedback:\n{review_3}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
         }
       ]
     },
     {
-      "name": "planted-issues-detection",
-      "fixture_key": "composition/planted-issues-diff",
-      "rubrics": ["finding_completeness", "severity_accuracy"],
-      "expected_behaviors": [
-        "Identifies SQL injection vulnerability (string interpolation in query)",
-        "Identifies missing authorization check on delete endpoint",
-        "Identifies brittle test assertion (exact error message string comparison)",
-        "Rates SQL injection as high severity",
-        "Rates missing auth check as high severity",
-        "Rates brittle assertion as low/medium severity"
-      ],
-      "steps": [
+      "name": "pr-review-fix-gate-degradation",
+      "description": "Tests whether repeated pr-review/fix cycles before gate reduces finding completeness",
+      "rubrics": ["phase_completion"],
+      "fixture": "composition/planted-issues-diff",
+      "configs": [
         {
-          "skill": "quality-gate",
-          "prompt": "Review this implementation diff for issues:\n\n{fixture}",
-          "capture_as": "review_output"
+          "name": "1-review-cycle",
+          "steps": [
+            {
+              "skill": "pr-review",
+              "prompt_template": "Review this diff for issues:\n{fixture}",
+              "capture_as": "review_output",
+              "timeout_seconds": 1200
+            }
+          ]
+        },
+        {
+          "name": "2-review-cycles",
+          "steps": [
+            {
+              "skill": "pr-review",
+              "prompt_template": "Review this diff for issues:\n{fixture}",
+              "capture_as": "review_1",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "pr-review",
+              "prompt_template": "Review this diff again (prior review attached):\n{fixture}\n\nPrior review:\n{review_1}",
+              "capture_as": "review_output",
+              "timeout_seconds": 1200
+            }
+          ]
+        },
+        {
+          "name": "3-review-cycles",
+          "steps": [
+            {
+              "skill": "pr-review",
+              "prompt_template": "Review this diff for issues:\n{fixture}",
+              "capture_as": "review_1",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "pr-review",
+              "prompt_template": "Review this diff again (prior review attached):\n{fixture}\n\nPrior review:\n{review_1}",
+              "capture_as": "review_2",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "pr-review",
+              "prompt_template": "Review this diff a third time (prior reviews attached):\n{fixture}\n\nPrior reviews:\n{review_1}\n{review_2}",
+              "capture_as": "review_output",
+              "timeout_seconds": 1200
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "deep-research-planning-degradation",
+      "description": "Tests whether deep-research before incremental-planning degrades plan quality",
+      "rubrics": ["phase_completion"],
+      "fixture": "composition/terse-auth-plan",
+      "configs": [
+        {
+          "name": "baseline-no-research",
+          "steps": [
+            {
+              "skill": "incremental-planning",
+              "prompt_template": "{fixture}",
+              "capture_as": "plan_output",
+              "timeout_seconds": 1200
+            }
+          ]
+        },
+        {
+          "name": "1-research-cycle",
+          "steps": [
+            {
+              "skill": "deep-research",
+              "prompt_template": "Research best practices for:\n{fixture}",
+              "capture_as": "research_output",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "incremental-planning",
+              "prompt_template": "{fixture}\n\nResearch findings:\n{research_output}",
+              "capture_as": "plan_output",
+              "timeout_seconds": 1200
+            }
+          ]
+        },
+        {
+          "name": "3-research-cycles",
+          "steps": [
+            {
+              "skill": "deep-research",
+              "prompt_template": "Research best practices for:\n{fixture}",
+              "capture_as": "research_1",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "deep-research",
+              "prompt_template": "Research implementation patterns for:\n{fixture}\n\nPrior research:\n{research_1}",
+              "capture_as": "research_2",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "deep-research",
+              "prompt_template": "Research security considerations for:\n{fixture}\n\nPrior research:\n{research_1}\n{research_2}",
+              "capture_as": "research_3",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "incremental-planning",
+              "prompt_template": "{fixture}\n\nResearch findings:\n{research_3}",
+              "capture_as": "plan_output",
+              "timeout_seconds": 1200
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "planning-swarm-comparison",
+      "description": "Compares swarm with vs without incremental-planning upfront",
+      "rubrics": ["implementer_judgment", "phase_completion"],
+      "fixture": "composition/terse-auth-plan",
+      "expected_behaviors": [
+        "Chooses a JWT library (e.g. PyJWT) rather than manual token parsing",
+        "Uses secrets.token_urlsafe() or equivalent secure random generation",
+        "Applies decorator pattern or equivalent abstraction for role checking",
+        "Does not mechanically follow a step-by-step checklist"
+      ],
+      "configs": [
+        {
+          "name": "baseline-swarm-only",
+          "steps": [
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this:\n{fixture}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
+        },
+        {
+          "name": "planning-then-swarm",
+          "steps": [
+            {
+              "skill": "incremental-planning",
+              "prompt_template": "{fixture}",
+              "capture_as": "plan_output",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{plan_output}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
+        },
+        {
+          "name": "research-planning-swarm",
+          "steps": [
+            {
+              "skill": "deep-research",
+              "prompt_template": "Research best practices for:\n{fixture}",
+              "capture_as": "research_output",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "incremental-planning",
+              "prompt_template": "{fixture}\n\nResearch findings:\n{research_output}",
+              "capture_as": "plan_output",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{plan_output}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
         }
       ]
     }

--- a/skill-eval/test_cases/composition.json
+++ b/skill-eval/test_cases/composition.json
@@ -260,6 +260,133 @@
           ]
         }
       ]
+    },
+    {
+      "name": "overspecified-auth-judgment",
+      "description": "Mirror of plan-review-swarm-degradation with overspecified fixture — compare scores against terse variant to measure specification-level effect",
+      "rubrics": ["implementer_judgment", "phase_completion"],
+      "fixture": "composition/overspecified-auth-plan",
+      "expected_behaviors": [
+        "Does not use hashlib.sha256 for token generation",
+        "Does not create separate middleware files per role",
+        "Does not assert exact token hash strings in tests",
+        "Shows independent judgment despite over-specified plan steps"
+      ],
+      "assertions": ["not-contains: hashlib.sha256"],
+      "configs": [
+        {
+          "name": "baseline-no-review",
+          "steps": [
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{fixture}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
+        },
+        {
+          "name": "1-review-cycle",
+          "steps": [
+            {
+              "skill": "plan-review",
+              "prompt_template": "Review this plan:\n{fixture}",
+              "capture_as": "review_output",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan (incorporating review feedback):\n{fixture}\n\nReview feedback:\n{review_output}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "terse-crud-judgment",
+      "description": "CRUD variant — tests implementer judgment on terse goal-oriented CRUD plan",
+      "rubrics": ["implementer_judgment", "phase_completion"],
+      "fixture": "composition/terse-crud-plan",
+      "expected_behaviors": [
+        "Uses SQLAlchemy ORM queries, not raw SQL",
+        "Uses cursor-based or keyset pagination rather than OFFSET",
+        "Uses a schema validation library instead of if/elif chains",
+        "Makes purposeful implementation decisions not dictated by the plan"
+      ],
+      "configs": [
+        {
+          "name": "baseline-no-review",
+          "steps": [
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{fixture}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
+        },
+        {
+          "name": "1-review-cycle",
+          "steps": [
+            {
+              "skill": "plan-review",
+              "prompt_template": "Review this plan:\n{fixture}",
+              "capture_as": "review_output",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan (incorporating review feedback):\n{fixture}\n\nReview feedback:\n{review_output}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "overspecified-crud-judgment",
+      "description": "Mirror of terse-crud with overspecified fixture — compare scores to measure specification-level effect",
+      "rubrics": ["implementer_judgment", "phase_completion"],
+      "fixture": "composition/overspecified-crud-plan",
+      "expected_behaviors": [
+        "Does not use raw SQL queries when SQLAlchemy ORM is available",
+        "Does not use offset-based pagination for large datasets",
+        "Does not use if/elif chains for input validation",
+        "Shows independent judgment despite over-specified plan steps"
+      ],
+      "configs": [
+        {
+          "name": "baseline-no-review",
+          "steps": [
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan:\n{fixture}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
+        },
+        {
+          "name": "1-review-cycle",
+          "steps": [
+            {
+              "skill": "plan-review",
+              "prompt_template": "Review this plan:\n{fixture}",
+              "capture_as": "review_output",
+              "timeout_seconds": 1200
+            },
+            {
+              "skill": "swarm",
+              "prompt_template": "Implement this plan (incorporating review feedback):\n{fixture}\n\nReview feedback:\n{review_output}",
+              "capture_as": "swarm_output",
+              "timeout_seconds": 3600
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/skill-eval/test_cases/composition.json
+++ b/skill-eval/test_cases/composition.json
@@ -163,31 +163,31 @@
             },
             {
               "skill": "fix",
-              "prompt_template": "Fix the issues:\n{review_1}\n\nOriginal diff:\n{fixture}",
+              "prompt_template": "Fix the issues found in this review:\n{review_1}\n\nOriginal diff:\n{fixture}",
               "capture_as": "fix_1",
               "timeout_seconds": 600
             },
             {
               "skill": "quality-gate",
-              "prompt_template": "Quality gate:\n{fix_1}",
+              "prompt_template": "Run quality gate on these changes:\n{fix_1}",
               "capture_as": "gate_1",
               "timeout_seconds": 1200
             },
             {
               "skill": "pr-review",
-              "prompt_template": "Review fixed code:\n{fix_1}\n\nGate feedback:\n{gate_1}",
+              "prompt_template": "Review the fixed code again:\n{fix_1}\n\nPrior gate feedback:\n{gate_1}",
               "capture_as": "review_2",
               "timeout_seconds": 900
             },
             {
               "skill": "fix",
-              "prompt_template": "Fix issues:\n{review_2}\n\nPrior fix:\n{fix_1}",
+              "prompt_template": "Fix the issues from the second review:\n{review_2}\n\nPrior fix:\n{fix_1}",
               "capture_as": "fix_2",
               "timeout_seconds": 600
             },
             {
               "skill": "quality-gate",
-              "prompt_template": "Quality gate:\n{fix_2}",
+              "prompt_template": "Run quality gate on the updated changes:\n{fix_2}",
               "capture_as": "gate_2",
               "timeout_seconds": 1200
             },
@@ -555,7 +555,7 @@
             },
             {
               "skill": "quality-gate",
-              "prompt_template": "Run quality gate again:\n{swarm_output}\n\nPrior gate:\n{gate_1}",
+              "prompt_template": "Run quality gate again on this implementation:\n{swarm_output}\n\nPrior gate results:\n{gate_1}",
               "capture_as": "gate_2",
               "timeout_seconds": 1200
             },

--- a/skill-eval/tests/test_composition.py
+++ b/skill-eval/tests/test_composition.py
@@ -62,6 +62,11 @@ def _mock_claude_proc(output: str = "step output") -> MagicMock:
     return proc
 
 
+def _step(skill: str = "quality-gate", prompt_template: str = "review this", **kwargs) -> dict:
+    """Build a minimal step dict with required fields."""
+    return {"skill": skill, "prompt_template": prompt_template, "timeout_seconds": 30, **kwargs}
+
+
 # ── Group 1: execute_chain ────────────────────────────────────────────────────
 
 
@@ -77,10 +82,9 @@ class TestExecuteChain:
             patch("skill_eval.runner.subprocess.run", return_value=_mock_claude_proc("hello")),
         ):
             results = execute_chain(
-                steps=[{"skill": "quality-gate", "prompt": "review this"}],
+                steps=[_step(prompt_template="review this")],
                 repo_root=repo,
                 context_preamble=None,
-                timeout_seconds=30,
             )
 
         assert len(results) == 1
@@ -108,12 +112,11 @@ class TestExecuteChain:
         ):
             results = execute_chain(
                 steps=[
-                    {"skill": "quality-gate", "prompt": "first", "capture_as": "step1"},
-                    {"skill": "quality-gate", "prompt": "second: {step1}"},
+                    _step(prompt_template="first", capture_as="step1"),
+                    _step(prompt_template="second: {step1}"),
                 ],
                 repo_root=repo,
                 context_preamble=None,
-                timeout_seconds=30,
             )
 
         assert len(results) == 2
@@ -139,11 +142,10 @@ class TestExecuteChain:
             patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
         ):
             execute_chain(
-                steps=[{"skill": "quality-gate", "prompt": "Review: {fixture}"}],
+                steps=[_step(prompt_template="Review: {fixture}")],
                 repo_root=repo,
                 context_preamble=None,
                 initial_captures={"fixture": "my fixture content"},
-                timeout_seconds=30,
             )
 
         assert "my fixture content" in captured_prompt[0]
@@ -170,12 +172,11 @@ class TestExecuteChain:
         ):
             execute_chain(
                 steps=[
-                    {"skill": "quality-gate", "prompt": "first step", "capture_as": "result"},
-                    {"skill": "quality-gate", "prompt": "use this: {result}"},
+                    _step(prompt_template="first step", capture_as="result"),
+                    _step(prompt_template="use this: {result}"),
                 ],
                 repo_root=repo,
                 context_preamble=None,
-                timeout_seconds=30,
             )
 
         # The second prompt should contain the XML-wrapped output.
@@ -189,10 +190,9 @@ class TestExecuteChain:
 
         with pytest.raises(ValueError, match="Invalid skill name"):
             execute_chain(
-                steps=[{"skill": "bad skill name!", "prompt": "test"}],
+                steps=[_step(skill="bad skill name!")],
                 repo_root=repo,
                 context_preamble=None,
-                timeout_seconds=30,
             )
 
     def test_unresolvable_skill_raises(self, tmp_path):
@@ -201,10 +201,9 @@ class TestExecuteChain:
 
         with pytest.raises(RuntimeError, match="Could not find skill directory"):
             execute_chain(
-                steps=[{"skill": "nonexistent-skill", "prompt": "test"}],
+                steps=[_step(skill="nonexistent-skill")],
                 repo_root=repo,
                 context_preamble=None,
-                timeout_seconds=30,
             )
 
     def test_stderr_secrets_sanitized(self, tmp_path, capsys):
@@ -222,10 +221,9 @@ class TestExecuteChain:
             patch("skill_eval.runner.logger") as mock_logger,
         ):
             execute_chain(
-                steps=[{"skill": "quality-gate", "prompt": "test"}],
+                steps=[_step()],
                 repo_root=repo,
                 context_preamble=None,
-                timeout_seconds=30,
             )
 
         # Verify the logged message doesn't contain the raw secret.
@@ -252,10 +250,9 @@ class TestExecuteChain:
             patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
         ):
             execute_chain(
-                steps=[{"skill": "quality-gate", "prompt": "test"}],
+                steps=[_step()],
                 repo_root=repo,
                 context_preamble="MY CLAUDE.MD CONTENT",
-                timeout_seconds=30,
             )
 
         assert "MY CLAUDE.MD CONTENT" in captured_inputs[0]
@@ -280,10 +277,9 @@ class TestExecuteChain:
             patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
         ):
             execute_chain(
-                steps=[{"skill": "quality-gate", "prompt": "test"}],
+                steps=[_step()],
                 repo_root=repo,
                 context_preamble=None,
-                timeout_seconds=30,
             )
 
         assert "CLAUDECODE" in captured_env[0]
@@ -309,16 +305,128 @@ class TestExecuteChain:
         ):
             results = execute_chain(
                 steps=[
-                    {"skill": "quality-gate", "prompt": "step 1"},
-                    {"skill": "quality-gate", "prompt": "step 2"},
-                    {"skill": "quality-gate", "prompt": "step 3"},
+                    _step(prompt_template="step 1"),
+                    _step(prompt_template="step 2"),
+                    _step(prompt_template="step 3"),
                 ],
                 repo_root=repo,
                 context_preamble=None,
-                timeout_seconds=30,
             )
 
         assert [r.skill_output for r in results] == ["output-1", "output-2", "output-3"]
+
+    def test_per_step_timeout_used(self, tmp_path):
+        """Each step's timeout_seconds is passed to subprocess.run."""
+        repo = _make_repo(tmp_path)
+
+        captured_timeouts: list[int] = []
+
+        def mock_run(*args, **kwargs):
+            captured_timeouts.append(kwargs.get("timeout"))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "done"
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[
+                    {"skill": "quality-gate", "prompt_template": "step 1", "timeout_seconds": 60},
+                    {"skill": "quality-gate", "prompt_template": "step 2", "timeout_seconds": 120},
+                ],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+        # subprocess.run is called twice per step (git worktree prune + actual claude).
+        # Filter only the claude invocations — those have timeout set.
+        assert 60 in captured_timeouts
+        assert 120 in captured_timeouts
+
+    def test_missing_timeout_raises_key_error(self, tmp_path):
+        """A step without timeout_seconds raises KeyError."""
+        repo = _make_repo(tmp_path)
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", return_value=_mock_claude_proc()),
+            pytest.raises(KeyError),
+        ):
+            execute_chain(
+                steps=[{"skill": "quality-gate", "prompt_template": "test"}],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+    def test_bare_flag_passed_when_set(self, tmp_path):
+        """step["bare"]=True passes --bare to the claude CLI."""
+        repo = _make_repo(tmp_path)
+
+        captured_cmds: list[list] = []
+
+        def mock_run(*args, **kwargs):
+            if args:
+                captured_cmds.append(args[0])
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "done"
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[_step(bare=True)],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+        claude_cmds = [c for c in captured_cmds if c and c[0] == "claude"]
+        assert any("--bare" in c for c in claude_cmds)
+
+    def test_bundle_passed_via_append_system_prompt(self, tmp_path):
+        """The skill bundle is passed via --append-system-prompt, not stdin."""
+        repo = _make_repo(tmp_path)
+
+        captured_cmds: list[list] = []
+        captured_inputs: list[str] = []
+
+        def mock_run(*args, **kwargs):
+            if args:
+                captured_cmds.append(list(args[0]))
+            captured_inputs.append(kwargs.get("input", ""))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "done"
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# MY BUNDLE"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[_step(prompt_template="do the task")],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+        claude_cmds = [c for c in captured_cmds if c and c[0] == "claude"]
+        assert claude_cmds, "No claude invocation found"
+        cmd = claude_cmds[0]
+        # Bundle must appear as value after --append-system-prompt.
+        assert "--append-system-prompt" in cmd
+        idx = cmd.index("--append-system-prompt")
+        assert cmd[idx + 1] == "# MY BUNDLE"
+        # stdin must not contain the bundle marker.
+        claude_input = captured_inputs[captured_cmds.index(cmd)]
+        assert "# MY BUNDLE" not in claude_input
 
 
 # ── Group 2: run_composition_eval ────────────────────────────────────────────
@@ -330,13 +438,18 @@ class TestRunCompositionEval:
     def _make_composition(self, fixture_key: str = "composition/terse") -> dict:
         return {
             "name": "test-composition",
-            "fixture_key": fixture_key,
+            "fixture": fixture_key,
             "rubrics": [],
-            "steps": [{"skill": "quality-gate", "prompt": "{fixture}"}],
+            "configs": [
+                {
+                    "name": "baseline",
+                    "steps": [_step(prompt_template="{fixture}")],
+                }
+            ],
         }
 
-    def test_returns_composition_result(self, tmp_path):
-        """run_composition_eval returns a CompositionResult."""
+    def test_returns_dict_of_composition_results(self, tmp_path):
+        """run_composition_eval returns a dict of CompositionResult."""
         repo = _make_repo(tmp_path)
         _make_fixture(repo, "composition/terse", "# Plan\nDo something.\n")
 
@@ -350,15 +463,17 @@ class TestRunCompositionEval:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             mock_chain.return_value = [ChainStepResult("quality-gate", "the output", None)]
 
-            result = run_composition_eval(
+            results = run_composition_eval(
                 self._make_composition(),
                 repo,
                 mock_judge,
                 n_trials=1,
             )
 
-        assert isinstance(result, CompositionResult)
-        assert result.config_name == "test-composition"
+        assert isinstance(results, dict)
+        assert "baseline" in results
+        assert isinstance(results["baseline"], CompositionResult)
+        assert results["baseline"].config_name == "baseline"
 
     def test_infra_error_on_chain_failure(self, tmp_path):
         """Chain execution failure returns CompositionResult with infra_error=True."""
@@ -373,14 +488,14 @@ class TestRunCompositionEval:
         ):
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-            result = run_composition_eval(
+            results = run_composition_eval(
                 self._make_composition(),
                 repo,
                 mock_judge,
                 n_trials=1,
             )
 
-        assert result.infra_error is True
+        assert results["baseline"].infra_error is True
 
     def test_worktree_cleanup_on_success(self, tmp_path):
         """git worktree remove is called after successful chain execution."""
@@ -426,9 +541,9 @@ class TestRunCompositionEval:
             patch("skill_eval.runner.subprocess.run", side_effect=mock_subprocess_run),
             patch("skill_eval.runner.execute_chain", side_effect=RuntimeError("boom")),
         ):
-            result = run_composition_eval(self._make_composition(), repo, mock_judge, n_trials=1)
+            results = run_composition_eval(self._make_composition(), repo, mock_judge, n_trials=1)
 
-        assert result.infra_error is True
+        assert results["baseline"].infra_error is True
         assert any("remove" in c for c in worktree_remove_calls)
 
     def test_fixture_not_found_raises(self, tmp_path):
@@ -469,92 +584,168 @@ class TestRunCompositionEval:
 
         assert chain_call_count["n"] == 3
 
+    def test_multiple_configs_returned(self, tmp_path):
+        """Multiple configs each produce a CompositionResult in the returned dict."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        composition = {
+            "name": "multi-config",
+            "fixture": "composition/terse",
+            "rubrics": [],
+            "configs": [
+                {"name": "config-a", "steps": [_step()]},
+                {"name": "config-b", "steps": [_step()]},
+            ],
+        }
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch(
+                "skill_eval.runner.execute_chain",
+                return_value=[ChainStepResult("quality-gate", "output", None)],
+            ),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            results = run_composition_eval(composition, repo, mock_judge, n_trials=1)
+
+        assert set(results.keys()) == {"config-a", "config-b"}
+
+    def test_fixture_key_is_fixture_not_fixture_key(self, tmp_path):
+        """Fixture is read from composition['fixture'], not composition['fixture_key']."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        # composition dict uses 'fixture', not 'fixture_key'
+        composition = {
+            "name": "test",
+            "fixture": "composition/terse",
+            "rubrics": [],
+            "configs": [{"name": "c1", "steps": [_step()]}],
+        }
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch(
+                "skill_eval.runner.execute_chain",
+                return_value=[ChainStepResult("quality-gate", "output", None)],
+            ),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            results = run_composition_eval(composition, repo, mock_judge, n_trials=1)
+
+        assert "c1" in results
+
 
 # ── Group 3: compare_composition_results ─────────────────────────────────────
 
 
 class TestCompareCompositionResults:
-    """compare_composition_results detects degradation and prints ASCII table."""
+    """compare_composition_results detects degradation across configs."""
 
     def _make_result(
         self,
-        name: str = "test",
+        config_name: str = "test",
         scores: dict | None = None,
         infra_error: bool = False,
     ) -> CompositionResult:
         return CompositionResult(
-            config_name=name,
+            config_name=config_name,
             step_results=[],
             final_scores=scores or {},
             trial_scores=None,
             infra_error=infra_error,
         )
 
+    def _make_results(self, **named_scores) -> dict[str, CompositionResult]:
+        """Build a results dict from config_name -> scores pairs."""
+        return {
+            name: self._make_result(config_name=name, scores=scores)
+            for name, scores in named_scores.items()
+        }
+
     def test_no_regression_when_within_tolerance(self):
         """No degradation when score drop is within tolerance."""
-        current = self._make_result(scores={"implementer_judgment": 8.0})
-        baseline = self._make_result(scores={"implementer_judgment": 8.1})
+        results = self._make_results(
+            baseline={"implementer_judgment": 8.1},
+            current={"implementer_judgment": 8.0},
+        )
 
-        degraded, report = compare_composition_results(current, baseline, tolerance=0.15)
+        cmp = compare_composition_results(results, baseline_config="baseline", tolerance=0.15)
 
-        assert degraded is False
-        assert "PASS" in report
+        assert cmp["degradation_detected"] is False
+        assert "PASS" in cmp["reports"]["current"]
 
     def test_degradation_detected_when_score_drops(self):
         """Degradation flagged when score drops more than tolerance."""
-        current = self._make_result(scores={"implementer_judgment": 5.0})
-        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+        results = self._make_results(
+            baseline={"implementer_judgment": 8.0},
+            current={"implementer_judgment": 5.0},
+        )
 
-        degraded, report = compare_composition_results(current, baseline, tolerance=0.15)
+        cmp = compare_composition_results(results, baseline_config="baseline", tolerance=0.15)
 
-        assert degraded is True
-        assert "DEGRADATION" in report
+        assert cmp["degradation_detected"] is True
+        assert "DEGRADATION" in cmp["reports"]["current"]
 
     def test_infra_error_in_current_is_degradation(self):
-        """infra_error=True in current result signals degradation."""
-        current = self._make_result(infra_error=True)
-        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+        """infra_error=True in a non-baseline config signals degradation."""
+        results = {
+            "baseline": self._make_result(config_name="baseline", scores={"x": 8.0}),
+            "current": self._make_result(config_name="current", infra_error=True),
+        }
 
-        degraded, report = compare_composition_results(current, baseline)
+        cmp = compare_composition_results(results, baseline_config="baseline")
 
-        assert degraded is True
-        assert "INFRA ERROR" in report
+        assert cmp["degradation_detected"] is True
+        assert "INFRA ERROR" in cmp["reports"]["current"]
 
     def test_infra_error_in_baseline_is_pass(self):
         """infra_error=True in baseline treats comparison as pass."""
-        current = self._make_result(scores={"implementer_judgment": 8.0})
-        baseline = self._make_result(infra_error=True)
+        results = {
+            "baseline": self._make_result(config_name="baseline", infra_error=True),
+            "current": self._make_result(config_name="current", scores={"x": 8.0}),
+        }
 
-        degraded, report = compare_composition_results(current, baseline)
+        cmp = compare_composition_results(results, baseline_config="baseline")
 
-        assert degraded is False
+        assert cmp["degradation_detected"] is False
 
     def test_empty_baseline_scores_is_pass(self):
         """No baseline scores available — treating as pass."""
-        current = self._make_result(scores={"implementer_judgment": 8.0})
-        baseline = self._make_result(scores={})
+        results = self._make_results(
+            baseline={},
+            current={"implementer_judgment": 8.0},
+        )
 
-        degraded, report = compare_composition_results(current, baseline)
+        cmp = compare_composition_results(results, baseline_config="baseline")
 
-        assert degraded is False
+        assert cmp["degradation_detected"] is False
 
     def test_missing_metric_in_current_flags_degradation(self):
         """A metric present in baseline but absent from current is a regression."""
-        current = self._make_result(scores={})
-        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+        results = self._make_results(
+            baseline={"implementer_judgment": 8.0},
+            current={},
+        )
 
-        degraded, report = compare_composition_results(current, baseline)
+        cmp = compare_composition_results(results, baseline_config="baseline")
 
-        assert degraded is True
-        assert "missing from current" in report
+        assert cmp["degradation_detected"] is True
+        assert "missing from current" in cmp["reports"]["current"]
 
     def test_report_contains_ascii_table(self):
         """The report contains an ASCII table with metric names and scores."""
-        current = self._make_result(scores={"implementer_judgment": 8.0})
-        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+        results = self._make_results(
+            baseline={"implementer_judgment": 8.0},
+            current={"implementer_judgment": 8.0},
+        )
 
-        _, report = compare_composition_results(current, baseline)
+        cmp = compare_composition_results(results, baseline_config="baseline")
 
+        report = cmp["reports"]["current"]
         assert "implementer_judgment" in report
         assert "Current" in report
         assert "Baseline" in report
@@ -562,23 +753,60 @@ class TestCompareCompositionResults:
 
     def test_per_rubric_deltas_shown(self):
         """Delta values appear in the ASCII table."""
-        current = self._make_result(scores={"implementer_judgment": 7.0})
-        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+        results = self._make_results(
+            baseline={"implementer_judgment": 8.0},
+            current={"implementer_judgment": 7.0},
+        )
 
-        _, report = compare_composition_results(current, baseline, tolerance=0.15)
+        cmp = compare_composition_results(results, baseline_config="baseline", tolerance=0.15)
 
-        # Drop of 1.0 > tolerance 0.15 — should be flagged.
+        report = cmp["reports"]["current"]
         assert "-1.000" in report or "-1.0" in report
 
     def test_drop_within_tolerance_is_pass(self):
         """A drop smaller than tolerance is not flagged as degradation."""
-        current = self._make_result(scores={"implementer_judgment": 7.9})
-        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+        results = self._make_results(
+            baseline={"implementer_judgment": 8.0},
+            current={"implementer_judgment": 7.9},
+        )
 
         # Drop = 0.1, tolerance = 0.15 → not > tolerance → pass.
-        degraded, _ = compare_composition_results(current, baseline, tolerance=0.15)
+        cmp = compare_composition_results(results, baseline_config="baseline", tolerance=0.15)
 
-        assert degraded is False
+        assert cmp["degradation_detected"] is False
+
+    def test_baseline_config_not_in_reports(self):
+        """The baseline config itself does not appear in the reports dict."""
+        results = self._make_results(
+            baseline={"implementer_judgment": 8.0},
+            current={"implementer_judgment": 8.0},
+        )
+
+        cmp = compare_composition_results(results, baseline_config="baseline")
+
+        assert "baseline" not in cmp["reports"]
+
+    def test_multiple_non_baseline_configs(self):
+        """All non-baseline configs are compared and reported."""
+        results = self._make_results(
+            baseline={"implementer_judgment": 8.0},
+            config_a={"implementer_judgment": 8.0},
+            config_b={"implementer_judgment": 5.0},
+        )
+
+        cmp = compare_composition_results(results, baseline_config="baseline")
+
+        assert "config_a" in cmp["reports"]
+        assert "config_b" in cmp["reports"]
+        assert cmp["degradation_detected"] is True
+
+    def test_missing_baseline_config_returns_degradation(self):
+        """Missing baseline config name returns degradation_detected=True."""
+        results = self._make_results(current={"implementer_judgment": 8.0})
+
+        cmp = compare_composition_results(results, baseline_config="nonexistent")
+
+        assert cmp["degradation_detected"] is True
 
 
 # ── Group 4: load_composition_fixture and load_composition_config ─────────────
@@ -632,7 +860,7 @@ class TestLoadCompositionConfig:
 
     def test_loads_valid_config(self, tmp_path):
         """A valid composition config is loaded as a dict."""
-        config = {"compositions": [{"name": "test", "steps": []}]}
+        config = {"compositions": [{"name": "test", "configs": []}]}
         path = _make_composition_config(tmp_path, config)
 
         result = load_composition_config(path)

--- a/skill-eval/tests/test_composition.py
+++ b/skill-eval/tests/test_composition.py
@@ -1,0 +1,654 @@
+"""Unit tests for composition eval framework.
+
+Three test groups:
+  1. execute_chain — step execution, variable substitution, XML wrapping.
+  2. run_composition_eval — fixture loading, worktree lifecycle, scoring.
+  3. compare_composition_results — regression detection, ASCII table.
+
+All tests use mocked subprocess.run and resolve_skill_bundle — no claude CLI
+or git worktree calls in the test suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from skill_eval.runner import (
+    ChainStepResult,
+    CompositionResult,
+    compare_composition_results,
+    execute_chain,
+    load_composition_config,
+    load_composition_fixture,
+    run_composition_eval,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Create a minimal repo with a skill SKILL.md."""
+    repo = tmp_path / "repo"
+    skill_dir = repo / "code-quality" / "skills" / "quality-gate"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# quality-gate\nDoes review.\n")
+    return repo
+
+
+def _make_fixture(repo: Path, key: str, content: str) -> None:
+    """Create a fixture file at skill-eval/fixtures/{key}.md."""
+    fixture_path = repo / "skill-eval" / "fixtures" / f"{key}.md"
+    fixture_path.parent.mkdir(parents=True, exist_ok=True)
+    fixture_path.write_text(content)
+
+
+def _make_composition_config(tmp_path: Path, data: dict) -> Path:
+    """Write a composition config JSON and return its path."""
+    import json
+
+    config_path = tmp_path / "composition.json"
+    config_path.write_text(json.dumps(data))
+    return config_path
+
+
+def _mock_claude_proc(output: str = "step output") -> MagicMock:
+    """Return a mock CompletedProcess for claude CLI invocations."""
+    proc = MagicMock()
+    proc.returncode = 0
+    proc.stdout = output
+    proc.stderr = ""
+    return proc
+
+
+# ── Group 1: execute_chain ────────────────────────────────────────────────────
+
+
+class TestExecuteChain:
+    """execute_chain executes skill steps and threads outputs."""
+
+    def test_single_step_returns_result(self, tmp_path):
+        """A single step returns one ChainStepResult."""
+        repo = _make_repo(tmp_path)
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# skill bundle"),
+            patch("skill_eval.runner.subprocess.run", return_value=_mock_claude_proc("hello")),
+        ):
+            results = execute_chain(
+                steps=[{"skill": "quality-gate", "prompt": "review this"}],
+                repo_root=repo,
+                context_preamble=None,
+                timeout_seconds=30,
+            )
+
+        assert len(results) == 1
+        assert results[0].skill_name == "quality-gate"
+        assert results[0].skill_output == "hello"
+        assert results[0].capture_name is None
+
+    def test_capture_as_stored_with_xml_wrapping(self, tmp_path):
+        """Captured output is XML-wrapped before storage."""
+        repo = _make_repo(tmp_path)
+
+        call_outputs = ["step1 output", "step2 output"]
+        call_iter = iter(call_outputs)
+
+        def mock_run(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = next(call_iter)
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            results = execute_chain(
+                steps=[
+                    {"skill": "quality-gate", "prompt": "first", "capture_as": "step1"},
+                    {"skill": "quality-gate", "prompt": "second: {step1}"},
+                ],
+                repo_root=repo,
+                context_preamble=None,
+                timeout_seconds=30,
+            )
+
+        assert len(results) == 2
+        assert results[0].capture_name == "step1"
+        assert results[1].skill_output == "step2 output"
+
+    def test_variable_substitution_from_initial_captures(self, tmp_path):
+        """Initial captures are substituted into step prompts."""
+        repo = _make_repo(tmp_path)
+
+        captured_prompt: list[str] = []
+
+        def mock_run(*args, **kwargs):
+            captured_prompt.append(kwargs.get("input", ""))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "response"
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[{"skill": "quality-gate", "prompt": "Review: {fixture}"}],
+                repo_root=repo,
+                context_preamble=None,
+                initial_captures={"fixture": "my fixture content"},
+                timeout_seconds=30,
+            )
+
+        assert "my fixture content" in captured_prompt[0]
+
+    def test_prior_step_output_xml_wrapped_in_next_prompt(self, tmp_path):
+        """Prior step output is XML-wrapped when substituted into later prompts."""
+        repo = _make_repo(tmp_path)
+
+        outputs = ["output from step1", "step2 done"]
+        call_iter = iter(outputs)
+        captured_inputs: list[str] = []
+
+        def mock_run(*args, **kwargs):
+            captured_inputs.append(kwargs.get("input", ""))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = next(call_iter)
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[
+                    {"skill": "quality-gate", "prompt": "first step", "capture_as": "result"},
+                    {"skill": "quality-gate", "prompt": "use this: {result}"},
+                ],
+                repo_root=repo,
+                context_preamble=None,
+                timeout_seconds=30,
+            )
+
+        # The second prompt should contain the XML-wrapped output.
+        second_input = captured_inputs[1]
+        assert '<prior-step-output skill="quality-gate">' in second_input
+        assert "output from step1" in second_input
+
+    def test_invalid_skill_name_raises(self, tmp_path):
+        """A skill name with invalid characters raises ValueError."""
+        repo = _make_repo(tmp_path)
+
+        with pytest.raises(ValueError, match="Invalid skill name"):
+            execute_chain(
+                steps=[{"skill": "bad skill name!", "prompt": "test"}],
+                repo_root=repo,
+                context_preamble=None,
+                timeout_seconds=30,
+            )
+
+    def test_unresolvable_skill_raises(self, tmp_path):
+        """A skill that cannot be found raises RuntimeError."""
+        repo = _make_repo(tmp_path)
+
+        with pytest.raises(RuntimeError, match="Could not find skill directory"):
+            execute_chain(
+                steps=[{"skill": "nonexistent-skill", "prompt": "test"}],
+                repo_root=repo,
+                context_preamble=None,
+                timeout_seconds=30,
+            )
+
+    def test_stderr_secrets_sanitized(self, tmp_path, capsys):
+        """Secrets in stderr are redacted before logging."""
+        repo = _make_repo(tmp_path)
+
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.stdout = ""
+        proc.stderr = "auth_key=supersecretvalue123"
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", return_value=proc),
+            patch("skill_eval.runner.logger") as mock_logger,
+        ):
+            execute_chain(
+                steps=[{"skill": "quality-gate", "prompt": "test"}],
+                repo_root=repo,
+                context_preamble=None,
+                timeout_seconds=30,
+            )
+
+        # Verify the logged message doesn't contain the raw secret.
+        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+        for wc in warning_calls:
+            assert "supersecretvalue123" not in wc
+
+    def test_context_preamble_included_in_prompt(self, tmp_path):
+        """context_preamble is included in the step's stdin input."""
+        repo = _make_repo(tmp_path)
+
+        captured_inputs: list[str] = []
+
+        def mock_run(*args, **kwargs):
+            captured_inputs.append(kwargs.get("input", ""))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "done"
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[{"skill": "quality-gate", "prompt": "test"}],
+                repo_root=repo,
+                context_preamble="MY CLAUDE.MD CONTENT",
+                timeout_seconds=30,
+            )
+
+        assert "MY CLAUDE.MD CONTENT" in captured_inputs[0]
+        assert "BEHAVIORAL CONTEXT" in captured_inputs[0]
+
+    def test_claudecode_env_var_set(self, tmp_path):
+        """CLAUDECODE='' is set in the subprocess environment."""
+        repo = _make_repo(tmp_path)
+
+        captured_env: list[dict] = []
+
+        def mock_run(*args, **kwargs):
+            captured_env.append(kwargs.get("env", {}))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = "done"
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[{"skill": "quality-gate", "prompt": "test"}],
+                repo_root=repo,
+                context_preamble=None,
+                timeout_seconds=30,
+            )
+
+        assert "CLAUDECODE" in captured_env[0]
+        assert captured_env[0]["CLAUDECODE"] == ""
+
+    def test_multiple_steps_in_order(self, tmp_path):
+        """Steps execute in order and results accumulate."""
+        repo = _make_repo(tmp_path)
+
+        outputs = ["output-1", "output-2", "output-3"]
+        call_iter = iter(outputs)
+
+        def mock_run(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = next(call_iter)
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            results = execute_chain(
+                steps=[
+                    {"skill": "quality-gate", "prompt": "step 1"},
+                    {"skill": "quality-gate", "prompt": "step 2"},
+                    {"skill": "quality-gate", "prompt": "step 3"},
+                ],
+                repo_root=repo,
+                context_preamble=None,
+                timeout_seconds=30,
+            )
+
+        assert [r.skill_output for r in results] == ["output-1", "output-2", "output-3"]
+
+
+# ── Group 2: run_composition_eval ────────────────────────────────────────────
+
+
+class TestRunCompositionEval:
+    """run_composition_eval manages worktree lifecycle and scores final output."""
+
+    def _make_composition(self, fixture_key: str = "composition/terse") -> dict:
+        return {
+            "name": "test-composition",
+            "fixture_key": fixture_key,
+            "rubrics": [],
+            "steps": [{"skill": "quality-gate", "prompt": "{fixture}"}],
+        }
+
+    def test_returns_composition_result(self, tmp_path):
+        """run_composition_eval returns a CompositionResult."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\nDo something.\n")
+
+        mock_judge = MagicMock()
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.execute_chain") as mock_chain,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            mock_chain.return_value = [ChainStepResult("quality-gate", "the output", None)]
+
+            result = run_composition_eval(
+                self._make_composition(),
+                repo,
+                mock_judge,
+                n_trials=1,
+            )
+
+        assert isinstance(result, CompositionResult)
+        assert result.config_name == "test-composition"
+
+    def test_infra_error_on_chain_failure(self, tmp_path):
+        """Chain execution failure returns CompositionResult with infra_error=True."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch("skill_eval.runner.execute_chain", side_effect=RuntimeError("chain failed")),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = run_composition_eval(
+                self._make_composition(),
+                repo,
+                mock_judge,
+                n_trials=1,
+            )
+
+        assert result.infra_error is True
+
+    def test_worktree_cleanup_on_success(self, tmp_path):
+        """git worktree remove is called after successful chain execution."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        worktree_remove_calls: list[list] = []
+
+        def mock_subprocess_run(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, list) and "remove" in cmd:
+                worktree_remove_calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_subprocess_run),
+            patch(
+                "skill_eval.runner.execute_chain",
+                return_value=[ChainStepResult("quality-gate", "output", None)],
+            ),
+        ):
+            run_composition_eval(self._make_composition(), repo, mock_judge, n_trials=1)
+
+        # Verify worktree remove was called.
+        assert any("remove" in c for c in worktree_remove_calls)
+
+    def test_worktree_cleanup_on_chain_failure(self, tmp_path):
+        """git worktree remove is called even when chain execution fails."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        worktree_remove_calls: list[list] = []
+
+        def mock_subprocess_run(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, list) and "remove" in cmd:
+                worktree_remove_calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_subprocess_run),
+            patch("skill_eval.runner.execute_chain", side_effect=RuntimeError("boom")),
+        ):
+            result = run_composition_eval(self._make_composition(), repo, mock_judge, n_trials=1)
+
+        assert result.infra_error is True
+        assert any("remove" in c for c in worktree_remove_calls)
+
+    def test_fixture_not_found_raises(self, tmp_path):
+        """Missing fixture raises FileNotFoundError."""
+        repo = _make_repo(tmp_path)
+        mock_judge = MagicMock()
+
+        with (
+            patch("skill_eval.runner.subprocess.run", return_value=MagicMock(returncode=0)),
+            pytest.raises(FileNotFoundError),
+        ):
+            run_composition_eval(
+                self._make_composition("composition/nonexistent"),
+                repo,
+                mock_judge,
+                n_trials=1,
+            )
+
+    def test_n_trials_runs_multiple_times(self, tmp_path):
+        """n_trials=3 runs the chain 3 times."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        chain_call_count = {"n": 0}
+
+        def mock_chain(*args, **kwargs):
+            chain_call_count["n"] += 1
+            return [ChainStepResult("quality-gate", f"output-{chain_call_count['n']}", None)]
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch("skill_eval.runner.execute_chain", side_effect=mock_chain),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            run_composition_eval(self._make_composition(), repo, mock_judge, n_trials=3)
+
+        assert chain_call_count["n"] == 3
+
+
+# ── Group 3: compare_composition_results ─────────────────────────────────────
+
+
+class TestCompareCompositionResults:
+    """compare_composition_results detects degradation and prints ASCII table."""
+
+    def _make_result(
+        self,
+        name: str = "test",
+        scores: dict | None = None,
+        infra_error: bool = False,
+    ) -> CompositionResult:
+        return CompositionResult(
+            config_name=name,
+            step_results=[],
+            final_scores=scores or {},
+            trial_scores=None,
+            infra_error=infra_error,
+        )
+
+    def test_no_regression_when_within_tolerance(self):
+        """No degradation when score drop is within tolerance."""
+        current = self._make_result(scores={"implementer_judgment": 8.0})
+        baseline = self._make_result(scores={"implementer_judgment": 8.1})
+
+        degraded, report = compare_composition_results(current, baseline, tolerance=0.15)
+
+        assert degraded is False
+        assert "PASS" in report
+
+    def test_degradation_detected_when_score_drops(self):
+        """Degradation flagged when score drops more than tolerance."""
+        current = self._make_result(scores={"implementer_judgment": 5.0})
+        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+
+        degraded, report = compare_composition_results(current, baseline, tolerance=0.15)
+
+        assert degraded is True
+        assert "DEGRADATION" in report
+
+    def test_infra_error_in_current_is_degradation(self):
+        """infra_error=True in current result signals degradation."""
+        current = self._make_result(infra_error=True)
+        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+
+        degraded, report = compare_composition_results(current, baseline)
+
+        assert degraded is True
+        assert "INFRA ERROR" in report
+
+    def test_infra_error_in_baseline_is_pass(self):
+        """infra_error=True in baseline treats comparison as pass."""
+        current = self._make_result(scores={"implementer_judgment": 8.0})
+        baseline = self._make_result(infra_error=True)
+
+        degraded, report = compare_composition_results(current, baseline)
+
+        assert degraded is False
+
+    def test_empty_baseline_scores_is_pass(self):
+        """No baseline scores available — treating as pass."""
+        current = self._make_result(scores={"implementer_judgment": 8.0})
+        baseline = self._make_result(scores={})
+
+        degraded, report = compare_composition_results(current, baseline)
+
+        assert degraded is False
+
+    def test_missing_metric_in_current_flags_degradation(self):
+        """A metric present in baseline but absent from current is a regression."""
+        current = self._make_result(scores={})
+        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+
+        degraded, report = compare_composition_results(current, baseline)
+
+        assert degraded is True
+        assert "missing from current" in report
+
+    def test_report_contains_ascii_table(self):
+        """The report contains an ASCII table with metric names and scores."""
+        current = self._make_result(scores={"implementer_judgment": 8.0})
+        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+
+        _, report = compare_composition_results(current, baseline)
+
+        assert "implementer_judgment" in report
+        assert "Current" in report
+        assert "Baseline" in report
+        assert "Delta" in report
+
+    def test_per_rubric_deltas_shown(self):
+        """Delta values appear in the ASCII table."""
+        current = self._make_result(scores={"implementer_judgment": 7.0})
+        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+
+        _, report = compare_composition_results(current, baseline, tolerance=0.15)
+
+        # Drop of 1.0 > tolerance 0.15 — should be flagged.
+        assert "-1.000" in report or "-1.0" in report
+
+    def test_drop_within_tolerance_is_pass(self):
+        """A drop smaller than tolerance is not flagged as degradation."""
+        current = self._make_result(scores={"implementer_judgment": 7.9})
+        baseline = self._make_result(scores={"implementer_judgment": 8.0})
+
+        # Drop = 0.1, tolerance = 0.15 → not > tolerance → pass.
+        degraded, _ = compare_composition_results(current, baseline, tolerance=0.15)
+
+        assert degraded is False
+
+
+# ── Group 4: load_composition_fixture and load_composition_config ─────────────
+
+
+class TestLoadCompositionFixture:
+    """load_composition_fixture validates keys and returns full file content."""
+
+    def test_returns_full_content_including_frontmatter(self, tmp_path):
+        """Frontmatter is NOT stripped — caller parses it."""
+        repo = tmp_path / "repo"
+        _make_fixture(
+            repo,
+            "composition/test-fixture",
+            "---\nscaffold:\n  files: []\n---\n\n# Plan\nDo things.\n",
+        )
+
+        content = load_composition_fixture("composition/test-fixture", repo)
+
+        assert "---" in content
+        assert "scaffold" in content
+        assert "# Plan" in content
+
+    def test_invalid_key_raises_value_error(self, tmp_path):
+        """Fixture key with invalid characters raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid fixture key"):
+            load_composition_fixture("../../../etc/passwd", tmp_path)
+
+    def test_missing_fixture_raises_file_not_found(self, tmp_path):
+        """Missing fixture raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_composition_fixture("composition/nonexistent", tmp_path)
+
+    def test_key_with_subdirectory_path_is_valid(self, tmp_path):
+        """Keys with subdirectory segments (e.g. 'composition/foo') are valid."""
+        repo = tmp_path / "repo"
+        _make_fixture(repo, "composition/valid-key", "# content\n")
+
+        content = load_composition_fixture("composition/valid-key", repo)
+
+        assert "# content" in content
+
+    def test_path_traversal_key_rejected(self, tmp_path):
+        """Keys containing '..' are rejected by validation."""
+        with pytest.raises(ValueError, match="Invalid fixture key"):
+            load_composition_fixture("composition/../../../secret", tmp_path)
+
+
+class TestLoadCompositionConfig:
+    """load_composition_config reads JSON and raises on missing file."""
+
+    def test_loads_valid_config(self, tmp_path):
+        """A valid composition config is loaded as a dict."""
+        config = {"compositions": [{"name": "test", "steps": []}]}
+        path = _make_composition_config(tmp_path, config)
+
+        result = load_composition_config(path)
+
+        assert result["compositions"][0]["name"] == "test"
+
+    def test_raises_on_missing_file(self, tmp_path):
+        """Missing config file raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_composition_config(tmp_path / "nonexistent.json")
+
+    def test_empty_compositions_list_is_valid(self, tmp_path):
+        """An empty compositions list is valid — no error raised."""
+        config = {"compositions": []}
+        path = _make_composition_config(tmp_path, config)
+
+        result = load_composition_config(path)
+
+        assert result["compositions"] == []

--- a/skill-eval/tests/test_composition.py
+++ b/skill-eval/tests/test_composition.py
@@ -251,8 +251,8 @@ class TestExecuteChain:
                 context_preamble=None,
             )
 
-    def test_stderr_secrets_sanitized(self, tmp_path, capsys):
-        """Secrets in stderr are redacted before logging."""
+    def test_stderr_secrets_sanitized(self, tmp_path):
+        """Secrets in stderr are redacted in the RuntimeError message."""
         repo = _make_repo(tmp_path)
 
         proc = MagicMock()
@@ -263,18 +263,20 @@ class TestExecuteChain:
         with (
             patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
             patch("skill_eval.runner.subprocess.run", return_value=proc),
-            patch("skill_eval.runner.logger") as mock_logger,
+            pytest.raises(RuntimeError, match=r"auth_key=\[REDACTED\]"),
         ):
             execute_chain(
-                steps=[{"skill": "quality-gate", "prompt_template": "test", "timeout_seconds": 30}],
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "test",
+                        "timeout_seconds": 30,
+                    }
+                ],
                 repo_root=repo,
                 context_preamble=None,
             )
-
-        # Verify the logged message doesn't contain the raw secret.
-        warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
-        for wc in warning_calls:
-            assert "supersecretvalue123" not in wc
+        # The raw secret must not appear in the error message.
 
     def test_context_preamble_included_in_prompt(self, tmp_path):
         """context_preamble is included in the step's stdin input."""

--- a/skill-eval/tests/test_composition.py
+++ b/skill-eval/tests/test_composition.py
@@ -334,6 +334,63 @@ class TestExecuteChain:
         assert "CLAUDECODE" in captured_env[0]
         assert captured_env[0]["CLAUDECODE"] == ""
 
+    def test_env_allowlist_excludes_non_allowlisted_keys(self, tmp_path):
+        """Non-allowlisted env vars are absent from subprocess env."""
+        repo = _make_repo(tmp_path)
+
+        captured_env: list[dict] = []
+
+        def mock_run(*args, **kwargs):
+            captured_env.append(kwargs.get("env", {}))
+            return _mock_claude_proc()
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+            patch.dict("os.environ", {"DATABASE_PASSWORD": "s3cr3t"}, clear=False),
+        ):
+            execute_chain(
+                steps=[{"skill": "quality-gate", "prompt_template": "test", "timeout_seconds": 30}],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+        assert "DATABASE_PASSWORD" not in captured_env[0]
+        assert "CLAUDECODE" in captured_env[0]
+
+    def test_bare_mode_skips_preamble_and_passes_flag(self, tmp_path):
+        """bare=True passes --bare to claude CLI and omits BEHAVIORAL CONTEXT from stdin."""
+        repo = _make_repo(tmp_path)
+
+        captured_cmds: list[list] = []
+        captured_inputs: list[str] = []
+
+        def mock_run(*args, **kwargs):
+            captured_cmds.append(args[0])
+            captured_inputs.append(kwargs.get("input", ""))
+            return _mock_claude_proc()
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "test",
+                        "timeout_seconds": 30,
+                        "bare": True,
+                    }
+                ],
+                repo_root=repo,
+                context_preamble="MY CLAUDE.MD CONTENT",
+            )
+
+        assert "--bare" in captured_cmds[0]
+        assert "BEHAVIORAL CONTEXT" not in captured_inputs[0]
+        assert "test" in captured_inputs[0]
+
     def test_multiple_steps_in_order(self, tmp_path):
         """Steps execute in order and results accumulate."""
         repo = _make_repo(tmp_path)
@@ -511,6 +568,49 @@ class TestRunCompositionEval:
             run_composition_eval(_make_composition(), repo, mock_judge, n_trials=3)
 
         assert chain_call_count["n"] == 3
+
+    def test_partial_trial_failure_averages_successful_trials(self, tmp_path):
+        """When some trials fail and some succeed, scores average over successes only."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        call_count = {"n": 0}
+
+        def mock_chain(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("first trial failed")
+            return [ChainStepResult("quality-gate", f"output-{call_count['n']}", None)]
+
+        mock_metric = MagicMock()
+        mock_metric.name = "test_metric"
+        mock_metric.score = 0.8
+
+        composition = _make_composition()
+        composition["rubrics"] = ["implementer_judgment"]
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch("skill_eval.runner.execute_chain", side_effect=mock_chain),
+            patch("skill_eval.runner.build_metrics", return_value=[mock_metric]),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = run_composition_eval(
+                composition,
+                repo,
+                mock_judge,
+                n_trials=3,
+            )
+
+        baseline = result["baseline"]
+        assert baseline.infra_error is False
+        assert baseline.trial_scores is not None
+        assert len(baseline.trial_scores) == 2
+        assert "test_metric" in baseline.final_scores
+        assert baseline.final_scores["test_metric"] == pytest.approx(0.8)
+        assert mock_metric.measure.call_count == 2
 
 
 # ── Group 3: compare_composition_results ─────────────────────────────────────
@@ -707,7 +807,7 @@ class TestLoadCompositionConfig:
         assert result["compositions"] == []
 
 
-# ── Group 6: _scaffold_worktree ──────────────────────────────────────────────
+# ── Group 5: _scaffold_worktree ──────────────────────────────────────────────
 
 
 class TestScaffoldWorktree:
@@ -762,7 +862,7 @@ class TestScaffoldWorktree:
             _scaffold_worktree(tmp_path, {"files": ["../escape.txt"]})
 
 
-# ── Group 7: _build_context_preamble ─────────────────────────────────────────
+# ── Group 6: _build_context_preamble ─────────────────────────────────────────
 
 
 class TestBuildContextPreamble:
@@ -786,7 +886,7 @@ class TestBuildContextPreamble:
         assert "Project rules" in result
 
 
-# ── Group 8: execute_chain edge cases ────────────────────────────────────────
+# ── Group 7: execute_chain edge cases ────────────────────────────────────────
 
 
 class TestExecuteChainEdgeCases:
@@ -902,7 +1002,7 @@ class TestExecuteChainEdgeCases:
         assert "[suspect output" in results[0].skill_output
 
 
-# ── Group 9: compare_composition_results edge cases ──────────────────────────
+# ── Group 8: compare_composition_results edge cases ──────────────────────────
 
 
 class TestCompareEdgeCases:
@@ -922,18 +1022,16 @@ class TestCompareEdgeCases:
         assert outcome["degradation_detected"] is True
 
 
-# ── Group 10: YAML frontmatter parsing ───────────────────────────────────────
+# ── Group 9: YAML frontmatter parsing ────────────────────────────────────────
 
 
 class TestFrontmatterParsing:
     """Frontmatter parsing in run_composition_eval."""
 
     def test_fixture_without_frontmatter(self, tmp_path):
-        """Fixture with no --- frontmatter uses empty scaffold spec."""
+        """Fixture with no --- frontmatter skips _scaffold_worktree entirely."""
         repo = _make_repo(tmp_path)
         _make_fixture(repo, "composition/nofm", "# Just content\nNo frontmatter here.\n")
-
-        import contextlib
 
         mock_judge = MagicMock()
         scaffold_calls: list = []
@@ -946,7 +1044,6 @@ class TestFrontmatterParsing:
             patch("skill_eval.runner.execute_chain", return_value=[]),
             patch("skill_eval.runner._scaffold_worktree", side_effect=track_scaffold),
             patch("skill_eval.runner._build_context_preamble", return_value=None),
-            contextlib.suppress(Exception),
         ):
             run_composition_eval(
                 {
@@ -970,5 +1067,67 @@ class TestFrontmatterParsing:
                 mock_judge,
             )
 
-        if scaffold_calls:
-            assert scaffold_calls[0] == {}
+        assert scaffold_calls == []
+
+    def test_frontmatter_stripped_from_fixture_content(self, tmp_path):
+        """Frontmatter (including planted_issues) is stripped before reaching execute_chain."""
+        repo = _make_repo(tmp_path)
+        fixture_text = (
+            "---\nscaffold:\n  files: []\nplanted_issues:\n  - secret answer\n---\n"
+            "\n# Body content\nThis is the plan.\n"
+        )
+        _make_fixture(repo, "composition/withfm", fixture_text)
+
+        mock_judge = MagicMock()
+        captured_captures: list[dict] = []
+
+        def mock_chain(*args, **kwargs):
+            captured_captures.append(kwargs.get("initial_captures", {}))
+            return [ChainStepResult("quality-gate", "output", None)]
+
+        with (
+            patch("skill_eval.runner.subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("skill_eval.runner.execute_chain", side_effect=mock_chain),
+            patch("skill_eval.runner._scaffold_worktree"),
+            patch("skill_eval.runner._build_context_preamble", return_value=None),
+        ):
+            run_composition_eval(
+                {
+                    "name": "test",
+                    "fixture": "composition/withfm",
+                    "rubrics": [],
+                    "configs": [
+                        {
+                            "name": "base",
+                            "steps": [
+                                {
+                                    "skill": "quality-gate",
+                                    "prompt_template": "{fixture}",
+                                    "timeout_seconds": 30,
+                                }
+                            ],
+                        }
+                    ],
+                },
+                repo,
+                mock_judge,
+            )
+
+        fixture_passed = captured_captures[0]["fixture"]
+        assert "planted_issues" not in fixture_passed
+        assert "secret answer" not in fixture_passed
+        assert "# Body content" in fixture_passed
+
+    def test_unterminated_frontmatter_raises(self, tmp_path):
+        """Fixture with opening --- but no closing --- raises ValueError."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/bad", "---\nkey: value\nno closing delimiter\n")
+
+        mock_judge = MagicMock()
+
+        with pytest.raises(ValueError, match="unterminated YAML frontmatter"):
+            run_composition_eval(
+                _make_composition("composition/bad"),
+                repo,
+                mock_judge,
+            )

--- a/skill-eval/tests/test_composition.py
+++ b/skill-eval/tests/test_composition.py
@@ -53,7 +53,10 @@ def _make_composition_config(tmp_path: Path, data: dict) -> Path:
     return config_path
 
 
-def _mock_claude_proc(output: str = "step output") -> MagicMock:
+_DEFAULT_OUTPUT = "This is a sufficiently long mock output for the composition eval test suite."
+
+
+def _mock_claude_proc(output: str = _DEFAULT_OUTPUT) -> MagicMock:
     """Return a mock CompletedProcess for claude CLI invocations."""
     proc = MagicMock()
     proc.returncode = 0
@@ -90,7 +93,7 @@ class TestExecuteChain:
 
         with (
             patch("skill_eval.runner.resolve_skill_bundle", return_value="# skill bundle"),
-            patch("skill_eval.runner.subprocess.run", return_value=_mock_claude_proc("hello")),
+            patch("skill_eval.runner.subprocess.run", return_value=_mock_claude_proc()),
         ):
             results = execute_chain(
                 steps=[
@@ -106,14 +109,17 @@ class TestExecuteChain:
 
         assert len(results) == 1
         assert results[0].skill_name == "quality-gate"
-        assert results[0].skill_output == "hello"
+        assert results[0].skill_output == _DEFAULT_OUTPUT
         assert results[0].capture_name is None
 
     def test_capture_as_stored_with_xml_wrapping(self, tmp_path):
         """Captured output is XML-wrapped before storage."""
         repo = _make_repo(tmp_path)
 
-        call_outputs = ["step1 output", "step2 output"]
+        call_outputs = [
+            "Step 1 produced this output which is long enough to pass the guard check.",
+            "Step 2 produced this output which is also long enough to pass the guard check.",
+        ]
         call_iter = iter(call_outputs)
 
         def mock_run(*args, **kwargs):
@@ -147,7 +153,7 @@ class TestExecuteChain:
 
         assert len(results) == 2
         assert results[0].capture_name == "step1"
-        assert results[1].skill_output == "step2 output"
+        assert "long enough to pass the guard" in results[1].skill_output
 
     def test_variable_substitution_from_initial_captures(self, tmp_path):
         """Initial captures are substituted into step prompts."""
@@ -313,11 +319,7 @@ class TestExecuteChain:
 
         def mock_run(*args, **kwargs):
             captured_env.append(kwargs.get("env", {}))
-            proc = MagicMock()
-            proc.returncode = 0
-            proc.stdout = "done"
-            proc.stderr = ""
-            return proc
+            return _mock_claude_proc()
 
         with (
             patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
@@ -336,7 +338,11 @@ class TestExecuteChain:
         """Steps execute in order and results accumulate."""
         repo = _make_repo(tmp_path)
 
-        outputs = ["output-1", "output-2", "output-3"]
+        outputs = [
+            "Output from step 1 — long enough to pass the 50-char guard threshold.",
+            "Output from step 2 — long enough to pass the 50-char guard threshold.",
+            "Output from step 3 — long enough to pass the 50-char guard threshold.",
+        ]
         call_iter = iter(outputs)
 
         def mock_run(*args, **kwargs):
@@ -360,7 +366,8 @@ class TestExecuteChain:
                 context_preamble=None,
             )
 
-        assert [r.skill_output for r in results] == ["output-1", "output-2", "output-3"]
+        assert len(results) == 3
+        assert all("long enough to pass" in r.skill_output for r in results)
 
 
 # ── Group 2: run_composition_eval ────────────────────────────────────────────
@@ -698,3 +705,270 @@ class TestLoadCompositionConfig:
         result = load_composition_config(path)
 
         assert result["compositions"] == []
+
+
+# ── Group 6: _scaffold_worktree ──────────────────────────────────────────────
+
+
+class TestScaffoldWorktree:
+    """_scaffold_worktree creates files and commits in a worktree."""
+
+    def test_creates_scaffold_files(self, tmp_path):
+        """Scaffold files are created at the specified paths."""
+        from skill_eval.runner import _scaffold_worktree
+
+        trial = tmp_path / "trial"
+        trial.mkdir()
+        # Init a git repo so git add/commit works.
+        import subprocess
+
+        subprocess.run(["git", "init"], cwd=trial, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=trial,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=trial,
+            capture_output=True,
+        )
+
+        spec = {
+            "files": ["app/__init__.py", "app/models.py"],
+            "requirements": ["flask", "pytest"],
+        }
+        _scaffold_worktree(trial, spec)
+
+        assert (trial / "app" / "__init__.py").is_file()
+        assert (trial / "app" / "models.py").is_file()
+        assert (trial / "requirements.txt").is_file()
+        assert "flask" in (trial / "requirements.txt").read_text()
+        assert (trial / ".pre-commit-config.yaml").is_file()
+        assert "repos: []" in (trial / ".pre-commit-config.yaml").read_text()
+
+    def test_rejects_absolute_path(self, tmp_path):
+        """Absolute scaffold file paths are rejected."""
+        from skill_eval.runner import _scaffold_worktree
+
+        with pytest.raises(ValueError, match="relative"):
+            _scaffold_worktree(tmp_path, {"files": ["/etc/passwd"]})
+
+    def test_rejects_dotdot_path(self, tmp_path):
+        """Paths with '..' are rejected."""
+        from skill_eval.runner import _scaffold_worktree
+
+        with pytest.raises(ValueError, match="\\.\\."):
+            _scaffold_worktree(tmp_path, {"files": ["../escape.txt"]})
+
+
+# ── Group 7: _build_context_preamble ─────────────────────────────────────────
+
+
+class TestBuildContextPreamble:
+    """_build_context_preamble joins CLAUDE.md layers."""
+
+    def test_returns_none_when_no_layers(self, tmp_path):
+        """Returns None when load_context_layers returns empty dict."""
+        from skill_eval.runner import _build_context_preamble
+
+        with patch("skill_eval.runner.load_context_layers", return_value={}):
+            result = _build_context_preamble(tmp_path)
+        assert result is None
+
+    def test_returns_joined_layers(self, tmp_path):
+        """Returns joined CLAUDE.md content when project CLAUDE.md exists."""
+        from skill_eval.runner import _build_context_preamble
+
+        (tmp_path / "CLAUDE.md").write_text("# Project rules\n")
+        result = _build_context_preamble(tmp_path)
+        assert result is not None
+        assert "Project rules" in result
+
+
+# ── Group 8: execute_chain edge cases ────────────────────────────────────────
+
+
+class TestExecuteChainEdgeCases:
+    """Edge cases for execute_chain."""
+
+    def test_empty_steps_returns_empty(self, tmp_path):
+        """Empty steps list returns empty results."""
+        repo = _make_repo(tmp_path)
+        results = execute_chain([], repo, None)
+        assert results == []
+
+    def test_timeout_expired_propagates(self, tmp_path):
+        """TimeoutExpired from subprocess propagates up."""
+        import subprocess as sp
+
+        repo = _make_repo(tmp_path)
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch(
+                "skill_eval.runner.subprocess.run",
+                side_effect=sp.TimeoutExpired(cmd=["claude"], timeout=30),
+            ),
+            pytest.raises(sp.TimeoutExpired),
+        ):
+            execute_chain(
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "test",
+                        "timeout_seconds": 30,
+                    }
+                ],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+    def test_nonzero_exit_raises_runtime_error(self, tmp_path):
+        """Non-zero exit code from claude CLI raises RuntimeError."""
+        repo = _make_repo(tmp_path)
+        proc = MagicMock()
+        proc.returncode = 1
+        proc.stdout = ""
+        proc.stderr = "some error"
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", return_value=proc),
+            pytest.raises(RuntimeError, match="claude CLI failed"),
+        ):
+            execute_chain(
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "test",
+                        "timeout_seconds": 30,
+                    }
+                ],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+    def test_empty_output_replaced_with_marker(self, tmp_path):
+        """Empty stdout is replaced with an [empty output] marker."""
+        repo = _make_repo(tmp_path)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = ""
+        proc.stderr = ""
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", return_value=proc),
+        ):
+            results = execute_chain(
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "test",
+                        "timeout_seconds": 30,
+                    }
+                ],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+        assert "[empty output" in results[0].skill_output
+
+    def test_short_output_replaced_with_suspect_marker(self, tmp_path):
+        """Output shorter than 50 chars is replaced with [suspect output] marker."""
+        repo = _make_repo(tmp_path)
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = "too short"
+        proc.stderr = ""
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", return_value=proc),
+        ):
+            results = execute_chain(
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "test",
+                        "timeout_seconds": 30,
+                    }
+                ],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+        assert "[suspect output" in results[0].skill_output
+
+
+# ── Group 9: compare_composition_results edge cases ──────────────────────────
+
+
+class TestCompareEdgeCases:
+    """Edge cases for compare_composition_results."""
+
+    def test_missing_baseline_config(self):
+        """Missing baseline config name returns degradation_detected=True."""
+        results = {
+            "config-a": CompositionResult(
+                config_name="config-a",
+                step_results=[],
+                final_scores={"m": 0.8},
+                trial_scores=None,
+            ),
+        }
+        outcome = compare_composition_results(results, "nonexistent-baseline")
+        assert outcome["degradation_detected"] is True
+
+
+# ── Group 10: YAML frontmatter parsing ───────────────────────────────────────
+
+
+class TestFrontmatterParsing:
+    """Frontmatter parsing in run_composition_eval."""
+
+    def test_fixture_without_frontmatter(self, tmp_path):
+        """Fixture with no --- frontmatter uses empty scaffold spec."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/nofm", "# Just content\nNo frontmatter here.\n")
+
+        import contextlib
+
+        mock_judge = MagicMock()
+        scaffold_calls: list = []
+
+        def track_scaffold(trial_root, spec):
+            scaffold_calls.append(spec)
+
+        with (
+            patch("skill_eval.runner.subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("skill_eval.runner.execute_chain", return_value=[]),
+            patch("skill_eval.runner._scaffold_worktree", side_effect=track_scaffold),
+            patch("skill_eval.runner._build_context_preamble", return_value=None),
+            contextlib.suppress(Exception),
+        ):
+            run_composition_eval(
+                {
+                    "name": "test",
+                    "fixture": "composition/nofm",
+                    "rubrics": [],
+                    "configs": [
+                        {
+                            "name": "base",
+                            "steps": [
+                                {
+                                    "skill": "quality-gate",
+                                    "prompt_template": "{fixture}",
+                                    "timeout_seconds": 30,
+                                }
+                            ],
+                        }
+                    ],
+                },
+                repo,
+                mock_judge,
+            )
+
+        if scaffold_calls:
+            assert scaffold_calls[0] == {}

--- a/skill-eval/tests/test_composition.py
+++ b/skill-eval/tests/test_composition.py
@@ -62,9 +62,20 @@ def _mock_claude_proc(output: str = "step output") -> MagicMock:
     return proc
 
 
-def _step(skill: str = "quality-gate", prompt_template: str = "review this", **kwargs) -> dict:
-    """Build a minimal step dict with required fields."""
-    return {"skill": skill, "prompt_template": prompt_template, "timeout_seconds": 30, **kwargs}
+def _make_composition(fixture_key: str = "composition/terse") -> dict:
+    return {
+        "name": "test-composition",
+        "fixture": fixture_key,
+        "rubrics": [],
+        "configs": [
+            {
+                "name": "baseline",
+                "steps": [
+                    {"skill": "quality-gate", "prompt_template": "{fixture}", "timeout_seconds": 30}
+                ],
+            }
+        ],
+    }
 
 
 # ── Group 1: execute_chain ────────────────────────────────────────────────────
@@ -82,7 +93,13 @@ class TestExecuteChain:
             patch("skill_eval.runner.subprocess.run", return_value=_mock_claude_proc("hello")),
         ):
             results = execute_chain(
-                steps=[_step(prompt_template="review this")],
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "review this",
+                        "timeout_seconds": 30,
+                    }
+                ],
                 repo_root=repo,
                 context_preamble=None,
             )
@@ -112,8 +129,17 @@ class TestExecuteChain:
         ):
             results = execute_chain(
                 steps=[
-                    _step(prompt_template="first", capture_as="step1"),
-                    _step(prompt_template="second: {step1}"),
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "first",
+                        "capture_as": "step1",
+                        "timeout_seconds": 30,
+                    },
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "second: {step1}",
+                        "timeout_seconds": 30,
+                    },
                 ],
                 repo_root=repo,
                 context_preamble=None,
@@ -142,7 +168,13 @@ class TestExecuteChain:
             patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
         ):
             execute_chain(
-                steps=[_step(prompt_template="Review: {fixture}")],
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "Review: {fixture}",
+                        "timeout_seconds": 30,
+                    }
+                ],
                 repo_root=repo,
                 context_preamble=None,
                 initial_captures={"fixture": "my fixture content"},
@@ -172,8 +204,17 @@ class TestExecuteChain:
         ):
             execute_chain(
                 steps=[
-                    _step(prompt_template="first step", capture_as="result"),
-                    _step(prompt_template="use this: {result}"),
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "first step",
+                        "capture_as": "result",
+                        "timeout_seconds": 30,
+                    },
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "use this: {result}",
+                        "timeout_seconds": 30,
+                    },
                 ],
                 repo_root=repo,
                 context_preamble=None,
@@ -190,7 +231,9 @@ class TestExecuteChain:
 
         with pytest.raises(ValueError, match="Invalid skill name"):
             execute_chain(
-                steps=[_step(skill="bad skill name!")],
+                steps=[
+                    {"skill": "bad skill name!", "prompt_template": "test", "timeout_seconds": 30}
+                ],
                 repo_root=repo,
                 context_preamble=None,
             )
@@ -201,7 +244,9 @@ class TestExecuteChain:
 
         with pytest.raises(RuntimeError, match="Could not find skill directory"):
             execute_chain(
-                steps=[_step(skill="nonexistent-skill")],
+                steps=[
+                    {"skill": "nonexistent-skill", "prompt_template": "test", "timeout_seconds": 30}
+                ],
                 repo_root=repo,
                 context_preamble=None,
             )
@@ -221,7 +266,7 @@ class TestExecuteChain:
             patch("skill_eval.runner.logger") as mock_logger,
         ):
             execute_chain(
-                steps=[_step()],
+                steps=[{"skill": "quality-gate", "prompt_template": "test", "timeout_seconds": 30}],
                 repo_root=repo,
                 context_preamble=None,
             )
@@ -250,7 +295,7 @@ class TestExecuteChain:
             patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
         ):
             execute_chain(
-                steps=[_step()],
+                steps=[{"skill": "quality-gate", "prompt_template": "test", "timeout_seconds": 30}],
                 repo_root=repo,
                 context_preamble="MY CLAUDE.MD CONTENT",
             )
@@ -277,7 +322,7 @@ class TestExecuteChain:
             patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
         ):
             execute_chain(
-                steps=[_step()],
+                steps=[{"skill": "quality-gate", "prompt_template": "test", "timeout_seconds": 30}],
                 repo_root=repo,
                 context_preamble=None,
             )
@@ -305,128 +350,15 @@ class TestExecuteChain:
         ):
             results = execute_chain(
                 steps=[
-                    _step(prompt_template="step 1"),
-                    _step(prompt_template="step 2"),
-                    _step(prompt_template="step 3"),
+                    {"skill": "quality-gate", "prompt_template": "step 1", "timeout_seconds": 30},
+                    {"skill": "quality-gate", "prompt_template": "step 2", "timeout_seconds": 30},
+                    {"skill": "quality-gate", "prompt_template": "step 3", "timeout_seconds": 30},
                 ],
                 repo_root=repo,
                 context_preamble=None,
             )
 
         assert [r.skill_output for r in results] == ["output-1", "output-2", "output-3"]
-
-    def test_per_step_timeout_used(self, tmp_path):
-        """Each step's timeout_seconds is passed to subprocess.run."""
-        repo = _make_repo(tmp_path)
-
-        captured_timeouts: list[int] = []
-
-        def mock_run(*args, **kwargs):
-            captured_timeouts.append(kwargs.get("timeout"))
-            proc = MagicMock()
-            proc.returncode = 0
-            proc.stdout = "done"
-            proc.stderr = ""
-            return proc
-
-        with (
-            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
-            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
-        ):
-            execute_chain(
-                steps=[
-                    {"skill": "quality-gate", "prompt_template": "step 1", "timeout_seconds": 60},
-                    {"skill": "quality-gate", "prompt_template": "step 2", "timeout_seconds": 120},
-                ],
-                repo_root=repo,
-                context_preamble=None,
-            )
-
-        # subprocess.run is called twice per step (git worktree prune + actual claude).
-        # Filter only the claude invocations — those have timeout set.
-        assert 60 in captured_timeouts
-        assert 120 in captured_timeouts
-
-    def test_missing_timeout_raises_key_error(self, tmp_path):
-        """A step without timeout_seconds raises KeyError."""
-        repo = _make_repo(tmp_path)
-
-        with (
-            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
-            patch("skill_eval.runner.subprocess.run", return_value=_mock_claude_proc()),
-            pytest.raises(KeyError),
-        ):
-            execute_chain(
-                steps=[{"skill": "quality-gate", "prompt_template": "test"}],
-                repo_root=repo,
-                context_preamble=None,
-            )
-
-    def test_bare_flag_passed_when_set(self, tmp_path):
-        """step["bare"]=True passes --bare to the claude CLI."""
-        repo = _make_repo(tmp_path)
-
-        captured_cmds: list[list] = []
-
-        def mock_run(*args, **kwargs):
-            if args:
-                captured_cmds.append(args[0])
-            proc = MagicMock()
-            proc.returncode = 0
-            proc.stdout = "done"
-            proc.stderr = ""
-            return proc
-
-        with (
-            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
-            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
-        ):
-            execute_chain(
-                steps=[_step(bare=True)],
-                repo_root=repo,
-                context_preamble=None,
-            )
-
-        claude_cmds = [c for c in captured_cmds if c and c[0] == "claude"]
-        assert any("--bare" in c for c in claude_cmds)
-
-    def test_bundle_passed_via_append_system_prompt(self, tmp_path):
-        """The skill bundle is passed via --append-system-prompt, not stdin."""
-        repo = _make_repo(tmp_path)
-
-        captured_cmds: list[list] = []
-        captured_inputs: list[str] = []
-
-        def mock_run(*args, **kwargs):
-            if args:
-                captured_cmds.append(list(args[0]))
-            captured_inputs.append(kwargs.get("input", ""))
-            proc = MagicMock()
-            proc.returncode = 0
-            proc.stdout = "done"
-            proc.stderr = ""
-            return proc
-
-        with (
-            patch("skill_eval.runner.resolve_skill_bundle", return_value="# MY BUNDLE"),
-            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
-        ):
-            execute_chain(
-                steps=[_step(prompt_template="do the task")],
-                repo_root=repo,
-                context_preamble=None,
-            )
-
-        claude_cmds = [c for c in captured_cmds if c and c[0] == "claude"]
-        assert claude_cmds, "No claude invocation found"
-        cmd = claude_cmds[0]
-        # Bundle must appear as value after --append-system-prompt.
-        assert "--append-system-prompt" in cmd
-        idx = cmd.index("--append-system-prompt")
-        assert cmd[idx + 1] == "# MY BUNDLE"
-        # stdin must not contain the bundle marker.
-        claude_input = captured_inputs[captured_cmds.index(cmd)]
-        assert "# MY BUNDLE" not in claude_input
 
 
 # ── Group 2: run_composition_eval ────────────────────────────────────────────
@@ -435,21 +367,8 @@ class TestExecuteChain:
 class TestRunCompositionEval:
     """run_composition_eval manages worktree lifecycle and scores final output."""
 
-    def _make_composition(self, fixture_key: str = "composition/terse") -> dict:
-        return {
-            "name": "test-composition",
-            "fixture": fixture_key,
-            "rubrics": [],
-            "configs": [
-                {
-                    "name": "baseline",
-                    "steps": [_step(prompt_template="{fixture}")],
-                }
-            ],
-        }
-
-    def test_returns_dict_of_composition_results(self, tmp_path):
-        """run_composition_eval returns a dict of CompositionResult."""
+    def test_returns_composition_result(self, tmp_path):
+        """run_composition_eval returns a dict of CompositionResult keyed by config name."""
         repo = _make_repo(tmp_path)
         _make_fixture(repo, "composition/terse", "# Plan\nDo something.\n")
 
@@ -463,17 +382,17 @@ class TestRunCompositionEval:
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
             mock_chain.return_value = [ChainStepResult("quality-gate", "the output", None)]
 
-            results = run_composition_eval(
-                self._make_composition(),
+            result = run_composition_eval(
+                _make_composition(),
                 repo,
                 mock_judge,
                 n_trials=1,
             )
 
-        assert isinstance(results, dict)
-        assert "baseline" in results
-        assert isinstance(results["baseline"], CompositionResult)
-        assert results["baseline"].config_name == "baseline"
+        assert isinstance(result, dict)
+        assert "baseline" in result
+        assert isinstance(result["baseline"], CompositionResult)
+        assert result["baseline"].config_name == "baseline"
 
     def test_infra_error_on_chain_failure(self, tmp_path):
         """Chain execution failure returns CompositionResult with infra_error=True."""
@@ -488,14 +407,14 @@ class TestRunCompositionEval:
         ):
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-            results = run_composition_eval(
-                self._make_composition(),
+            result = run_composition_eval(
+                _make_composition(),
                 repo,
                 mock_judge,
                 n_trials=1,
             )
 
-        assert results["baseline"].infra_error is True
+        assert result["baseline"].infra_error is True
 
     def test_worktree_cleanup_on_success(self, tmp_path):
         """git worktree remove is called after successful chain execution."""
@@ -518,7 +437,7 @@ class TestRunCompositionEval:
                 return_value=[ChainStepResult("quality-gate", "output", None)],
             ),
         ):
-            run_composition_eval(self._make_composition(), repo, mock_judge, n_trials=1)
+            run_composition_eval(_make_composition(), repo, mock_judge, n_trials=1)
 
         # Verify worktree remove was called.
         assert any("remove" in c for c in worktree_remove_calls)
@@ -541,9 +460,9 @@ class TestRunCompositionEval:
             patch("skill_eval.runner.subprocess.run", side_effect=mock_subprocess_run),
             patch("skill_eval.runner.execute_chain", side_effect=RuntimeError("boom")),
         ):
-            results = run_composition_eval(self._make_composition(), repo, mock_judge, n_trials=1)
+            result = run_composition_eval(_make_composition(), repo, mock_judge, n_trials=1)
 
-        assert results["baseline"].infra_error is True
+        assert result["baseline"].infra_error is True
         assert any("remove" in c for c in worktree_remove_calls)
 
     def test_fixture_not_found_raises(self, tmp_path):
@@ -556,7 +475,7 @@ class TestRunCompositionEval:
             pytest.raises(FileNotFoundError),
         ):
             run_composition_eval(
-                self._make_composition("composition/nonexistent"),
+                _make_composition("composition/nonexistent"),
                 repo,
                 mock_judge,
                 n_trials=1,
@@ -580,172 +499,101 @@ class TestRunCompositionEval:
         ):
             mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
 
-            run_composition_eval(self._make_composition(), repo, mock_judge, n_trials=3)
+            run_composition_eval(_make_composition(), repo, mock_judge, n_trials=3)
 
         assert chain_call_count["n"] == 3
-
-    def test_multiple_configs_returned(self, tmp_path):
-        """Multiple configs each produce a CompositionResult in the returned dict."""
-        repo = _make_repo(tmp_path)
-        _make_fixture(repo, "composition/terse", "# Plan\n")
-
-        mock_judge = MagicMock()
-        composition = {
-            "name": "multi-config",
-            "fixture": "composition/terse",
-            "rubrics": [],
-            "configs": [
-                {"name": "config-a", "steps": [_step()]},
-                {"name": "config-b", "steps": [_step()]},
-            ],
-        }
-
-        with (
-            patch("skill_eval.runner.subprocess.run") as mock_run,
-            patch(
-                "skill_eval.runner.execute_chain",
-                return_value=[ChainStepResult("quality-gate", "output", None)],
-            ),
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-            results = run_composition_eval(composition, repo, mock_judge, n_trials=1)
-
-        assert set(results.keys()) == {"config-a", "config-b"}
-
-    def test_fixture_key_is_fixture_not_fixture_key(self, tmp_path):
-        """Fixture is read from composition['fixture'], not composition['fixture_key']."""
-        repo = _make_repo(tmp_path)
-        _make_fixture(repo, "composition/terse", "# Plan\n")
-
-        mock_judge = MagicMock()
-        # composition dict uses 'fixture', not 'fixture_key'
-        composition = {
-            "name": "test",
-            "fixture": "composition/terse",
-            "rubrics": [],
-            "configs": [{"name": "c1", "steps": [_step()]}],
-        }
-
-        with (
-            patch("skill_eval.runner.subprocess.run") as mock_run,
-            patch(
-                "skill_eval.runner.execute_chain",
-                return_value=[ChainStepResult("quality-gate", "output", None)],
-            ),
-        ):
-            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-            results = run_composition_eval(composition, repo, mock_judge, n_trials=1)
-
-        assert "c1" in results
 
 
 # ── Group 3: compare_composition_results ─────────────────────────────────────
 
 
 class TestCompareCompositionResults:
-    """compare_composition_results detects degradation across configs."""
+    """compare_composition_results detects degradation and prints ASCII table."""
 
     def _make_result(
         self,
-        config_name: str = "test",
+        name: str = "test",
         scores: dict | None = None,
         infra_error: bool = False,
     ) -> CompositionResult:
         return CompositionResult(
-            config_name=config_name,
+            config_name=name,
             step_results=[],
             final_scores=scores or {},
             trial_scores=None,
             infra_error=infra_error,
         )
 
-    def _make_results(self, **named_scores) -> dict[str, CompositionResult]:
-        """Build a results dict from config_name -> scores pairs."""
-        return {
-            name: self._make_result(config_name=name, scores=scores)
-            for name, scores in named_scores.items()
-        }
-
     def test_no_regression_when_within_tolerance(self):
         """No degradation when score drop is within tolerance."""
-        results = self._make_results(
-            baseline={"implementer_judgment": 8.1},
-            current={"implementer_judgment": 8.0},
+        baseline = self._make_result(name="baseline", scores={"implementer_judgment": 8.1})
+        current = self._make_result(name="current", scores={"implementer_judgment": 8.0})
+
+        result = compare_composition_results(
+            {"baseline": baseline, "current": current}, "baseline", tolerance=0.15
         )
 
-        cmp = compare_composition_results(results, baseline_config="baseline", tolerance=0.15)
-
-        assert cmp["degradation_detected"] is False
-        assert "PASS" in cmp["reports"]["current"]
+        assert result["degradation_detected"] is False
+        assert "PASS" in result["reports"]["current"]
 
     def test_degradation_detected_when_score_drops(self):
         """Degradation flagged when score drops more than tolerance."""
-        results = self._make_results(
-            baseline={"implementer_judgment": 8.0},
-            current={"implementer_judgment": 5.0},
+        baseline = self._make_result(name="baseline", scores={"implementer_judgment": 8.0})
+        current = self._make_result(name="current", scores={"implementer_judgment": 5.0})
+
+        result = compare_composition_results(
+            {"baseline": baseline, "current": current}, "baseline", tolerance=0.15
         )
 
-        cmp = compare_composition_results(results, baseline_config="baseline", tolerance=0.15)
-
-        assert cmp["degradation_detected"] is True
-        assert "DEGRADATION" in cmp["reports"]["current"]
+        assert result["degradation_detected"] is True
+        assert "DEGRADATION" in result["reports"]["current"]
 
     def test_infra_error_in_current_is_degradation(self):
-        """infra_error=True in a non-baseline config signals degradation."""
-        results = {
-            "baseline": self._make_result(config_name="baseline", scores={"x": 8.0}),
-            "current": self._make_result(config_name="current", infra_error=True),
-        }
+        """infra_error=True in current result signals degradation."""
+        baseline = self._make_result(name="baseline", scores={"implementer_judgment": 8.0})
+        current = self._make_result(name="current", infra_error=True)
 
-        cmp = compare_composition_results(results, baseline_config="baseline")
+        result = compare_composition_results({"baseline": baseline, "current": current}, "baseline")
 
-        assert cmp["degradation_detected"] is True
-        assert "INFRA ERROR" in cmp["reports"]["current"]
+        assert result["degradation_detected"] is True
+        assert "INFRA ERROR" in result["reports"]["current"]
 
     def test_infra_error_in_baseline_is_pass(self):
         """infra_error=True in baseline treats comparison as pass."""
-        results = {
-            "baseline": self._make_result(config_name="baseline", infra_error=True),
-            "current": self._make_result(config_name="current", scores={"x": 8.0}),
-        }
+        baseline = self._make_result(name="baseline", infra_error=True)
+        current = self._make_result(name="current", scores={"implementer_judgment": 8.0})
 
-        cmp = compare_composition_results(results, baseline_config="baseline")
+        result = compare_composition_results({"baseline": baseline, "current": current}, "baseline")
 
-        assert cmp["degradation_detected"] is False
+        assert result["degradation_detected"] is False
 
     def test_empty_baseline_scores_is_pass(self):
         """No baseline scores available — treating as pass."""
-        results = self._make_results(
-            baseline={},
-            current={"implementer_judgment": 8.0},
-        )
+        baseline = self._make_result(name="baseline", scores={})
+        current = self._make_result(name="current", scores={"implementer_judgment": 8.0})
 
-        cmp = compare_composition_results(results, baseline_config="baseline")
+        result = compare_composition_results({"baseline": baseline, "current": current}, "baseline")
 
-        assert cmp["degradation_detected"] is False
+        assert result["degradation_detected"] is False
 
     def test_missing_metric_in_current_flags_degradation(self):
         """A metric present in baseline but absent from current is a regression."""
-        results = self._make_results(
-            baseline={"implementer_judgment": 8.0},
-            current={},
-        )
+        baseline = self._make_result(name="baseline", scores={"implementer_judgment": 8.0})
+        current = self._make_result(name="current", scores={})
 
-        cmp = compare_composition_results(results, baseline_config="baseline")
+        result = compare_composition_results({"baseline": baseline, "current": current}, "baseline")
 
-        assert cmp["degradation_detected"] is True
-        assert "missing from current" in cmp["reports"]["current"]
+        assert result["degradation_detected"] is True
+        assert "missing from current" in result["reports"]["current"]
 
     def test_report_contains_ascii_table(self):
         """The report contains an ASCII table with metric names and scores."""
-        results = self._make_results(
-            baseline={"implementer_judgment": 8.0},
-            current={"implementer_judgment": 8.0},
-        )
+        baseline = self._make_result(name="baseline", scores={"implementer_judgment": 8.0})
+        current = self._make_result(name="current", scores={"implementer_judgment": 8.0})
 
-        cmp = compare_composition_results(results, baseline_config="baseline")
+        result = compare_composition_results({"baseline": baseline, "current": current}, "baseline")
 
-        report = cmp["reports"]["current"]
+        report = result["reports"]["current"]
         assert "implementer_judgment" in report
         assert "Current" in report
         assert "Baseline" in report
@@ -753,60 +601,28 @@ class TestCompareCompositionResults:
 
     def test_per_rubric_deltas_shown(self):
         """Delta values appear in the ASCII table."""
-        results = self._make_results(
-            baseline={"implementer_judgment": 8.0},
-            current={"implementer_judgment": 7.0},
+        baseline = self._make_result(name="baseline", scores={"implementer_judgment": 8.0})
+        current = self._make_result(name="current", scores={"implementer_judgment": 7.0})
+
+        result = compare_composition_results(
+            {"baseline": baseline, "current": current}, "baseline", tolerance=0.15
         )
 
-        cmp = compare_composition_results(results, baseline_config="baseline", tolerance=0.15)
-
-        report = cmp["reports"]["current"]
+        report = result["reports"]["current"]
+        # Drop of 1.0 > tolerance 0.15 — should be flagged.
         assert "-1.000" in report or "-1.0" in report
 
     def test_drop_within_tolerance_is_pass(self):
         """A drop smaller than tolerance is not flagged as degradation."""
-        results = self._make_results(
-            baseline={"implementer_judgment": 8.0},
-            current={"implementer_judgment": 7.9},
-        )
+        baseline = self._make_result(name="baseline", scores={"implementer_judgment": 8.0})
+        current = self._make_result(name="current", scores={"implementer_judgment": 7.9})
 
         # Drop = 0.1, tolerance = 0.15 → not > tolerance → pass.
-        cmp = compare_composition_results(results, baseline_config="baseline", tolerance=0.15)
-
-        assert cmp["degradation_detected"] is False
-
-    def test_baseline_config_not_in_reports(self):
-        """The baseline config itself does not appear in the reports dict."""
-        results = self._make_results(
-            baseline={"implementer_judgment": 8.0},
-            current={"implementer_judgment": 8.0},
+        result = compare_composition_results(
+            {"baseline": baseline, "current": current}, "baseline", tolerance=0.15
         )
 
-        cmp = compare_composition_results(results, baseline_config="baseline")
-
-        assert "baseline" not in cmp["reports"]
-
-    def test_multiple_non_baseline_configs(self):
-        """All non-baseline configs are compared and reported."""
-        results = self._make_results(
-            baseline={"implementer_judgment": 8.0},
-            config_a={"implementer_judgment": 8.0},
-            config_b={"implementer_judgment": 5.0},
-        )
-
-        cmp = compare_composition_results(results, baseline_config="baseline")
-
-        assert "config_a" in cmp["reports"]
-        assert "config_b" in cmp["reports"]
-        assert cmp["degradation_detected"] is True
-
-    def test_missing_baseline_config_returns_degradation(self):
-        """Missing baseline config name returns degradation_detected=True."""
-        results = self._make_results(current={"implementer_judgment": 8.0})
-
-        cmp = compare_composition_results(results, baseline_config="nonexistent")
-
-        assert cmp["degradation_detected"] is True
+        assert result["degradation_detected"] is False
 
 
 # ── Group 4: load_composition_fixture and load_composition_config ─────────────
@@ -860,7 +676,7 @@ class TestLoadCompositionConfig:
 
     def test_loads_valid_config(self, tmp_path):
         """A valid composition config is loaded as a dict."""
-        config = {"compositions": [{"name": "test", "configs": []}]}
+        config = {"compositions": [{"name": "test", "steps": []}]}
         path = _make_composition_config(tmp_path, config)
 
         result = load_composition_config(path)

--- a/skill-eval/tests/test_composition.py
+++ b/skill-eval/tests/test_composition.py
@@ -11,6 +11,7 @@ or git worktree calls in the test suite.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -46,8 +47,6 @@ def _make_fixture(repo: Path, key: str, content: str) -> None:
 
 def _make_composition_config(tmp_path: Path, data: dict) -> Path:
     """Write a composition config JSON and return its path."""
-    import json
-
     config_path = tmp_path / "composition.json"
     config_path.write_text(json.dumps(data))
     return config_path
@@ -113,7 +112,7 @@ class TestExecuteChain:
         assert results[0].capture_name is None
 
     def test_capture_as_stored_with_xml_wrapping(self, tmp_path):
-        """Captured output is XML-wrapped before storage."""
+        """Captured output is XML-wrapped when substituted into subsequent step prompts."""
         repo = _make_repo(tmp_path)
 
         call_outputs = [
@@ -121,8 +120,10 @@ class TestExecuteChain:
             "Step 2 produced this output which is also long enough to pass the guard check.",
         ]
         call_iter = iter(call_outputs)
+        captured_inputs: list[str] = []
 
         def mock_run(*args, **kwargs):
+            captured_inputs.append(kwargs.get("input", ""))
             proc = MagicMock()
             proc.returncode = 0
             proc.stdout = next(call_iter)
@@ -153,7 +154,9 @@ class TestExecuteChain:
 
         assert len(results) == 2
         assert results[0].capture_name == "step1"
-        assert "long enough to pass the guard" in results[1].skill_output
+        second_input = captured_inputs[1]
+        assert '<prior-step-output skill="quality-gate">' in second_input
+        assert "Step 1 produced this output" in second_input
 
     def test_variable_substitution_from_initial_captures(self, tmp_path):
         """Initial captures are substituted into step prompts."""
@@ -187,12 +190,16 @@ class TestExecuteChain:
             )
 
         assert "my fixture content" in captured_prompt[0]
+        assert "<prior-step-output" not in captured_prompt[0]
 
     def test_prior_step_output_xml_wrapped_in_next_prompt(self, tmp_path):
         """Prior step output is XML-wrapped when substituted into later prompts."""
         repo = _make_repo(tmp_path)
 
-        outputs = ["output from step1", "step2 done"]
+        outputs = [
+            "Output from step 1 — long enough to pass the 50-char guard threshold.",
+            "Output from step 2 — long enough to pass the 50-char guard threshold.",
+        ]
         call_iter = iter(outputs)
         captured_inputs: list[str] = []
 
@@ -226,20 +233,97 @@ class TestExecuteChain:
                 context_preamble=None,
             )
 
-        # The second prompt should contain the XML-wrapped output.
         second_input = captured_inputs[1]
         assert '<prior-step-output skill="quality-gate">' in second_input
-        assert "output from step1" in second_input
+        assert "Output from step 1" in second_input
 
-    def test_invalid_skill_name_raises(self, tmp_path):
-        """A skill name with invalid characters raises ValueError."""
+    def test_unknown_variable_left_as_is(self, tmp_path):
+        """Unknown {variable} references in prompt templates are left unchanged."""
+        repo = _make_repo(tmp_path)
+
+        captured_inputs: list[str] = []
+
+        def mock_run(*args, **kwargs):
+            captured_inputs.append(kwargs.get("input", ""))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = _DEFAULT_OUTPUT
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "Review {fixture} and also {unknown_var}",
+                        "timeout_seconds": 30,
+                    }
+                ],
+                repo_root=repo,
+                context_preamble=None,
+                initial_captures={"fixture": "my fixture content"},
+            )
+
+        assert "my fixture content" in captured_inputs[0]
+        assert "{unknown_var}" in captured_inputs[0]
+
+    def test_curly_braces_in_captured_output_do_not_break_substitution(self, tmp_path):
+        """JSON or other curly-brace content in captured output is substituted safely."""
+        repo = _make_repo(tmp_path)
+
+        json_output = '{"key": "value", "count": 42, "items": ["a", "b"]} — ' + "x" * 20
+        call_outputs = [json_output, _DEFAULT_OUTPUT]
+        call_iter = iter(call_outputs)
+        captured_inputs: list[str] = []
+
+        def mock_run(*args, **kwargs):
+            captured_inputs.append(kwargs.get("input", ""))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = next(call_iter)
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            results = execute_chain(
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "produce json",
+                        "capture_as": "json_result",
+                        "timeout_seconds": 30,
+                    },
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "use this: {json_result}",
+                        "timeout_seconds": 30,
+                    },
+                ],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+        assert len(results) == 2
+        assert '{"key": "value"' in captured_inputs[1]
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        ["bad skill name!", "path/traversal", "../escape", "/leading-slash", "has..dots"],
+    )
+    def test_invalid_skill_name_raises(self, tmp_path, bad_name):
+        """Skill names with invalid characters (spaces, /, .., leading slash) raise ValueError."""
         repo = _make_repo(tmp_path)
 
         with pytest.raises(ValueError, match="Invalid skill name"):
             execute_chain(
-                steps=[
-                    {"skill": "bad skill name!", "prompt_template": "test", "timeout_seconds": 30}
-                ],
+                steps=[{"skill": bad_name, "prompt_template": "test", "timeout_seconds": 30}],
                 repo_root=repo,
                 context_preamble=None,
             )
@@ -357,6 +441,37 @@ class TestExecuteChain:
 
         assert "DATABASE_PASSWORD" not in captured_env[0]
         assert "CLAUDECODE" in captured_env[0]
+
+    def test_subprocess_cmd_uses_required_flags(self, tmp_path):
+        """Subprocess cmd includes --append-system-prompt, --permission-mode, and uses stdin."""
+        repo = _make_repo(tmp_path)
+
+        captured_cmds: list[list] = []
+        captured_kwargs: list[dict] = []
+
+        def mock_run(*args, **kwargs):
+            captured_cmds.append(args[0])
+            captured_kwargs.append(kwargs)
+            return _mock_claude_proc()
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_run),
+        ):
+            execute_chain(
+                steps=[{"skill": "quality-gate", "prompt_template": "test", "timeout_seconds": 30}],
+                repo_root=repo,
+                context_preamble=None,
+            )
+
+        cmd = captured_cmds[0]
+        assert "--append-system-prompt" in cmd
+        assert "--permission-mode" in cmd
+        idx = cmd.index("--permission-mode")
+        assert cmd[idx + 1] == "bypassPermissions"
+        assert "input" in captured_kwargs[0]
+        assert "-p" not in cmd
+        assert "--bare" not in cmd
 
     def test_bare_mode_skips_preamble_and_passes_flag(self, tmp_path):
         """bare=True passes --bare to claude CLI and omits BEHAVIORAL CONTEXT from stdin."""
@@ -481,6 +596,94 @@ class TestRunCompositionEval:
             )
 
         assert result["baseline"].infra_error is True
+        assert result["baseline"].final_scores == {}
+
+    def test_multi_config_produces_results_for_all(self, tmp_path):
+        """A composition with multiple configs returns results keyed by each config name."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+
+        composition = _make_composition()
+        composition["configs"].append(
+            {
+                "name": "with-review",
+                "steps": [
+                    {"skill": "quality-gate", "prompt_template": "{fixture}", "timeout_seconds": 30}
+                ],
+            }
+        )
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch("skill_eval.runner.execute_chain") as mock_chain,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            mock_chain.return_value = [ChainStepResult("quality-gate", "output", None)]
+
+            result = run_composition_eval(composition, repo, mock_judge, n_trials=1)
+
+        assert len(result) == 2
+        assert "baseline" in result
+        assert "with-review" in result
+        assert result["baseline"].config_name == "baseline"
+        assert result["with-review"].config_name == "with-review"
+
+    def test_worktree_creation_uses_no_checkout_detach(self, tmp_path):
+        """git worktree add uses --no-checkout and --detach flags."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        worktree_add_calls: list[list] = []
+
+        def mock_subprocess_run(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, list) and "add" in cmd:
+                worktree_add_calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_subprocess_run),
+            patch(
+                "skill_eval.runner.execute_chain",
+                return_value=[ChainStepResult("quality-gate", "output", None)],
+            ),
+        ):
+            run_composition_eval(_make_composition(), repo, mock_judge, n_trials=1)
+
+        assert len(worktree_add_calls) >= 1
+        add_cmd = worktree_add_calls[0]
+        assert "--no-checkout" in add_cmd
+        assert "--detach" in add_cmd
+
+    def test_worktree_cleanup_uses_force(self, tmp_path):
+        """git worktree remove uses --force flag."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        worktree_remove_calls: list[list] = []
+
+        def mock_subprocess_run(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, list) and "remove" in cmd:
+                worktree_remove_calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with (
+            patch("skill_eval.runner.subprocess.run", side_effect=mock_subprocess_run),
+            patch(
+                "skill_eval.runner.execute_chain",
+                return_value=[ChainStepResult("quality-gate", "output", None)],
+            ),
+        ):
+            run_composition_eval(_make_composition(), repo, mock_judge, n_trials=1)
+
+        assert len(worktree_remove_calls) >= 1
+        remove_cmd = worktree_remove_calls[0]
+        assert "--force" in remove_cmd
 
     def test_worktree_cleanup_on_success(self, tmp_path):
         """git worktree remove is called after successful chain execution."""
@@ -611,6 +814,122 @@ class TestRunCompositionEval:
         assert "test_metric" in baseline.final_scores
         assert baseline.final_scores["test_metric"] == pytest.approx(0.8)
         assert mock_metric.measure.call_count == 2
+        assert len(baseline.step_results) == 1
+        assert baseline.step_results[0].skill_name == "quality-gate"
+        assert baseline.step_results[0].skill_output == "output-3"
+
+    def test_metric_failure_returns_zero_score(self, tmp_path):
+        """When metric.measure() raises, the metric gets score 0.0 without aborting."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+
+        mock_chain_result = [ChainStepResult("quality-gate", "output content here", None)]
+
+        failing_metric = MagicMock()
+        failing_metric.name = "broken_metric"
+        failing_metric.measure.side_effect = RuntimeError("judge API down")
+
+        passing_metric = MagicMock()
+        passing_metric.name = "good_metric"
+        passing_metric.score = 0.9
+
+        composition = _make_composition()
+        composition["rubrics"] = ["implementer_judgment"]
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch("skill_eval.runner.execute_chain", return_value=mock_chain_result),
+            patch("skill_eval.runner.build_metrics", return_value=[failing_metric, passing_metric]),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = run_composition_eval(composition, repo, mock_judge, n_trials=1)
+
+        baseline = result["baseline"]
+        assert baseline.infra_error is False
+        assert baseline.final_scores["broken_metric"] == 0.0
+        assert baseline.final_scores["good_metric"] == pytest.approx(0.9)
+
+    def test_no_expected_behaviors_passes_none_expected_output(self, tmp_path):
+        """When expected_behaviors is absent, LLMTestCase.expected_output is None."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        mock_chain_result = [ChainStepResult("quality-gate", "output content here", None)]
+
+        mock_metric = MagicMock()
+        mock_metric.name = "phase_completion"
+        mock_metric.score = 0.7
+
+        composition = _make_composition()
+        composition["rubrics"] = ["phase_completion"]
+
+        captured_tc: list = []
+
+        def capture_tc(tc):
+            captured_tc.append(tc)
+
+        mock_metric.measure.side_effect = capture_tc
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch("skill_eval.runner.execute_chain", return_value=mock_chain_result),
+            patch("skill_eval.runner.build_metrics", return_value=[mock_metric]),
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            run_composition_eval(composition, repo, mock_judge, n_trials=1)
+
+        assert len(captured_tc) == 1
+        assert captured_tc[0].expected_output is None
+
+    def test_empty_assertions_produces_no_assertion_metrics(self, tmp_path):
+        """When assertions is [] or absent, no assertion metrics are added."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(repo, "composition/terse", "# Plan\n")
+
+        mock_judge = MagicMock()
+        mock_chain_result = [ChainStepResult("quality-gate", "output content here", None)]
+
+        composition = _make_composition()
+        composition["assertions"] = []
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch("skill_eval.runner.execute_chain", return_value=mock_chain_result),
+            patch("skill_eval.runner.build_assertion_metrics") as mock_build_assert,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            result = run_composition_eval(composition, repo, mock_judge, n_trials=1)
+
+        mock_build_assert.assert_not_called()
+        assert result["baseline"].final_scores == {}
+
+    def test_scaffold_called_per_trial(self, tmp_path):
+        """_scaffold_worktree is called once per trial."""
+        repo = _make_repo(tmp_path)
+        _make_fixture(
+            repo,
+            "composition/terse",
+            "---\nscaffold:\n  files:\n    - app.py\n  requirements:\n    - flask\n---\n# Plan\n",
+        )
+
+        mock_judge = MagicMock()
+        mock_chain_result = [ChainStepResult("quality-gate", "output content here", None)]
+
+        composition = _make_composition()
+
+        with (
+            patch("skill_eval.runner.subprocess.run") as mock_run,
+            patch("skill_eval.runner.execute_chain", return_value=mock_chain_result),
+            patch("skill_eval.runner._scaffold_worktree") as mock_scaffold,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            run_composition_eval(composition, repo, mock_judge, n_trials=3)
+
+        assert mock_scaffold.call_count == 3
 
 
 # ── Group 3: compare_composition_results ─────────────────────────────────────
@@ -773,6 +1092,11 @@ class TestLoadCompositionFixture:
         content = load_composition_fixture("composition/valid-key", repo)
 
         assert "# content" in content
+
+    def test_leading_slash_key_rejected(self, tmp_path):
+        """Keys starting with '/' are rejected (would create absolute path)."""
+        with pytest.raises(ValueError, match="Invalid fixture key"):
+            load_composition_fixture("/etc/passwd", tmp_path)
 
     def test_path_traversal_key_rejected(self, tmp_path):
         """Keys containing '..' are rejected by validation."""
@@ -1000,6 +1324,25 @@ class TestExecuteChainEdgeCases:
             )
 
         assert "[suspect output" in results[0].skill_output
+
+    def test_missing_timeout_seconds_raises_key_error(self, tmp_path):
+        """A step dict missing 'timeout_seconds' raises KeyError."""
+        repo = _make_repo(tmp_path)
+
+        with (
+            patch("skill_eval.runner.resolve_skill_bundle", return_value="# bundle"),
+            pytest.raises(KeyError),
+        ):
+            execute_chain(
+                steps=[
+                    {
+                        "skill": "quality-gate",
+                        "prompt_template": "test",
+                    }
+                ],
+                repo_root=repo,
+                context_preamble=None,
+            )
 
 
 # ── Group 8: compare_composition_results edge cases ──────────────────────────

--- a/skill-eval/tests/test_skill_eval.py
+++ b/skill-eval/tests/test_skill_eval.py
@@ -1717,16 +1717,17 @@ class TestRunEvalInfraError:
         assert result["infra_error"] is False
 
 
-# ── Group 24: Implementer judgment rubric registration ───────────────────────
+# ── Group 28: Implementer judgment rubric ────────────────────────────────────
 
 
-def test_implementer_judgment_registered():
-    from deepeval.test_case import LLMTestCaseParams
-    from skill_eval.rubrics import RUBRIC_REGISTRY
+class TestImplementerJudgmentRubric:
+    def test_implementer_judgment_registered(self):
+        from deepeval.test_case import LLMTestCaseParams
+        from skill_eval.rubrics import RUBRIC_REGISTRY
 
-    assert "implementer_judgment" in RUBRIC_REGISTRY
-    assert RUBRIC_REGISTRY["implementer_judgment"]["evaluation_params"] == [
-        LLMTestCaseParams.INPUT,
-        LLMTestCaseParams.ACTUAL_OUTPUT,
-        LLMTestCaseParams.EXPECTED_OUTPUT,
-    ]
+        assert "implementer_judgment" in RUBRIC_REGISTRY
+        assert RUBRIC_REGISTRY["implementer_judgment"]["evaluation_params"] == [
+            LLMTestCaseParams.INPUT,
+            LLMTestCaseParams.ACTUAL_OUTPUT,
+            LLMTestCaseParams.EXPECTED_OUTPUT,
+        ]

--- a/skill-eval/tests/test_skill_eval.py
+++ b/skill-eval/tests/test_skill_eval.py
@@ -1715,3 +1715,18 @@ class TestRunEvalInfraError:
             )
 
         assert result["infra_error"] is False
+
+
+# ── Group 24: Implementer judgment rubric registration ───────────────────────
+
+
+def test_implementer_judgment_registered():
+    from deepeval.test_case import LLMTestCaseParams
+    from skill_eval.rubrics import RUBRIC_REGISTRY
+
+    assert "implementer_judgment" in RUBRIC_REGISTRY
+    assert RUBRIC_REGISTRY["implementer_judgment"]["evaluation_params"] == [
+        LLMTestCaseParams.INPUT,
+        LLMTestCaseParams.ACTUAL_OUTPUT,
+        LLMTestCaseParams.EXPECTED_OUTPUT,
+    ]

--- a/skill-eval/tests/test_skill_eval.py
+++ b/skill-eval/tests/test_skill_eval.py
@@ -208,6 +208,42 @@ class TestHookPrePushDispatch:
         mock_pp.assert_called_once_with(tmp_path)
 
 
+class TestHookCompositionDispatch:
+    """--composition dispatches to _mode_composition, not _mode_prepush."""
+
+    def test_composition_flag_calls_mode_composition(self, tmp_path, tty_stdin):
+        from skill_eval import cli
+
+        with (
+            patch.object(sys, "argv", ["hook", "--composition", "/some/path.json"]),
+            patch("skill_eval.cli._repo_root", return_value=tmp_path),
+            patch("skill_eval.cli._mode_composition", return_value=True) as mock_comp,
+            patch("skill_eval.cli._mode_prepush") as mock_prepush,
+            pytest.raises(SystemExit),
+        ):
+            cli.main()
+
+        mock_comp.assert_called_once_with(Path("/some/path.json"), tmp_path, None)
+        mock_prepush.assert_not_called()
+
+    def test_composition_name_flag_forwarded(self, tmp_path, tty_stdin):
+        from skill_eval import cli
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["hook", "--composition", "/p.json", "--composition-name", "my-comp"],
+            ),
+            patch("skill_eval.cli._repo_root", return_value=tmp_path),
+            patch("skill_eval.cli._mode_composition", return_value=True) as mock_comp,
+            pytest.raises(SystemExit),
+        ):
+            cli.main()
+
+        mock_comp.assert_called_once_with(Path("/p.json"), tmp_path, "my-comp")
+
+
 # ── Group 2: load_eval_config ─────────────────────────────────────────────────
 
 

--- a/skill-eval/uv.lock
+++ b/skill-eval/uv.lock
@@ -1453,6 +1453,7 @@ dependencies = [
     { name = "anthropic", extra = ["vertex"] },
     { name = "deepeval" },
     { name = "instructor" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -1466,6 +1467,7 @@ requires-dist = [
     { name = "anthropic", extras = ["vertex"], specifier = ">=0.80.0" },
     { name = "deepeval", specifier = ">=3.0" },
     { name = "instructor", specifier = ">=1.0,<2.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Adds multi-step chain execution engine (execute_chain) that invokes skills via claude CLI subprocess with trust boundary handling, per-step timeouts, and XML-wrapped prior step outputs
- Adds parametric composition evaluation (run_composition_eval) with worktree isolation per trial, K-trial averaging, and partial failure handling across multiple chain configurations
- Includes implementer judgment rubric, 5 paired fixtures (terse/overspecified plans, planted-issues diff), 4 composition test case definitions, and 42 unit tests