### PR TITLE
Migrate from claudelint to skillsaw

### DIFF
--- a/.github/workflows/plugin-lint.yml
+++ b/.github/workflows/plugin-lint.yml
@@ -10,7 +10,7 @@ on:
       - '**/hooks.json'
       - '**/plugin.json'
       - '**/SKILL.md'
-      - '.claudelint.yaml'
+      - '.skillsaw.yaml'
       - '.github/workflows/plugin-lint.yml'
   workflow_dispatch:
 
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6
       - uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41  # v7
-      - run: uvx claudelint --strict
+      - run: uvx skillsaw --strict
 
       - name: No README in skill directories
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,10 @@ repos:
 
   - repo: local
     hooks:
-      - id: claudelint
-        name: claudelint
+      - id: skillsaw
+        name: skillsaw
         language: system
-        entry: uvx claudelint --strict
+        entry: uvx skillsaw --strict
         pass_filenames: false
         files: \.(json|md|yaml)$
 

--- a/.skillsaw.yaml
+++ b/.skillsaw.yaml
@@ -8,12 +8,6 @@ rules:
   plugin-naming:
     enabled: true
     severity: warning
-  commands-dir-required:
-    enabled: false
-    severity: warning
-  commands-exist:
-    enabled: false
-    severity: info
   command-naming:
     enabled: true
     severity: warning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,4 +53,4 @@ Each plugin has `.claude-plugin/plugin.json`. Hooks register in `hooks/hooks.jso
 
 ## CI
 
-GitHub Actions on PRs to main. Two workflows: `ci.yml` (Python checks via `make all`, `uv sync --group dev`) and `plugin-lint.yml` (plugin structure via `uvx claudelint --strict`).
+GitHub Actions on PRs to main. Two workflows: `ci.yml` (Python checks via `make all`, `uv sync --group dev`) and `plugin-lint.yml` (plugin structure via `uvx skillsaw --strict`).


### PR DESCRIPTION
## Summary

- claudelint has been renamed to [skillsaw](https://github.com/stbenjam/skillsaw)
- Rename `.claudelint.yaml` → `.skillsaw.yaml`, remove stale rule IDs (`commands-dir-required`, `commands-exist`)
- Update pre-commit hook and `plugin-lint.yml` workflow to use `uvx skillsaw`
- Update CLAUDE.md reference

Note: skillsaw reports 23 `allowed-tools` errors in your skills — these use YAML list syntax (`[Read, Write, ...]`) but the [agentskills.io spec](https://agentskills.io/specification) requires a space-separated string (`"Read Write ..."`), but I have seen lists in the wild, https://github.com/stbenjam/skillsaw/issues/24 targets loosening this


## Test plan

- [x] `skillsaw -v` runs (23 pre-existing `allowed-tools` format errors, 0 from migration)
- [x] Pre-commit hook passes locally
- [ ] CI workflow runs successfully with `uvx skillsaw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)